### PR TITLE
Fixup header validation semantics

### DIFF
--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -39,7 +39,7 @@ func Handle{{title .Name}}Request(
 	clients *clients.Clients,
 ) {
 	{{ if .Headers -}}
-	if ok := req.CheckHeaders({{.Headers | printf "%#v" }}); !ok {
+	if !req.CheckHeaders({{.Headers | printf "%#v" }}) {
 		return
 	}
 	{{- end}}

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -38,17 +38,15 @@ func Handle{{title .Name}}Request(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 	{{ if .Headers -}}
-	for _, header := range {{.Headers | printf "%#v"}} {
-		h.Set(header, req.Header.Get(header))
+	if ok := req.CheckHeaders({{.Headers | printf "%#v" }}); !ok {
+		return
 	}
 	{{- end}}
 
 	// Handle request body.
 	{{if or (eq .RequestType "") (eq $clientMethodRequestType "") -}}
-	clientResp, err := clients.{{$clientName}}.{{title ($clientMethod).Name}}(ctx, h)
+	clientResp, err := clients.{{$clientName}}.{{title ($clientMethod).Name}}(ctx)
 
 	{{- else -}}
 		var body {{title .RequestType}}
@@ -56,7 +54,7 @@ func Handle{{title .Name}}Request(
 			return
 		}
 		clientRequest := convertTo{{title .Name}}ClientRequest(&body)
-		clientResp, err := clients.{{$clientName}}.{{title ($clientMethod).Name}}(ctx, clientRequest, h)
+		clientResp, err := clients.{{$clientName}}.{{title ($clientMethod).Name}}(ctx, clientRequest)
 	{{- end }}
 	if err != nil {
 		req.Logger.Error("Could not make client request",

--- a/codegen/templates/endpoint_test.tmpl
+++ b/codegen/templates/endpoint_test.tmpl
@@ -23,6 +23,7 @@ import (
 {{- $clientMethodName := $clientMethod.Name | title -}}
 {{- $clientMethodRequestType := fullTypeName  ($clientMethod).RequestType ($clientPackage) -}}
 {{- $clientMethodResponseType := fullTypeName  ($clientMethod).ResponseType ($clientPackage) -}}
+{{- $headers := .Headers }}
 
 
 {{range $.TestStubs}}
@@ -57,8 +58,18 @@ func Test{{.HandlerID | Title}}{{.TestName | Title}}OKResponse(t *testing.T) {
 
 	{{end -}}
 
+	headers := map[string]string{}
+	{{ if $headers -}}
+	{{range $idx, $headerName := $headers -}}
+	headers["{{$headerName}}"] = "placeholder"
+	{{end}}
+	{{- end}}
+
 	res, err := gateway.MakeRequest(
-		"{{$.Method.HTTPMethod}}", "{{$.Method.HTTPPath}}", bytes.NewReader([]byte(`{{.EndpointRequestString}}`)),
+		"{{$.Method.HTTPMethod}}",
+		"{{$.Method.HTTPPath}}",
+		headers,
+		bytes.NewReader([]byte(`{{.EndpointRequestString}}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -47,7 +47,7 @@ func NewClient(config *zanzibar.StaticConfig) *{{$clientName}} {
 {{- if ne .RequestType ""}}
 {{/* template for having request http body */}}
 // {{title .Name}} calls "{{.HTTPPath}}" endpoint.
-func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType}}, h http.Header) (*http.Response, error) {
+func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType}}) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL
@@ -66,9 +66,6 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
@@ -76,7 +73,7 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 {{else}} {{/* template for having http body */ -}}
 
 // {{title .Name}} calls "{{.HTTPPath}}" endpoint.
-func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
@@ -88,9 +85,6 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, h http.Header) (*
 	req, err := http.NewRequest("{{.HTTPMethod}}", fullURL, nil)
 	if err != nil {
 		return nil, err
-	}
-	if h != nil {
-		req.Header = h
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -34,7 +34,7 @@ func NewClient(config *zanzibar.StaticConfig) *BarClient {
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
-func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/arg-not-struct-path"
@@ -48,15 +48,12 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
-func (c *BarClient) MissingArg(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL + "/missing-arg-path"
 
@@ -64,15 +61,12 @@ func (c *BarClient) MissingArg(ctx context.Context, h http.Header) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // NoRequest calls "/no-request-path" endpoint.
-func (c *BarClient) NoRequest(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL + "/no-request-path"
 
@@ -80,15 +74,12 @@ func (c *BarClient) NoRequest(ctx context.Context, h http.Header) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // Normal calls "/bar-path" endpoint.
-func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/bar-path"
@@ -102,15 +93,12 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest, h http.Hea
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
-func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/too-many-args-path"
@@ -123,9 +111,6 @@ func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest, 
 	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
 	if err != nil {
 		return nil, err
-	}
-	if h != nil {
-		req.Header = h
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))

--- a/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
@@ -40,8 +40,13 @@ func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/arg-not-struct-path", fakeArgNotStruct,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/arg-not-struct-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/arg-not-struct-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
@@ -40,8 +40,13 @@ func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 		"GET", "/missing-arg-path", fakeMissingArg,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"GET", "/bar/missing-arg-path", bytes.NewReader([]byte(`{}`)),
+		"GET",
+		"/bar/missing-arg-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
@@ -40,8 +40,13 @@ func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 		"GET", "/no-request-path", fakeNoRequest,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"GET", "/bar/no-request-path", bytes.NewReader([]byte(`{}`)),
+		"GET",
+		"/bar/no-request-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
@@ -40,8 +40,13 @@ func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/bar-path", fakeNormal,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/bar-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/bar-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
@@ -40,8 +40,15 @@ func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/too-many-args-path", fakeTooManyArgs,
 	)
 
+	headers := map[string]string{}
+	headers["x-uuid"] = "placeholder"
+	headers["x-token"] = "placeholder"
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/too-many-args-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/too-many-args-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -5,7 +5,6 @@ package bar
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -22,8 +21,6 @@ func HandleArgNotStructRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
 	var body ArgNotStructHTTPRequest
@@ -31,7 +28,7 @@ func HandleArgNotStructRequest(
 		return
 	}
 	clientRequest := convertToArgNotStructClientRequest(&body)
-	clientResp, err := clients.Bar.ArgNotStruct(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.ArgNotStruct(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -23,11 +22,9 @@ func HandleMissingArgRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
-	clientResp, err := clients.Bar.MissingArg(ctx, h)
+	clientResp, err := clients.Bar.MissingArg(ctx)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -23,11 +22,9 @@ func HandleNoRequestRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
-	clientResp, err := clients.Bar.NoRequest(ctx, h)
+	clientResp, err := clients.Bar.NoRequest(ctx)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -26,8 +25,6 @@ func HandleNormalRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
 	var body NormalHTTPRequest
@@ -35,7 +32,7 @@ func HandleNormalRequest(
 		return
 	}
 	clientRequest := convertToNormalClientRequest(&body)
-	clientResp, err := clients.Bar.Normal(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.Normal(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -26,7 +26,7 @@ func HandleTooManyArgsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -27,10 +26,8 @@ func HandleTooManyArgsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
-	for _, header := range []string{"x-uuid", "x-token"} {
-		h.Set(header, req.Header.Get(header))
+	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+		return
 	}
 
 	// Handle request body.
@@ -39,7 +36,7 @@ func HandleTooManyArgsRequest(
 		return
 	}
 	clientRequest := convertToTooManyArgsClientRequest(&body)
-	clientResp, err := clients.Bar.TooManyArgs(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.TooManyArgs(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -34,7 +34,7 @@ func NewClient(config *zanzibar.StaticConfig) *BarClient {
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
-func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/arg-not-struct-path"
@@ -48,15 +48,12 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
-func (c *BarClient) MissingArg(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL + "/missing-arg-path"
 
@@ -64,15 +61,12 @@ func (c *BarClient) MissingArg(ctx context.Context, h http.Header) (*http.Respon
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // NoRequest calls "/no-request-path" endpoint.
-func (c *BarClient) NoRequest(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL + "/no-request-path"
 
@@ -80,15 +74,12 @@ func (c *BarClient) NoRequest(ctx context.Context, h http.Header) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // Normal calls "/bar-path" endpoint.
-func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/bar-path"
@@ -102,15 +93,12 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest, h http.Hea
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
-func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/too-many-args-path"
@@ -123,9 +111,6 @@ func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest, 
 	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
 	if err != nil {
 		return nil, err
-	}
-	if h != nil {
-		req.Header = h
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -35,7 +35,7 @@ func NewClient(config *zanzibar.StaticConfig) *ContactsClient {
 }
 
 // SaveContacts calls "/:userUUID/contacts" endpoint.
-func (c *ContactsClient) SaveContacts(ctx context.Context, r *contacts.SaveContactsRequest, h http.Header) (*http.Response, error) {
+func (c *ContactsClient) SaveContacts(ctx context.Context, r *contacts.SaveContactsRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/" + string(r.UserUUID) + "/contacts"
@@ -48,9 +48,6 @@ func (c *ContactsClient) SaveContacts(ctx context.Context, r *contacts.SaveConta
 	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
 	if err != nil {
 		return nil, err
-	}
-	if h != nil {
-		req.Header = h
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -34,7 +34,7 @@ func NewClient(config *zanzibar.StaticConfig) *GoogleNowClient {
 }
 
 // AddCredentials calls "/add-credentials" endpoint.
-func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsHTTPRequest, h http.Header) (*http.Response, error) {
+func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
 	fullURL := c.BaseURL + "/add-credentials"
@@ -48,24 +48,18 @@ func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsH
 	if err != nil {
 		return nil, err
 	}
-	if h != nil {
-		req.Header = h
-	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))
 }
 
 // CheckCredentials calls "/check-credentials" endpoint.
-func (c *GoogleNowClient) CheckCredentials(ctx context.Context, h http.Header) (*http.Response, error) {
+func (c *GoogleNowClient) CheckCredentials(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
 	fullURL := c.BaseURL + "/check-credentials"
 
 	req, err := http.NewRequest("POST", fullURL, nil)
 	if err != nil {
 		return nil, err
-	}
-	if h != nil {
-		req.Header = h
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.Client.Do(req.WithContext(ctx))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -5,7 +5,6 @@ package bar
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -22,8 +21,6 @@ func HandleArgNotStructRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
 	var body ArgNotStructHTTPRequest
@@ -31,7 +28,7 @@ func HandleArgNotStructRequest(
 		return
 	}
 	clientRequest := convertToArgNotStructClientRequest(&body)
-	clientResp, err := clients.Bar.ArgNotStruct(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.ArgNotStruct(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
@@ -40,8 +40,13 @@ func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/arg-not-struct-path", fakeArgNotStruct,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/arg-not-struct-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/arg-not-struct-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -23,11 +22,9 @@ func HandleMissingArgRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
-	clientResp, err := clients.Bar.MissingArg(ctx, h)
+	clientResp, err := clients.Bar.MissingArg(ctx)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
@@ -40,8 +40,13 @@ func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 		"GET", "/missing-arg-path", fakeMissingArg,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"GET", "/bar/missing-arg-path", bytes.NewReader([]byte(`{}`)),
+		"GET",
+		"/bar/missing-arg-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -23,11 +22,9 @@ func HandleNoRequestRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
-	clientResp, err := clients.Bar.NoRequest(ctx, h)
+	clientResp, err := clients.Bar.NoRequest(ctx)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
@@ -40,8 +40,13 @@ func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 		"GET", "/no-request-path", fakeNoRequest,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"GET", "/bar/no-request-path", bytes.NewReader([]byte(`{}`)),
+		"GET",
+		"/bar/no-request-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -26,8 +25,6 @@ func HandleNormalRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
 
 	// Handle request body.
 	var body NormalHTTPRequest
@@ -35,7 +32,7 @@ func HandleNormalRequest(
 		return
 	}
 	clientRequest := convertToNormalClientRequest(&body)
-	clientResp, err := clients.Bar.Normal(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.Normal(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
@@ -40,8 +40,13 @@ func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/bar-path", fakeNormal,
 	)
 
+	headers := map[string]string{}
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/bar-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/bar-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -26,7 +26,7 @@ func HandleTooManyArgsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -6,7 +6,6 @@ package bar
 import (
 	"context"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -27,10 +26,8 @@ func HandleTooManyArgsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
-	for _, header := range []string{"x-uuid", "x-token"} {
-		h.Set(header, req.Header.Get(header))
+	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+		return
 	}
 
 	// Handle request body.
@@ -39,7 +36,7 @@ func HandleTooManyArgsRequest(
 		return
 	}
 	clientRequest := convertToTooManyArgsClientRequest(&body)
-	clientResp, err := clients.Bar.TooManyArgs(ctx, clientRequest, h)
+	clientResp, err := clients.Bar.TooManyArgs(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
@@ -40,8 +40,15 @@ func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/too-many-args-path", fakeTooManyArgs,
 	)
 
+	headers := map[string]string{}
+	headers["x-uuid"] = "placeholder"
+	headers["x-token"] = "placeholder"
+
 	res, err := gateway.MakeRequest(
-		"POST", "/bar/too-many-args-path", bytes.NewReader([]byte(`{}`)),
+		"POST",
+		"/bar/too-many-args-path",
+		headers,
+		bytes.NewReader([]byte(`{}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -21,7 +21,7 @@ func HandleAddCredentialsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
 	}
 

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -5,7 +5,6 @@ package googlenow
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -22,10 +21,8 @@ func HandleAddCredentialsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
-	for _, header := range []string{"x-uuid", "x-token"} {
-		h.Set(header, req.Header.Get(header))
+	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+		return
 	}
 
 	// Handle request body.
@@ -34,7 +31,7 @@ func HandleAddCredentialsRequest(
 		return
 	}
 	clientRequest := convertToAddCredentialsClientRequest(&body)
-	clientResp, err := clients.GoogleNow.AddCredentials(ctx, clientRequest, h)
+	clientResp, err := clients.GoogleNow.AddCredentials(ctx, clientRequest)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
@@ -40,8 +40,15 @@ func TestAddCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/add-credentials", fakeAddCredentials,
 	)
 
+	headers := map[string]string{}
+	headers["x-uuid"] = "placeholder"
+	headers["x-token"] = "placeholder"
+
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials", bytes.NewReader([]byte(`{"authcode":"test"}`)),
+		"POST",
+		"/googlenow/add-credentials",
+		headers,
+		bytes.NewReader([]byte(`{"authcode":"test"}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -19,7 +19,7 @@ func HandleCheckCredentialsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
 	}
 

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -5,7 +5,6 @@ package googlenow
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/zap"
@@ -20,14 +19,12 @@ func HandleCheckCredentialsRequest(
 	res *zanzibar.ServerHTTPResponse,
 	clients *clients.Clients,
 ) {
-	// Handle request headers.
-	h := http.Header{}
-	for _, header := range []string{"x-uuid", "x-token"} {
-		h.Set(header, req.Header.Get(header))
+	if ok := req.CheckHeaders([]string{"x-uuid", "x-token"}); !ok {
+		return
 	}
 
 	// Handle request body.
-	clientResp, err := clients.GoogleNow.CheckCredentials(ctx, h)
+	clientResp, err := clients.GoogleNow.CheckCredentials(ctx)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
@@ -40,8 +40,15 @@ func TestCheckCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 		"POST", "/check-credentials", fakeCheckCredentials,
 	)
 
+	headers := map[string]string{}
+	headers["x-uuid"] = "placeholder"
+	headers["x-token"] = "placeholder"
+
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/check-credentials", bytes.NewReader([]byte(`{"authcode":"test"}`)),
+		"POST",
+		"/googlenow/check-credentials",
+		headers,
+		bytes.NewReader([]byte(`{"authcode":"test"}`)),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/examples/example-gateway/endpoints/contacts/save-contacts.go
+++ b/examples/example-gateway/endpoints/contacts/save-contacts.go
@@ -34,7 +34,7 @@ func HandleSaveContactsRequest(
 	body.AppVersion = req.Header.Get("x-uber-client-version")
 
 	clientBody := convertToClient(&body)
-	cres, err := clients.Contacts.SaveContacts(ctx, clientBody, nil)
+	cres, err := clients.Contacts.SaveContacts(ctx, clientBody)
 	if err != nil {
 		req.Logger.Error("Could not make client request",
 			zap.String("error", err.Error()),

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -73,7 +73,7 @@ func TestHandlers(t *testing.T) {
 			middlewareStack.Handle,
 		),
 	)
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -154,7 +154,7 @@ func TestMiddlewareRequestAbort(t *testing.T) {
 			middlewareStack.Handle,
 		),
 	)
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -203,7 +203,7 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 			middlewareStack.Handle,
 		),
 	)
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -260,7 +260,7 @@ func TestMiddlewareSharedStates(t *testing.T) {
 			middlewareStack.Handle,
 		),
 	)
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -81,7 +81,7 @@ func TestTrailingSlashRoutes(t *testing.T) {
 	}
 
 	for _, testReq := range testRequests {
-		resp, err := gateway.MakeRequest("GET", testReq.url, nil)
+		resp, err := gateway.MakeRequest("GET", testReq.url, nil, nil)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -101,7 +101,7 @@ func TestRouterNotFound(t *testing.T) {
 		return
 	}
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -123,7 +123,7 @@ func TestRouterInvalidMethod(t *testing.T) {
 		return
 	}
 
-	resp, err := gateway.MakeRequest("POST", "/health", nil)
+	resp, err := gateway.MakeRequest("POST", "/health", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -99,7 +99,20 @@ func (req *ServerHTTPRequest) start(endpoint string, handler string) {
 }
 
 // CheckHeaders verifies that request contains required headers.
-func (req *ServerHTTPRequest) CheckHeaders([]string) bool {
+func (req *ServerHTTPRequest) CheckHeaders(headers []string) bool {
+	for _, headerName := range headers {
+		headerValue := req.httpRequest.Header.Get(headerName)
+		if headerValue == "" {
+			req.res.SendErrorString(
+				400, "Missing mandatory header: "+headerName,
+			)
+			req.Logger.Warn("Got request without mandatory header",
+				zap.String("headerName", headerName),
+			)
+			return false
+		}
+
+	}
 	return true
 }
 

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -98,6 +98,11 @@ func (req *ServerHTTPRequest) start(endpoint string, handler string) {
 	req.metrics.requestRecvd.Inc(1)
 }
 
+// CheckHeaders verifies that request contains required headers.
+func (req *ServerHTTPRequest) CheckHeaders([]string) bool {
+	return true
+}
+
 // ReadAndUnmarshalBody will try to unmarshal into struct or fail
 func (req *ServerHTTPRequest) ReadAndUnmarshalBody(
 	body json.Unmarshaler,

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -55,7 +55,7 @@ func TestInvalidStatusCode(t *testing.T) {
 		),
 	)
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -109,7 +109,7 @@ func TestCallingWriteJSONWithNil(t *testing.T) {
 		),
 	)
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -163,7 +163,7 @@ func TestCallWriteJSONWithBadJSON(t *testing.T) {
 		),
 	)
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -246,7 +246,7 @@ func TestResponsePeekBody(t *testing.T) {
 		),
 	)
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -295,7 +295,7 @@ func TestResponsePeekBodyError(t *testing.T) {
 		),
 	)
 
-	resp, err := gateway.MakeRequest("GET", "/foo", nil)
+	resp, err := gateway.MakeRequest("GET", "/foo", nil, nil)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/test/endpoints/contacts/save-contacts_test.go
+++ b/test/endpoints/contacts/save-contacts_test.go
@@ -58,7 +58,7 @@ func BenchmarkSaveContacts(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			res, err := gateway.MakeRequest(
-				"POST", "/contacts/foo/contacts",
+				"POST", "/contacts/foo/contacts", nil,
 				bytes.NewReader(benchBytes),
 			)
 			if err != nil {
@@ -119,7 +119,7 @@ func TestSaveContactsCall(t *testing.T) {
 	rawBody, _ := saveContacts.MarshalJSON()
 
 	res, err := gateway.MakeRequest(
-		"POST", "/contacts/foo/contacts", bytes.NewReader(rawBody),
+		"POST", "/contacts/foo/contacts", nil, bytes.NewReader(rawBody),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -423,7 +423,7 @@ func TestAddCredentialsWrongStatusCode(t *testing.T) {
 
 func TestGoogleNowMissingHeaders(t *testing.T) {
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
-		KnownBackends: []string{"googleNow"},
+		KnownHTTPBackends: []string{"googleNow"},
 		TestBinary: filepath.Join(
 			getDirName(), "..", "..", "..",
 			"examples", "example-gateway", "build", "main.go",

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -40,6 +40,10 @@ import (
 
 var benchBytes = []byte("{\"authCode\":\"abcdef\"}")
 var noAuthCodeBytes = []byte("{}")
+var headers map[string]string = map[string]string{
+	"x-uuid":  "uuid",
+	"x-token": "token",
+}
 
 func BenchmarkGoogleNowAddCredentials(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
@@ -65,7 +69,7 @@ func BenchmarkGoogleNowAddCredentials(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			res, err := gateway.MakeRequest(
-				"POST", "/googlenow/add-credentials",
+				"POST", "/googlenow/add-credentials", headers,
 				bytes.NewReader(benchBytes),
 			)
 			if err != nil {
@@ -123,7 +127,8 @@ func TestAddCredentials(t *testing.T) {
 	)
 
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials", bytes.NewReader(benchBytes),
+		"POST", "/googlenow/add-credentials", headers,
+		bytes.NewReader(benchBytes),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return
@@ -195,7 +200,7 @@ func TestGoogleNowFailReadAllCall(t *testing.T) {
 	}
 
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials",
+		"POST", "/googlenow/add-credentials", headers,
 		bytes.NewReader([]byte("junk data")),
 	)
 	assert.Error(t, err)
@@ -247,7 +252,7 @@ func TestGoogleNowFailJSONParsing(t *testing.T) {
 	)
 
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials",
+		"POST", "/googlenow/add-credentials", headers,
 		bytes.NewReader([]byte("bad bytes")),
 	)
 	if !assert.NoError(t, err, "got http error") {
@@ -302,7 +307,8 @@ func TestAddCredentialsMissingAuthCode(t *testing.T) {
 	)
 
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials", bytes.NewReader(noAuthCodeBytes),
+		"POST", "/googlenow/add-credentials", headers,
+		bytes.NewReader(noAuthCodeBytes),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return
@@ -333,7 +339,8 @@ func TestAddCredentialsBackendDown(t *testing.T) {
 	gateway.HTTPBackends()["googleNow"].Close()
 
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials", bytes.NewReader(noAuthCodeBytes),
+		"POST", "/googlenow/add-credentials", headers,
+		bytes.NewReader(noAuthCodeBytes),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return
@@ -396,7 +403,8 @@ func TestAddCredentialsWrongStatusCode(t *testing.T) {
 		},
 	)
 	res, err := gateway.MakeRequest(
-		"POST", "/googlenow/add-credentials", bytes.NewReader(noAuthCodeBytes),
+		"POST", "/googlenow/add-credentials", headers,
+		bytes.NewReader(noAuthCodeBytes),
 	)
 	if !assert.NoError(t, err, "got http error") {
 		return

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -450,7 +450,7 @@ func TestGoogleNowMissingHeaders(t *testing.T) {
 	}
 
 	assert.Equal(t,
-		"Missing mandatory header: x-uuid",
+		`{"error":"Missing mandatory header: x-uuid"}`,
 		string(respBytes),
 	)
 }

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -54,7 +54,7 @@ func TestHealthCall(t *testing.T) {
 
 	assert.NotNil(t, gateway, "gateway exists")
 
-	res, err := gateway.MakeRequest("GET", "/health", nil)
+	res, err := gateway.MakeRequest("GET", "/health", nil, nil)
 	if !assert.NoError(t, err, "got http error") {
 		return
 	}
@@ -74,7 +74,7 @@ func BenchmarkHealthCall(b *testing.B) {
 	// b.SetParallelism(100)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			res, err := gateway.MakeRequest("GET", "/health", nil)
+			res, err := gateway.MakeRequest("GET", "/health", nil, nil)
 			if err != nil {
 				b.Error("got http error: " + err.Error())
 				break
@@ -124,7 +124,7 @@ func TestHealthMetrics(t *testing.T) {
 	// Expect three metrics
 	cgateway.MetricsWaitGroup.Add(3)
 
-	res, err := gateway.MakeRequest("GET", "/health", nil)
+	res, err := gateway.MakeRequest("GET", "/health", nil, nil)
 	if !assert.NoError(t, err, "got http error") {
 		return
 	}

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -189,13 +189,16 @@ func (gateway *BenchGateway) HTTPBackends() map[string]*testBackend.TestHTTPBack
 
 // MakeRequest helper
 func (gateway *BenchGateway) MakeRequest(
-	method string, url string, body io.Reader,
+	method string, url string, headers map[string]string, body io.Reader,
 ) (*http.Response, error) {
 	client := gateway.httpClient
 
 	fullURL := "http://" + gateway.ActualGateway.RealAddr + url
 
 	req, err := http.NewRequest(method, fullURL, body)
+	for headerName, headerValue := range headers {
+		req.Header.Set(headerName, headerValue)
+	}
 
 	if err != nil {
 		return nil, err

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -38,7 +38,10 @@ import (
 // TestGateway interface
 type TestGateway interface {
 	MakeRequest(
-		method string, url string, body io.Reader,
+		method string,
+		url string,
+		headers map[string]string,
+		body io.Reader,
 	) (*http.Response, error)
 	HTTPBackends() map[string]*testBackend.TestHTTPBackend
 	GetPort() int
@@ -148,13 +151,16 @@ func CreateGateway(
 
 // MakeRequest helper
 func (gateway *ChildProcessGateway) MakeRequest(
-	method string, url string, body io.Reader,
+	method string, url string, headers map[string]string, body io.Reader,
 ) (*http.Response, error) {
 	client := gateway.HTTPClient
 
 	fullURL := "http://" + gateway.RealAddr + url
 
 	req, err := http.NewRequest(method, fullURL, body)
+	for headerName, headerValue := range headers {
+		req.Header.Set(headerName, headerValue)
+	}
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently on master our header semantics were broken.

We have an annotation for "mandatory" headers that was
implemented in code generation to mean "headers to propagate".

I've refactored the client to temporarily remove header
propagation for now and updated the endpoint to verify
that the mandatory headers exist.

 - add support for headers in `TestGateway#MakeRequest()`
 - add `ServerRequest#CheckHeaders`
 - refactor tests to pass

r: @uber/zanzibar-team