### PR TITLE
Add ClientHTTPRequest class.

### DIFF
--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -169,6 +169,7 @@ func NewHTTPClientSpec(jsonFile string, clientConfigObj map[string]string, h *Pa
 			err, "Could not build module spec for thrift %s: ", thriftFile,
 		)
 	}
+	mspec.PackageName = mspec.PackageName + "Client"
 
 	baseName := filepath.Base(filepath.Dir(jsonFile))
 

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -179,6 +179,14 @@ func NewTemplate(templatePattern string) (*Template, error) {
 	}, nil
 }
 
+// ClientMeta ...
+type ClientMeta struct {
+	PackageName      string
+	ClientID         string
+	IncludedPackages []string
+	Services         []*ServiceSpec
+}
+
 // GenerateClientFile generates Go http code for services defined in thrift file.
 // It returns the path of generated client file and struct file or an error.
 func (t *Template) GenerateClientFile(
@@ -190,13 +198,18 @@ func (t *Template) GenerateClientFile(
 		return nil, nil
 	}
 
-	m.PackageName = m.PackageName + "Client"
-	err := t.execTemplateAndFmt("http_client.tmpl", c.GoFileName, m)
+	clientMeta := &ClientMeta{
+		PackageName:      m.PackageName,
+		Services:         m.Services,
+		IncludedPackages: m.IncludedPackages,
+		ClientID:         c.ClientID,
+	}
+	err := t.execTemplateAndFmt("http_client.tmpl", c.GoFileName, clientMeta)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not run http_client template")
 	}
 
-	err = t.execTemplateAndFmt("structs.tmpl", c.GoStructsFileName, m)
+	err = t.execTemplateAndFmt("structs.tmpl", c.GoStructsFileName, clientMeta)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not run structs template")
 	}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -17,11 +17,13 @@ import (
 	{{end}}
 )
 
+{{- $clientID := .ClientID -}}
 {{range .Services}}
