### PR TITLE
Write a bunch of tests for http_server_response.go

### DIFF
--- a/examples/example-gateway/endpoints/contacts/save-contacts.go
+++ b/examples/example-gateway/endpoints/contacts/save-contacts.go
@@ -3,6 +3,8 @@ package contacts
 import (
 	"context"
 
+	"io/ioutil"
+
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
@@ -41,6 +43,12 @@ func HandleSaveContactsRequest(
 		return
 	}
 
+	defer func() {
+		if cerr := cres.Body.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
 	// Handle client respnse.
 	if !res.IsOKResponse(cres.StatusCode, []int{200, 202}) {
 		req.Logger.Warn("Unknown response status code",
@@ -48,8 +56,24 @@ func HandleSaveContactsRequest(
 		)
 	}
 
-	// res.Res.StatusCode
-	res.CopyJSON(cres.StatusCode, cres.Body)
+	bytes, err := ioutil.ReadAll(cres.Body)
+	if err != nil {
+		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
+		return
+	}
+	var clientRespBody contactsClientStructs.SaveContactsResponse
+	if err := clientRespBody.UnmarshalJSON(bytes); err != nil {
+		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
+		return
+	}
+	response := convertToResponse(&clientRespBody)
+	res.WriteJSON(cres.StatusCode, response)
+}
+
+func convertToResponse(
+	body *contactsClientStructs.SaveContactsResponse,
+) *SaveContactsResponse {
+	return &SaveContactsResponse{}
 }
 
 func convertToClient(

--- a/examples/example-gateway/endpoints/contacts/save-contacts_structs.go
+++ b/examples/example-gateway/endpoints/contacts/save-contacts_structs.go
@@ -37,3 +37,7 @@ type SaveContactsRequest struct {
 	DeviceType string
 	AppVersion string
 }
+
+// SaveContactsResponse ...
+type SaveContactsResponse struct {
+}

--- a/examples/example-gateway/endpoints/contacts/save-contacts_structs_easyjson.go
+++ b/examples/example-gateway/endpoints/contacts/save-contacts_structs_easyjson.go
@@ -5,6 +5,7 @@ package contacts
 import (
 	json "encoding/json"
 	fmt "fmt"
+
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -18,7 +19,67 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(in *jlexer.Lexer, out *SaveContactsRequest) {
+func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(in *jlexer.Lexer, out *SaveContactsResponse) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeString()
+		_ = key
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(out *jwriter.Writer, in SaveContactsResponse) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	out.RawByte('}')
+}
+
+// MarshalJSON supports json.Marshaler interface
+func (v SaveContactsResponse) MarshalJSON() ([]byte, error) {
+	w := jwriter.Writer{}
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(&w, v)
+	return w.Buffer.BuildBytes(), w.Error
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v SaveContactsResponse) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(w, v)
+}
+
+// UnmarshalJSON supports json.Unmarshaler interface
+func (v *SaveContactsResponse) UnmarshalJSON(data []byte) error {
+	r := jlexer.Lexer{Data: data}
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(&r, v)
+	return r.Error()
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *SaveContactsResponse) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(l, v)
+}
+func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(in *jlexer.Lexer, out *SaveContactsRequest) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -87,7 +148,7 @@ func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 		in.AddError(fmt.Errorf("key 'contacts' is required"))
 	}
 }
-func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(out *jwriter.Writer, in SaveContactsRequest) {
+func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(out *jwriter.Writer, in SaveContactsRequest) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -142,27 +203,27 @@ func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 // MarshalJSON supports json.Marshaler interface
 func (v SaveContactsRequest) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(&w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SaveContactsRequest) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *SaveContactsRequest) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(&r, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *SaveContactsRequest) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts(l, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(l, v)
 }
-func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(in *jlexer.Lexer, out *Contact) {
+func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(in *jlexer.Lexer, out *Contact) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -220,7 +281,7 @@ func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 		in.Consumed()
 	}
 }
-func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(out *jwriter.Writer, in Contact) {
+func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(out *jwriter.Writer, in Contact) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -257,27 +318,27 @@ func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 // MarshalJSON supports json.Marshaler interface
 func (v Contact) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(&w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Contact) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *Contact) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(&r, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *Contact) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts1(l, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(l, v)
 }
-func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(in *jlexer.Lexer, out *ContactAttributes) {
+func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(in *jlexer.Lexer, out *ContactAttributes) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -436,7 +497,7 @@ func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 		in.Consumed()
 	}
 }
-func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(out *jwriter.Writer, in ContactAttributes) {
+func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(out *jwriter.Writer, in ContactAttributes) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -576,27 +637,27 @@ func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 // MarshalJSON supports json.Marshaler interface
 func (v ContactAttributes) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(&w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ContactAttributes) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ContactAttributes) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(&r, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ContactAttributes) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts2(l, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(l, v)
 }
-func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(in *jlexer.Lexer, out *ContactFragment) {
+func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(in *jlexer.Lexer, out *ContactFragment) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -645,7 +706,7 @@ func easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 		in.Consumed()
 	}
 }
