### PR TITLE
Refactor client generation to take gateway as arg.

### DIFF
--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -47,7 +47,6 @@ func NewClient(
 // {{title .Name}} calls "{{.HTTPPath}}" endpoint.
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType}}) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
 	fullURL := c.client.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
 	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -20,23 +20,21 @@ import (
 {{range .Services}}
 {{- $clientName := title .Name | printf "%sClient" -}}
 // {{$clientName}} is the http client for service {{.Name}}.
-type {{$clientName}} zanzibar.HTTPClient
+type {{$clientName}} struct {
+	client *zanzibar.HTTPClient
+}
 
 // NewClient returns a new http client for service {{.Name}}.
-func NewClient(config *zanzibar.StaticConfig) *{{$clientName}} {
+func NewClient(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *{{$clientName}} {
 	ip := config.MustGetString("clients.{{.Name | camel}}.ip")
 	port := config.MustGetInt("clients.{{.Name | camel}}.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives:   false,
-				MaxIdleConns:        500,
-				MaxIdleConnsPerHost: 500,
-			},
-		},
-		BaseURL: baseURL,
+		client: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
@@ -50,7 +48,7 @@ func NewClient(config *zanzibar.StaticConfig) *{{$clientName}} {
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType}}) (*http.Response, error) {
 	// Generate full URL.
 	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL
+	fullURL := c.client.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
 	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"
 	{{- else -}}+"/"+string(r.{{$segment.BodyIdentifier | title}})
@@ -67,7 +65,7 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 {{else}} {{/* template for having http body */ -}}
@@ -75,7 +73,7 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 // {{title .Name}} calls "{{.HTTPPath}}" endpoint.
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL
+	fullURL := c.client.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
 	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"
 	{{- else -}}+"/"+r.{{$segment.BodyIdentifier}}
@@ -87,7 +85,7 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 {{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 {{end}} {{- /* <range .Methods> */ -}}

--- a/codegen/templates/init_clients.tmpl
+++ b/codegen/templates/init_clients.tmpl
@@ -20,10 +20,15 @@ type Clients struct {
 }
 
 // CreateClients will make all clients
-func CreateClients(config *zanzibar.StaticConfig) *Clients {
+func CreateClients(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *Clients {
 	return &Clients{
 		{{range $idx, $cinfo := .ClientInfo -}}
-		{{$cinfo.FieldName}}: {{$cinfo.PackageName}}.NewClient(config),
+		{{$cinfo.FieldName}}: {{$cinfo.PackageName}}.NewClient(
+			config, gateway,
+		),
 		{{end}}
 	}
 }

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -39,10 +39,16 @@ func getConfig() *zanzibar.StaticConfig {
 
 func createGateway() (*zanzibar.Gateway, error) {
 	config := getConfig()
-	clients := clients.CreateClients(config)
-	return zanzibar.CreateGateway(config, &zanzibar.Options{
-		Clients: clients,
-	})
+	
+	gateway, err := zanzibar.CreateGateway(config, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := clients.CreateClients(config, gateway)
+	gateway.Clients = clients
+
+	return gateway, nil
 }
 
 func logAndWait(server *zanzibar.Gateway) {

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -13,31 +13,28 @@ import (
 )
 
 // BarClient is the http client for service Bar.
-type BarClient zanzibar.HTTPClient
+type BarClient struct {
+	client *zanzibar.HTTPClient
+}
 
 // NewClient returns a new http client for service Bar.
-func NewClient(config *zanzibar.StaticConfig) *BarClient {
+func NewClient(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *BarClient {
 	ip := config.MustGetString("clients.bar.ip")
 	port := config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives:   false,
-				MaxIdleConns:        500,
-				MaxIdleConnsPerHost: 500,
-			},
-		},
-		BaseURL: baseURL,
+		client: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/arg-not-struct-path"
+	fullURL := c.client.BaseURL + "/arg-not-struct-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -49,40 +46,39 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL + "/missing-arg-path"
+	fullURL := c.client.BaseURL + "/missing-arg-path"
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL + "/no-request-path"
+	fullURL := c.client.BaseURL + "/no-request-path"
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/bar-path"
+	fullURL := c.client.BaseURL + "/bar-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -94,14 +90,13 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Res
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/too-many-args-path"
+	fullURL := c.client.BaseURL + "/too-many-args-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -113,5 +108,5 @@ func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -13,31 +13,28 @@ import (
 )
 
 // BarClient is the http client for service Bar.
-type BarClient zanzibar.HTTPClient
+type BarClient struct {
+	client *zanzibar.HTTPClient
+}
 
 // NewClient returns a new http client for service Bar.
-func NewClient(config *zanzibar.StaticConfig) *BarClient {
+func NewClient(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *BarClient {
 	ip := config.MustGetString("clients.bar.ip")
 	port := config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives:   false,
-				MaxIdleConns:        500,
-				MaxIdleConnsPerHost: 500,
-			},
-		},
-		BaseURL: baseURL,
+		client: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/arg-not-struct-path"
+	fullURL := c.client.BaseURL + "/arg-not-struct-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -49,40 +46,39 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL + "/missing-arg-path"
+	fullURL := c.client.BaseURL + "/missing-arg-path"
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL + "/no-request-path"
+	fullURL := c.client.BaseURL + "/no-request-path"
 
 	req, err := http.NewRequest("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/bar-path"
+	fullURL := c.client.BaseURL + "/bar-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -94,14 +90,13 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Res
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/too-many-args-path"
+	fullURL := c.client.BaseURL + "/too-many-args-path"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -113,5 +108,5 @@ func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) 
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }

--- a/examples/example-gateway/build/clients/clients.go
+++ b/examples/example-gateway/build/clients/clients.go
@@ -20,10 +20,19 @@ type Clients struct {
 }
 
 // CreateClients will make all clients
-func CreateClients(config *zanzibar.StaticConfig) *Clients {
+func CreateClients(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *Clients {
 	return &Clients{
-		Bar:       barClient.NewClient(config),
-		Contacts:  contactsClient.NewClient(config),
-		GoogleNow: googlenowClient.NewClient(config),
+		Bar: barClient.NewClient(
+			config, gateway,
+		),
+		Contacts: contactsClient.NewClient(
+			config, gateway,
+		),
+		GoogleNow: googlenowClient.NewClient(
+			config, gateway,
+		),
 	}
 }

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -13,31 +13,28 @@ import (
 )
 
 // GoogleNowClient is the http client for service GoogleNow.
-type GoogleNowClient zanzibar.HTTPClient
+type GoogleNowClient struct {
+	client *zanzibar.HTTPClient
+}
 
 // NewClient returns a new http client for service GoogleNow.
-func NewClient(config *zanzibar.StaticConfig) *GoogleNowClient {
+func NewClient(
+	config *zanzibar.StaticConfig,
+	gateway *zanzibar.Gateway,
+) *GoogleNowClient {
 	ip := config.MustGetString("clients.googleNow.ip")
 	port := config.MustGetInt("clients.googleNow.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &GoogleNowClient{
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives:   false,
-				MaxIdleConns:        500,
-				MaxIdleConnsPerHost: 500,
-			},
-		},
-		BaseURL: baseURL,
+		client: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // AddCredentials calls "/add-credentials" endpoint.
 func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsHTTPRequest) (*http.Response, error) {
 	// Generate full URL.
-	// TODO: (jakev) insert params if needed here.
-	fullURL := c.BaseURL + "/add-credentials"
+	fullURL := c.client.BaseURL + "/add-credentials"
 
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
@@ -49,18 +46,18 @@ func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsH
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }
 
 // CheckCredentials calls "/check-credentials" endpoint.
 func (c *GoogleNowClient) CheckCredentials(ctx context.Context) (*http.Response, error) {
 	// Generate full URL.
-	fullURL := c.BaseURL + "/check-credentials"
+	fullURL := c.client.BaseURL + "/check-credentials"
 
 	req, err := http.NewRequest("POST", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	return c.Client.Do(req.WithContext(ctx))
+	return c.client.Client.Do(req.WithContext(ctx))
 }

--- a/examples/example-gateway/build/main.go
+++ b/examples/example-gateway/build/main.go
@@ -37,10 +37,16 @@ func getConfig() *zanzibar.StaticConfig {
 
 func createGateway() (*zanzibar.Gateway, error) {
 	config := getConfig()
-	clients := clients.CreateClients(config)
-	return zanzibar.CreateGateway(config, &zanzibar.Options{
-		Clients: clients,
-	})
+
+	gateway, err := zanzibar.CreateGateway(config, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := clients.CreateClients(config, gateway)
+	gateway.Clients = clients
+
+	return gateway, nil
 }
 
 func logAndWait(server *zanzibar.Gateway) {

--- a/runtime/http_client.go
+++ b/runtime/http_client.go
@@ -24,12 +24,26 @@ import "net/http"
 
 // HTTPClient defines a http client.
 type HTTPClient struct {
+	gateway *Gateway
+
 	Client  *http.Client
 	BaseURL string
 }
 
-// HTTPClientOptions to create a new http client
-type HTTPClientOptions struct {
-	IP   string
-	Port int32
+// NewHTTPClient will allocate a http client.
+func NewHTTPClient(
+	gateway *Gateway, baseURL string,
+) *HTTPClient {
+	return &HTTPClient{
+		gateway: gateway,
+
+		Client: &http.Client{
+			Transport: &http.Transport{
+				DisableKeepAlives:   false,
+				MaxIdleConns:        500,
+				MaxIdleConnsPerHost: 500,
+			},
+		},
+		BaseURL: baseURL,
+	}
 }

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -124,15 +124,14 @@ func CreateGateway(
 		),
 	}, seedConfig)
 
-	clients := clients.CreateClients(config)
-
 	gateway, err := zanzibar.CreateGateway(config, &zanzibar.Options{
-		Clients:   clients,
 		LogWriter: zap.AddSync(benchGateway.logBytes),
 	})
 	if err != nil {
 		return nil, err
 	}
+	gateway.Clients = clients.CreateClients(config, gateway)
+
 	benchGateway.ActualGateway = gateway
 	err = gateway.Bootstrap(endpoints.Register)
 	if err != nil {


### PR DESCRIPTION
This prep allows us to get access to the `gateway.Logger`
in follow up PRs where we add a `HTTPClientRequest` class.

r: @uber/zanzibar-team