### PR TITLE
Add logger, endpoint and handler name to response to use in middlewares

### DIFF
--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -43,7 +43,11 @@ type ServerHTTPResponse struct {
 	pendingBodyObj    interface{}
 	pendingStatusCode int
 
-	StatusCode int
+	Logger zap.Logger
+
+	StatusCode   int
+	EndpointName string
+	HandlerName  string
 }
 
 // NewServerHTTPResponse is helper function to alloc ServerHTTPResponse
@@ -56,6 +60,11 @@ func NewServerHTTPResponse(
 		responseWriter: w,
 		StatusCode:     200,
 		metrics:        req.metrics,
+
+		Logger: req.Logger,
+
+		EndpointName: req.EndpointName,
+		HandlerName:  req.HandlerName,
 	}
 
 	return res

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -33,7 +33,7 @@ import (
 // ServerHTTPResponse struct manages request
 type ServerHTTPResponse struct {
 	responseWriter    http.ResponseWriter
-	req               *ServerHTTPRequest
+	Request           *ServerHTTPRequest
 	gateway           *Gateway
 	finishTime        time.Time
 	finished          bool
@@ -43,11 +43,7 @@ type ServerHTTPResponse struct {
 	pendingBodyObj    interface{}
 	pendingStatusCode int
 
-	Logger zap.Logger
-
-	StatusCode   int
-	EndpointName string
-	HandlerName  string
+	StatusCode int
 }
 
 // NewServerHTTPResponse is helper function to alloc ServerHTTPResponse
@@ -56,15 +52,10 @@ func NewServerHTTPResponse(
 ) *ServerHTTPResponse {
 	res := &ServerHTTPResponse{
 		gateway:        req.gateway,
-		req:            req,
+		Request:        req,
 		responseWriter: w,
 		StatusCode:     200,
 		metrics:        req.metrics,
-
-		Logger: req.Logger,
-
-		EndpointName: req.EndpointName,
-		HandlerName:  req.HandlerName,
 	}
 
 	return res
@@ -72,20 +63,20 @@ func NewServerHTTPResponse(
 
 // finish will handle final logic, like metrics
 func (res *ServerHTTPResponse) finish() {
-	if !res.req.started {
+	if !res.Request.started {
 		/* coverage ignore next line */
-		res.req.Logger.Error(
+		res.Request.Logger.Error(
 			"Forgot to start server response",
-			zap.String("path", res.req.URL.Path),
+			zap.String("path", res.Request.URL.Path),
 		)
 		/* coverage ignore next line */
 		return
 	}
 	if res.finished {
 		/* coverage ignore next line */
-		res.req.Logger.Error(
+		res.Request.Logger.Error(
 			"Finished an server response twice",
-			zap.String("path", res.req.URL.Path),
+			zap.String("path", res.Request.URL.Path),
 		)
 		/* coverage ignore next line */
 		return
@@ -96,7 +87,7 @@ func (res *ServerHTTPResponse) finish() {
 
 	counter := res.metrics.statusCodes[res.StatusCode]
 	if counter == nil {
-		res.req.Logger.Error(
+		res.Request.Logger.Error(
 			"Could not emit statusCode metric",
 			zap.Int("UnexpectedStatusCode", res.StatusCode),
 		)
@@ -105,7 +96,7 @@ func (res *ServerHTTPResponse) finish() {
 	}
 
 	res.metrics.requestLatency.Record(
-		res.finishTime.Sub(res.req.startTime),
+		res.finishTime.Sub(res.Request.startTime),
 	)
 }
 
@@ -118,10 +109,10 @@ func (res *ServerHTTPResponse) SendError(statusCode int, err error) {
 func (res *ServerHTTPResponse) SendErrorString(
 	statusCode int, err string,
 ) {
-	res.req.Logger.Warn(
+	res.Request.Logger.Warn(
 		"Sending error for endpoint request",
 		zap.String("error", err),
-		zap.String("path", res.req.URL.Path),
+		zap.String("path", res.Request.URL.Path),
 	)
 
 	res.WriteJSONBytes(statusCode,
@@ -147,14 +138,14 @@ func (res *ServerHTTPResponse) WriteJSON(
 ) {
 	if body == nil {
 		res.SendErrorString(500, "Could not serialize json response")
-		res.req.Logger.Error("Could not serialize nil pointer body")
+		res.Request.Logger.Error("Could not serialize nil pointer body")
 		return
 	}
 
 	bytes, err := body.MarshalJSON()
 	if err != nil {
 		res.SendErrorString(500, "Could not serialize json response")
-		res.req.Logger.Error("Could not serialize json response",
+		res.Request.Logger.Error("Could not serialize json response",
 			zap.String("error", err.Error()),
 		)
 		return
@@ -192,9 +183,9 @@ func (res *ServerHTTPResponse) PeekBody(
 func (res *ServerHTTPResponse) flush() {
 	if res.flushed {
 		/* coverage ignore next line */
-		res.req.Logger.Error(
+		res.Request.Logger.Error(
 			"Flushed a server response twice",
-			zap.String("path", res.req.URL.Path),
+			zap.String("path", res.Request.URL.Path),
 		)
 		/* coverage ignore next line */
 		return
@@ -216,7 +207,7 @@ func (res *ServerHTTPResponse) writeBytes(bytes []byte) {
 	_, err := res.responseWriter.Write(bytes)
 	if err != nil {
 		/* coverage ignore next line */
-		res.req.Logger.Error("Could not write string to resp body",
+		res.Request.Logger.Error("Could not write string to resp body",
 			zap.String("error", err.Error()),
 		)
 	}


### PR DESCRIPTION
Add logger, endpoint and handler name to response so that these can use used in the 

`	HandleResponse(
		ctx context.Context,
		res *ServerHTTPResponse,
		shared SharedState,
	)`

methods.