-func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(out *jwriter.Writer, in ContactFragment) {
+func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(out *jwriter.Writer, in ContactFragment) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -675,23 +736,23 @@ func easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsC
 // MarshalJSON supports json.Marshaler interface
 func (v ContactFragment) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(&w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ContactFragment) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(w, v)
+	easyjsonDae16842EncodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *ContactFragment) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(&r, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ContactFragment) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts3(l, v)
+	easyjsonDae16842DecodeGithubComUberZanzibarExamplesExampleGatewayEndpointsContacts4(l, v)
 }

--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -47,6 +47,7 @@ type HTTPServer struct {
 func (server *HTTPServer) JustListen() (net.Listener, error) {
 	addr := server.Addr
 	if addr == "" {
+		/* coverage ignore next line */
 		addr = ":http"
 	}
 
@@ -70,6 +71,7 @@ func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 
 	err := server.Serve(tcpKeepAliveListener{ln})
 	if err != nil && !server.closing {
+		/* coverage ignore next line */
 		server.Logger.Error("Error http serving",
 			zap.String("error", err.Error()),
 		)
@@ -87,6 +89,7 @@ func (server *HTTPServer) Close() {
 
 	err := server.listeningSocket.Close()
 	if err != nil {
+		/* coverage ignore next line */
 		server.Logger.Error("Error closing listening socket",
 			zap.String("error", err.Error()),
 		)

--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -84,6 +84,7 @@ func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 func (server *HTTPServer) Close() {
 	server.closing = true
 	if server.listeningSocket == nil {
+		/* coverage ignore next line */
 		return
 	}
 

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -162,6 +162,7 @@ func (res *ServerHTTPResponse) writeHeader(statusCode int) {
 func (res *ServerHTTPResponse) writeBytes(bytes []byte) {
 	_, err := res.responseWriter.Write(bytes)
 	if err != nil {
+		/* coverage ignore next line */
 		res.req.Logger.Error("Could not write string to resp body",
 			zap.String("error", err.Error()),
 		)

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -142,6 +142,12 @@ func (res *ServerHTTPResponse) WriteJSONBytes(
 func (res *ServerHTTPResponse) WriteJSON(
 	statusCode int, body json.Marshaler,
 ) {
+	if body == nil {
+		res.SendErrorString(500, "Could not serialize json response")
+		res.req.Logger.Error("Could not serialize nil pointer body")
+		return
+	}
+
 	bytes, err := body.MarshalJSON()
 	if err != nil {
 		res.SendErrorString(500, "Could not serialize json response")

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -22,7 +22,6 @@ package zanzibar
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"time"
@@ -113,20 +112,6 @@ func (res *ServerHTTPResponse) SendErrorString(
 
 	res.writeHeader(statusCode)
 	res.writeString(err)
-
-	res.finish()
-}
-
-// CopyJSON will copy json bytes from a Reader
-func (res *ServerHTTPResponse) CopyJSON(statusCode int, src io.Reader) {
-	res.responseWriter.Header().Set("content-type", "application/json")
-	res.writeHeader(statusCode)
-	_, err := io.Copy(res.responseWriter, src)
-	if err != nil {
-		res.req.Logger.Error("Could not copy bytes",
-			zap.String("error", err.Error()),
-		)
-	}
 
 	res.finish()
 }

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -168,11 +168,6 @@ func (res *ServerHTTPResponse) writeBytes(bytes []byte) {
 	}
 }
 
-// WriteHeader writes the header to http respnse.
-func (res *ServerHTTPResponse) WriteHeader(statusCode int) {
-	res.writeHeader(statusCode)
-}
-
 // WriteString helper just writes a string to the response
 func (res *ServerHTTPResponse) writeString(text string) {
 	res.writeBytes([]byte(text))

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -60,17 +60,21 @@ func NewServerHTTPResponse(
 // finish will handle final logic, like metrics
 func (res *ServerHTTPResponse) finish() {
 	if !res.req.started {
+		/* coverage ignore next line */
 		res.req.Logger.Error(
 			"Forgot to start incoming request",
 			zap.String("path", res.req.URL.Path),
 		)
+		/* coverage ignore next line */
 		return
 	}
 	if res.finished {
+		/* coverage ignore next line */
 		res.req.Logger.Error(
 			"Finished an incoming request twice",
 			zap.String("path", res.req.URL.Path),
 		)
+		/* coverage ignore next line */
 		return
 	}
 

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"encoding/json"
+
+	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
+	"github.com/uber/zanzibar/test/lib/bench_gateway"
+)
+
+func TestInvalidStatusCode(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	bgateway := gateway.(*benchGateway.BenchGateway)
+	bgateway.ActualGateway.Router.Register(
+		"GET", "/foo", zanzibar.NewEndpoint(
+			bgateway.ActualGateway,
+			"foo",
+			"foo",
+			func(
+				ctx context.Context,
+				req *zanzibar.ServerHTTPRequest,
+				res *zanzibar.ServerHTTPResponse,
+			) {
+				res.WriteJSONBytes(999, []byte("true"))
+			},
+		),
+	)
+
+	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, resp.Status, "999 status code 999")
+	assert.Equal(t, resp.StatusCode, 999)
+
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, "true", string(bytes))
+
+	errorLogs := bgateway.GetErrorLogs()
+	logLines := errorLogs["Could not emit statusCode metric"]
+
+	assert.NotNil(t, logLines)
+	assert.Equal(t, 1, len(logLines))
+
+	line := logLines[0]
+	lineStruct := map[string]interface{}{}
+	jsonErr := json.Unmarshal([]byte(line), &lineStruct)
+	if !assert.NoError(t, jsonErr, "cannot decode json lines") {
+		return
+	}
+
+	code := lineStruct["UnexpectedStatusCode"].(float64)
+	assert.Equal(t, 999.0, code)
+}

--- a/runtime/tchannel_server_test.go
+++ b/runtime/tchannel_server_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/test/lib/bench_gateway"
+)
+
+func TestCreatingTChannel(t *testing.T) {
+	_, err := benchGateway.CreateGateway(
+		map[string]interface{}{
+			"tchannel.serviceName": "",
+		},
+		nil,
+	)
+	assert.Error(t, err)
+
+	assert.Contains(t, err.Error(), "no service name provided")
+}

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -100,4 +100,17 @@ end=`date +%s`
 runtime=$((end-start))
 echo "Finished building istanbul reports : +$runtime"
 
+
+cat ./coverage/istanbul.json | jq '[
+	. |
+	to_entries |
+	.[] |
+	select(.key | contains("runtime")) |
+	select(.key | contains("runtime/gateway") | not)
+] | from_entries' > ./coverage/istanbul-runtime.json
+
+echo "Checking code coverage for runtime folder"
+./node_modules/.bin/istanbul check-coverage --statements 100 \
+	./coverage/istanbul-runtime.json
+
 rm -f ./test/.cached_binary_test_info.json

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -50,7 +50,7 @@ for file in "${FILES_ARR[@]}"; do
 
 	end=`date +%s`
 	runtime=$((end-start))
-	printf "Finished coverage test  :  %-60s  :  +%3d \n" $relativeName $runtime
+	printf "Finished coverage test  :  %-55s  :  +%3d \n" $relativeName $runtime
 done
 
 echo ""

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -57,6 +57,8 @@ echo ""
 echo "      --------------------        "
 echo ""
 
+rm -f ./test/.cached_binary_test_info.json
+
 cat test.out | grep -v "warning: no packages" | grep -v "\[no test files\]" || true
 rm -f coverage.tmp
 grep "FAIL" test.out | tee -a fail.out
@@ -112,5 +114,3 @@ cat ./coverage/istanbul.json | jq '[
 echo "Checking code coverage for runtime folder"
 ./node_modules/.bin/istanbul check-coverage --statements 100 \
 	./coverage/istanbul-runtime.json
-
-rm -f ./test/.cached_binary_test_info.json

--- a/test/endpoints/contacts/save-contacts_test.go
+++ b/test/endpoints/contacts/save-contacts_test.go
@@ -48,6 +48,7 @@ func BenchmarkSaveContacts(b *testing.B) {
 	gateway.Backends()["contacts"].HandleFunc(
 		"POST", "/foo/contacts", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(202)
+			_, _ = w.Write([]byte("{}"))
 		},
 	)
 
@@ -108,6 +109,7 @@ func TestSaveContactsCall(t *testing.T) {
 		"POST", "/foo/contacts", func(w http.ResponseWriter, r *http.Request) {
 			counter++
 			w.WriteHeader(202)
+			_, _ = w.Write([]byte("{}"))
 		},
 	)
 

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -79,7 +79,10 @@ func CreateGateway(
 	}
 
 	seedConfig["port"] = int64(0)
-	seedConfig["tchannel.serviceName"] = "bench-gateway"
+
+	if _, ok := seedConfig["tchannel.serviceName"]; !ok {
+		seedConfig["tchannel.serviceName"] = "bench-gateway"
+	}
 	seedConfig["tchannel.processName"] = "bench-gateway"
 	seedConfig["metrics.tally.service"] = "bench-gateway"
 	seedConfig["logger.output"] = "stdout"


### PR DESCRIPTION
I'm looking into add `PeekBody()` to `HTTPServerResponse`.

This is a pre-cursor PR that just ramps up the test coverage
so that we can iterate without breaking existing code & features.

 - Add `GetErrorLogs()` to `BenchGateway`
 - Add support for `zap.SyncWriter` in `Gateway`
 - Refactor and remove unneeded `CopyJSON()`
 - Remove unused `WriteHeader`
 - Write a bunch of tests.
 - Clamp code coverage @ 100% for runtime/*
 - Add nil gaurd to `WriteJSON` to avoid panics.

r: @uber/zanzibar-team