### PR TITLE
Generate non-reference type fields of client/endpoint structs as pointers to such types

### DIFF
--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -176,7 +176,7 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "bar.BarRequest",
+							"Type": "*bar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						}
@@ -226,12 +226,12 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "bar.BarRequest",
+							"Type": "*bar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						},
 						{
-							"Type": "foo.FooStruct",
+							"Type": "*foo.FooStruct",
 							"Name": "foo",
 							"Annotations": null
 						}

--- a/codegen/test_data/clients/bar_structs.gogen
+++ b/codegen/test_data/clients/bar_structs.gogen
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request bar.BarRequest
+	Request *bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request bar.BarRequest
-	Foo     foo.FooStruct
+	Request *bar.BarRequest
+	Foo     *foo.FooStruct
 }

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -73,7 +73,7 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = clientTypeBar.BarRequest(body.Request)
+	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
 
 	return clientRequest
 }

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -77,8 +77,8 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = clientTypeFoo.FooStruct(body.Foo)
-	clientRequest.Request = clientTypeBar.BarRequest(body.Request)
+	clientRequest.Foo = (*clientTypeFoo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
 
 	return clientRequest
 }

--- a/codegen/test_data/endpoints/bar_structs.gogen
+++ b/codegen/test_data/endpoints/bar_structs.gogen
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request bar.BarRequest
+	Request *bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request bar.BarRequest
-	Foo     foo.FooStruct
+	Request *bar.BarRequest
+	Foo     *foo.FooStruct
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs.go
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request bar.BarRequest
+	Request *bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request bar.BarRequest
-	Foo     foo.FooStruct
+	Request *bar.BarRequest
+	Foo     *foo.FooStruct
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs_easyjson.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs_easyjson.go
@@ -7,6 +7,8 @@ import (
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
+	bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 )
 
 // suppress unused package warning
@@ -37,9 +39,25 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		}
 		switch key {
 		case "Request":
-			(out.Request).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Request = nil
+			} else {
+				if out.Request == nil {
+					out.Request = new(bar.BarRequest)
+				}
+				(*out.Request).UnmarshalEasyJSON(in)
+			}
 		case "Foo":
-			(out.Foo).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Foo = nil
+			} else {
+				if out.Foo == nil {
+					out.Foo = new(foo.FooStruct)
+				}
+				(*out.Foo).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -59,13 +77,21 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 	}
 	first = false
 	out.RawString("\"Request\":")
-	(in.Request).MarshalEasyJSON(out)
+	if in.Request == nil {
+		out.RawString("null")
+	} else {
+		(*in.Request).MarshalEasyJSON(out)
+	}
 	if !first {
 		out.RawByte(',')
 	}
 	first = false
 	out.RawString("\"Foo\":")
-	(in.Foo).MarshalEasyJSON(out)
+	if in.Foo == nil {
+		out.RawString("null")
+	} else {
+		(*in.Foo).MarshalEasyJSON(out)
+	}
 	out.RawByte('}')
 }
 
@@ -112,7 +138,15 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		}
 		switch key {
 		case "Request":
-			(out.Request).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Request = nil
+			} else {
+				if out.Request == nil {
+					out.Request = new(bar.BarRequest)
+				}
+				(*out.Request).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -132,7 +166,11 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 	}
 	first = false
 	out.RawString("\"Request\":")
-	(in.Request).MarshalEasyJSON(out)
+	if in.Request == nil {
+		out.RawString("null")
+	} else {
+		(*in.Request).MarshalEasyJSON(out)
+	}
 	out.RawByte('}')
 }
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -73,7 +73,7 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = clientTypeBar.BarRequest(body.Request)
+	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
 
 	return clientRequest
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -77,8 +77,8 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = clientTypeFoo.FooStruct(body.Foo)
-	clientRequest.Request = clientTypeBar.BarRequest(body.Request)
+	clientRequest.Foo = (*clientTypeFoo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
 
 	return clientRequest
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs.go
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request bar.BarRequest
+	Request *bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request bar.BarRequest
-	Foo     foo.FooStruct
+	Request *bar.BarRequest
+	Foo     *foo.FooStruct
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs_easyjson.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs_easyjson.go
@@ -7,6 +7,8 @@ import (
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
+	bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
 )
 
 // suppress unused package warning
@@ -37,9 +39,25 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		}
 		switch key {
 		case "Request":
-			(out.Request).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Request = nil
+			} else {
+				if out.Request == nil {
+					out.Request = new(bar.BarRequest)
+				}
+				(*out.Request).UnmarshalEasyJSON(in)
+			}
 		case "Foo":
-			(out.Foo).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Foo = nil
+			} else {
+				if out.Foo == nil {
+					out.Foo = new(foo.FooStruct)
+				}
+				(*out.Foo).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -59,13 +77,21 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 	}
 	first = false
 	out.RawString("\"Request\":")
-	(in.Request).MarshalEasyJSON(out)
+	if in.Request == nil {
+		out.RawString("null")
+	} else {
+		(*in.Request).MarshalEasyJSON(out)
+	}
 	if !first {
 		out.RawByte(',')
 	}
 	first = false
 	out.RawString("\"Foo\":")
-	(in.Foo).MarshalEasyJSON(out)
+	if in.Foo == nil {
+		out.RawString("null")
+	} else {
+		(*in.Foo).MarshalEasyJSON(out)
+	}
 	out.RawByte('}')
 }
 
@@ -112,7 +138,15 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		}
 		switch key {
 		case "Request":
-			(out.Request).UnmarshalEasyJSON(in)
+			if in.IsNull() {
+				in.Skip()
+				out.Request = nil
+			} else {
+				if out.Request == nil {
+					out.Request = new(bar.BarRequest)
+				}
+				(*out.Request).UnmarshalEasyJSON(in)
+			}
 		default:
 			in.SkipRecursive()
 		}
@@ -132,7 +166,11 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 	}
 	first = false
 	out.RawString("\"Request\":")
-	(in.Request).MarshalEasyJSON(out)
+	if in.Request == nil {
+		out.RawString("null")
+	} else {
+		(*in.Request).MarshalEasyJSON(out)
+	}
 	out.RawByte('}')
 }
 


### PR DESCRIPTION
This PR updates the method.go in codegen dir to generate client/endpoint structs to align with thrift structs generated by thriftrw, where struct fields are of reference types.

r: @Raynos