-{{- $clientName := title .Name | printf "%sClient" -}}
+{{- $clientName := title .Name | printf "%sClient" }}
 // {{$clientName}} is the http client for service {{.Name}}.
 type {{$clientName}} struct {
-	client *zanzibar.HTTPClient
+	ClientID string
+	client   *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service {{.Name}}.
@@ -34,6 +36,7 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{
+		ClientID: "{{$clientID}}",
 		client: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
@@ -48,6 +51,10 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 {{else}}
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
 {{end}} {{- /* <if .ReqeustType ne ""> */ -}}
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "{{.Name}}", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
@@ -57,20 +64,14 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, 
 	{{- end}}
 
 	{{if ne .RequestType ""}}
-	rawBody, err := r.MarshalJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest("{{.HTTPMethod}}", fullURL, bytes.NewReader(rawBody))
+	err := req.WriteJSON("{{.HTTPMethod}}", fullURL, r)
 	{{else}}
-	req, err := http.NewRequest("{{.HTTPMethod}}", fullURL, nil)
+	err := req.WriteJSON("{{.HTTPMethod}}", fullURL, nil)
 	{{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 {{end}} {{- /* <range .Methods> */ -}}
 {{end}} {{- /* <range .Services> */ -}}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -23,7 +23,7 @@ import (
 // {{$clientName}} is the http client for service {{.Name}}.
 type {{$clientName}} struct {
 	ClientID string
-	client   *zanzibar.HTTPClient
+	HTTPClient   *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service {{.Name}}.
@@ -37,7 +37,7 @@ func NewClient(
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{
 		ClientID: "{{$clientID}}",
-		client: zanzibar.NewHTTPClient(gateway, baseURL),
+		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
@@ -52,11 +52,11 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
 {{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "{{.Name}}", c.client,
+		c.ClientID, "{{.Name}}", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL
+	fullURL := c.HTTPClient.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
 	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"
 	{{- else -}}+"/"+string(r.{{$segment.BodyIdentifier | title}})

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -42,10 +42,12 @@ func NewClient(
 
 {{range .Methods}}
 
-{{- if ne .RequestType ""}}
-{{/* template for having request http body */}}
 // {{title .Name}} calls "{{.HTTPPath}}" endpoint.
+{{- if ne .RequestType ""}}
 func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType}}) (*http.Response, error) {
+{{else}}
+func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
+{{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 	// Generate full URL.
 	fullURL := c.client.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
@@ -54,38 +56,21 @@ func (c *{{$clientName}}) {{title .Name}}(ctx context.Context, r *{{.RequestType
 	{{- end -}}
 	{{- end}}
 
+	{{if ne .RequestType ""}}
 	rawBody, err := r.MarshalJSON()
 	if err != nil {
 		return nil, err
 	}
 
 	req, err := http.NewRequest("{{.HTTPMethod}}", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
-}
-
-{{else}} {{/* template for having http body */ -}}
-
-// {{title .Name}} calls "{{.HTTPPath}}" endpoint.
-func (c *{{$clientName}}) {{title .Name}}(ctx context.Context) (*http.Response, error) {
-	// Generate full URL.
-	fullURL := c.client.BaseURL
-	{{- range $k, $segment := .PathSegments -}}
-	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"
-	{{- else -}}+"/"+r.{{$segment.BodyIdentifier}}
-	{{- end -}}
-	{{- end}}
-
+	{{else}}
 	req, err := http.NewRequest("{{.HTTPMethod}}", fullURL, nil)
+	{{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	return c.client.Client.Do(req.WithContext(ctx))
 }
-{{end}} {{- /* <if .ReqeustType ne ""> */ -}}
 {{end}} {{- /* <range .Methods> */ -}}
 {{end}} {{- /* <range .Services> */ -}}

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -4,7 +4,6 @@
 package barClient
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"strconv"
@@ -14,7 +13,8 @@ import (
 
 // BarClient is the http client for service Bar.
 type BarClient struct {
-	client *zanzibar.HTTPClient
+	ClientID string
+	client   *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service Bar.
@@ -27,86 +27,87 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		client: zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID: "bar",
+		client:   zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "argNotStruct", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/arg-not-struct-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "missingArg", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/missing-arg-path"
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "noRequest", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/no-request-path"
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "normal", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/bar-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "tooManyArgs", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/too-many-args-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -13,8 +13,8 @@ import (
 
 // BarClient is the http client for service Bar.
 type BarClient struct {
-	ClientID string
-	client   *zanzibar.HTTPClient
+	ClientID   string
+	HTTPClient *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service Bar.
@@ -27,19 +27,19 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		ClientID: "bar",
-		client:   zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID:   "bar",
+		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argNotStruct", c.client,
+		c.ClientID, "argNotStruct", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/arg-not-struct-path"
+	fullURL := c.HTTPClient.BaseURL + "/arg-not-struct-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
@@ -51,11 +51,11 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "missingArg", c.client,
+		c.ClientID, "missingArg", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/missing-arg-path"
+	fullURL := c.HTTPClient.BaseURL + "/missing-arg-path"
 
 	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
@@ -67,11 +67,11 @@ func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "noRequest", c.client,
+		c.ClientID, "noRequest", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/no-request-path"
+	fullURL := c.HTTPClient.BaseURL + "/no-request-path"
 
 	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
@@ -83,11 +83,11 @@ func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "normal", c.client,
+		c.ClientID, "normal", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/bar-path"
+	fullURL := c.HTTPClient.BaseURL + "/bar-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
@@ -99,11 +99,11 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Res
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "tooManyArgs", c.client,
+		c.ClientID, "tooManyArgs", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/too-many-args-path"
+	fullURL := c.HTTPClient.BaseURL + "/too-many-args-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -4,7 +4,6 @@
 package barClient
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"strconv"
@@ -14,7 +13,8 @@ import (
 
 // BarClient is the http client for service Bar.
 type BarClient struct {
-	client *zanzibar.HTTPClient
+	ClientID string
+	client   *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service Bar.
@@ -27,86 +27,87 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		client: zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID: "bar",
+		client:   zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "argNotStruct", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/arg-not-struct-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "missingArg", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/missing-arg-path"
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "noRequest", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/no-request-path"
 
-	req, err := http.NewRequest("GET", fullURL, nil)
+	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "normal", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/bar-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "tooManyArgs", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/too-many-args-path"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -13,8 +13,8 @@ import (
 
 // BarClient is the http client for service Bar.
 type BarClient struct {
-	ClientID string
-	client   *zanzibar.HTTPClient
+	ClientID   string
+	HTTPClient *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service Bar.
@@ -27,19 +27,19 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{
-		ClientID: "bar",
-		client:   zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID:   "bar",
+		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
 func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argNotStruct", c.client,
+		c.ClientID, "argNotStruct", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/arg-not-struct-path"
+	fullURL := c.HTTPClient.BaseURL + "/arg-not-struct-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
@@ -51,11 +51,11 @@ func (c *BarClient) ArgNotStruct(ctx context.Context, r *ArgNotStructHTTPRequest
 // MissingArg calls "/missing-arg-path" endpoint.
 func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "missingArg", c.client,
+		c.ClientID, "missingArg", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/missing-arg-path"
+	fullURL := c.HTTPClient.BaseURL + "/missing-arg-path"
 
 	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
@@ -67,11 +67,11 @@ func (c *BarClient) MissingArg(ctx context.Context) (*http.Response, error) {
 // NoRequest calls "/no-request-path" endpoint.
 func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "noRequest", c.client,
+		c.ClientID, "noRequest", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/no-request-path"
+	fullURL := c.HTTPClient.BaseURL + "/no-request-path"
 
 	err := req.WriteJSON("GET", fullURL, nil)
 	if err != nil {
@@ -83,11 +83,11 @@ func (c *BarClient) NoRequest(ctx context.Context) (*http.Response, error) {
 // Normal calls "/bar-path" endpoint.
 func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "normal", c.client,
+		c.ClientID, "normal", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/bar-path"
+	fullURL := c.HTTPClient.BaseURL + "/bar-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
@@ -99,11 +99,11 @@ func (c *BarClient) Normal(ctx context.Context, r *NormalHTTPRequest) (*http.Res
 // TooManyArgs calls "/too-many-args-path" endpoint.
 func (c *BarClient) TooManyArgs(ctx context.Context, r *TooManyArgsHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "tooManyArgs", c.client,
+		c.ClientID, "tooManyArgs", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/too-many-args-path"
+	fullURL := c.HTTPClient.BaseURL + "/too-many-args-path"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -14,8 +14,8 @@ import (
 
 // ContactsClient is the http client for service Contacts.
 type ContactsClient struct {
-	ClientID string
-	client   *zanzibar.HTTPClient
+	ClientID   string
+	HTTPClient *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service Contacts.
@@ -28,19 +28,19 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &ContactsClient{
-		ClientID: "contacts",
-		client:   zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID:   "contacts",
+		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // SaveContacts calls "/:userUUID/contacts" endpoint.
 func (c *ContactsClient) SaveContacts(ctx context.Context, r *contacts.SaveContactsRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "saveContacts", c.client,
+		c.ClientID, "saveContacts", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/" + string(r.UserUUID) + "/contacts"
+	fullURL := c.HTTPClient.BaseURL + "/" + string(r.UserUUID) + "/contacts"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -13,8 +13,8 @@ import (
 
 // GoogleNowClient is the http client for service GoogleNow.
 type GoogleNowClient struct {
-	ClientID string
-	client   *zanzibar.HTTPClient
+	ClientID   string
+	HTTPClient *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service GoogleNow.
@@ -27,19 +27,19 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &GoogleNowClient{
-		ClientID: "googlenow",
-		client:   zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID:   "googlenow",
+		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // AddCredentials calls "/add-credentials" endpoint.
 func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsHTTPRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "addCredentials", c.client,
+		c.ClientID, "addCredentials", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/add-credentials"
+	fullURL := c.HTTPClient.BaseURL + "/add-credentials"
 
 	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
@@ -51,11 +51,11 @@ func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsH
 // CheckCredentials calls "/check-credentials" endpoint.
 func (c *GoogleNowClient) CheckCredentials(ctx context.Context) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "checkCredentials", c.client,
+		c.ClientID, "checkCredentials", c.HTTPClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.client.BaseURL + "/check-credentials"
+	fullURL := c.HTTPClient.BaseURL + "/check-credentials"
 
 	err := req.WriteJSON("POST", fullURL, nil)
 	if err != nil {

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -4,7 +4,6 @@
 package googlenowClient
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"strconv"
@@ -14,7 +13,8 @@ import (
 
 // GoogleNowClient is the http client for service GoogleNow.
 type GoogleNowClient struct {
-	client *zanzibar.HTTPClient
+	ClientID string
+	client   *zanzibar.HTTPClient
 }
 
 // NewClient returns a new http client for service GoogleNow.
@@ -27,37 +27,39 @@ func NewClient(
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &GoogleNowClient{
-		client: zanzibar.NewHTTPClient(gateway, baseURL),
+		ClientID: "googlenow",
+		client:   zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
 // AddCredentials calls "/add-credentials" endpoint.
 func (c *GoogleNowClient) AddCredentials(ctx context.Context, r *AddCredentialsHTTPRequest) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "addCredentials", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/add-credentials"
 
-	rawBody, err := r.MarshalJSON()
+	err := req.WriteJSON("POST", fullURL, r)
 	if err != nil {
 		return nil, err
 	}
-
-	req, err := http.NewRequest("POST", fullURL, bytes.NewReader(rawBody))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }
 
 // CheckCredentials calls "/check-credentials" endpoint.
 func (c *GoogleNowClient) CheckCredentials(ctx context.Context) (*http.Response, error) {
+	req := zanzibar.NewClientHTTPRequest(
+		c.ClientID, "checkCredentials", c.client,
+	)
+
 	// Generate full URL.
 	fullURL := c.client.BaseURL + "/check-credentials"
 
-	req, err := http.NewRequest("POST", fullURL, nil)
+	err := req.WriteJSON("POST", fullURL, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	return c.client.Client.Do(req.WithContext(ctx))
+	return req.Do(ctx)
 }

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/uber-go/zap"
+)
+
+// ClientHTTPRequest is the struct for making outbound
+// requests using a client.
+type ClientHTTPRequest struct {
+	started     bool
+	startTime   time.Time
+	client      *HTTPClient
+	httpRequest *http.Request
+
+	ClientName string
+	MethodName string
+	Logger     zap.Logger
+}
+
+// NewClientHTTPRequest allocates a ClientHTTPRequest
+func NewClientHTTPRequest(
+	clientName string, methodName string,
+	client *HTTPClient,
+) *ClientHTTPRequest {
+	req := &ClientHTTPRequest{
+		Logger: client.Logger,
+		client: client,
+	}
+
+	req.start(clientName, methodName)
+	return req
+}
+
+// Start the request, do some metrics book keeping
+func (req *ClientHTTPRequest) start(
+	clientName string, methodName string,
+) {
+	if req.started {
+		/* coverage ignore next line */
+		req.Logger.Error(
+			"Cannot start ClientHTTPRequest twice",
+			zap.String("methodName", methodName),
+			zap.String("clientName", clientName),
+		)
+		/* coverage ignore next line */
+		return
+	}
+
+	req.ClientName = clientName
+	req.MethodName = methodName
+
+	req.started = true
+	req.startTime = time.Now()
+}
+
+// WriteJSON will send a json http request out.
+func (req *ClientHTTPRequest) WriteJSON(
+	method string, url string, body json.Marshaler,
+) error {
+	var httpReq *http.Request
+	var httpErr error
+	if body != nil {
+		rawBody, err := body.MarshalJSON()
+		if err != nil {
+			req.Logger.Error("Could not serialize client json request",
+				zap.String("error", err.Error()),
+			)
+			return errors.Wrapf(err,
+				"Could not serialize json for client: %s", req.ClientName,
+			)
+		}
+
+		httpReq, httpErr = http.NewRequest(
+			method, url, bytes.NewReader(rawBody),
+		)
+	} else {
+		httpReq, httpErr = http.NewRequest(method, url, nil)
+	}
+
+	if httpErr != nil {
+		req.Logger.Error("Could not make outbound request",
+			zap.String("error", httpErr.Error()),
+		)
+		return errors.Wrapf(httpErr,
+			"Could not make outbound request for client: %s",
+			req.ClientName,
+		)
+	}
+	req.httpRequest = httpReq
+	req.httpRequest.Header.Set("Content-Type", "application/json")
+	return nil
+}
+
+// Do will send the request out.
+func (req *ClientHTTPRequest) Do(
+	ctx context.Context,
+) (*http.Response, error) {
+	return req.client.Client.Do(req.httpRequest.WithContext(ctx))
+}

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
+	"github.com/uber/zanzibar/test/lib/bench_gateway"
+)
+
+func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	bgateway := gateway.(*benchGateway.BenchGateway)
+	client := zanzibar.NewHTTPClient(bgateway.ActualGateway, "/")
+	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)
+
+	err = req.WriteJSON("GET", "/foo", &failingJsonObj{})
+	assert.NotNil(t, err)
+
+	assert.Equal(t,
+		"Could not serialize json for client: clientID: cannot serialize",
+		err.Error(),
+	)
+}
+
+func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	bgateway := gateway.(*benchGateway.BenchGateway)
+	client := zanzibar.NewHTTPClient(bgateway.ActualGateway, "/")
+	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)
+
+	err = req.WriteJSON("@INVALIDMETHOD", "/foo", nil)
+	assert.NotNil(t, err)
+
+	assert.Equal(t,
+		"Could not make outbound request for client: "+
+			"clientID: net/http: invalid method \"@INVALIDMETHOD\"",
+		err.Error(),
+	)
+}

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -19,34 +19,3 @@
 // THE SOFTWARE.
 
 package zanzibar
-
-import "net/http"
-import "github.com/uber-go/zap"
-
-// HTTPClient defines a http client.
-type HTTPClient struct {
-	gateway *Gateway
-
-	Client  *http.Client
-	Logger  zap.Logger
-	BaseURL string
-}
-
-// NewHTTPClient will allocate a http client.
-func NewHTTPClient(
-	gateway *Gateway, baseURL string,
-) *HTTPClient {
-	return &HTTPClient{
-		gateway: gateway,
-
-		Logger: gateway.Logger,
-		Client: &http.Client{
-			Transport: &http.Transport{
-				DisableKeepAlives:   false,
-				MaxIdleConns:        500,
-				MaxIdleConnsPerHost: 500,
-			},
-		},
-		BaseURL: baseURL,
-	}
-}


### PR DESCRIPTION
This PR is refactoring the client so that it becomes transport
agnostic. As a first step we are adding a ClientHTTPRequest
class that can managed the sending component.

As a follow PR we will add a ClientHTTPResponse class that
can parse the response and the body.

In the future, the client API will no longer return a 
*http.Response but just return the struct itself.

r: @uber/zanzibar-team