### PR TITLE
Change benchGateway.CreateGateway to accept endpoint and clients funcs

### DIFF
--- a/codegen/templates/init_clients.tmpl
+++ b/codegen/templates/init_clients.tmpl
@@ -23,7 +23,7 @@ type Clients struct {
 func CreateClients(
 	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
-) *Clients {
+) interface{} {
 	return &Clients{
 		{{range $idx, $cinfo := .ClientInfo -}}
 		{{$cinfo.FieldName}}: {{$cinfo.PackageName}}.NewClient(

--- a/examples/example-gateway/build/clients/clients.go
+++ b/examples/example-gateway/build/clients/clients.go
@@ -23,7 +23,7 @@ type Clients struct {
 func CreateClients(
 	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
-) *Clients {
+) interface{} {
 	return &Clients{
 		Bar: barClient.NewClient(
 			config, gateway,

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -26,10 +26,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
+
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 )
 
 func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -48,7 +56,12 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 }
 
 func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -27,11 +27,11 @@ import (
 
 	jsonschema "github.com/mcuadros/go-jsonschema-generator"
 	"github.com/stretchr/testify/assert"
-	// TODO(sindelar): Refactor into a unit test and remove the
-	// example middleware (which creates a cyclic dependency)
 	"github.com/uber/zanzibar/examples/example-gateway/middlewares/example"
 	"github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader"
 
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 )
@@ -57,7 +57,12 @@ func TestHandlers(t *testing.T) {
 	// TODO(sindelar): Refactor. We some helpers to build zanzibar
 	// request/responses without setting up a backend and register.
 	// Currently they require endpoints to instantiate.
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -138,7 +143,12 @@ func TestMiddlewareRequestAbort(t *testing.T) {
 	middlewares := middlewareStack.Middlewares()
 	assert.Equal(t, 3, len(middlewares))
 
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -187,7 +197,12 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 	middlewares := middlewareStack.Middlewares()
 	assert.Equal(t, 3, len(middlewares))
 
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -244,7 +259,12 @@ func TestMiddlewareSharedStates(t *testing.T) {
 	// TODO(sindelar): Refactor. We some helpers to build zanzibar
 	// request/responses without setting up a backend and register.
 	// Currently they require endpoints to instantiate.
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -27,12 +27,19 @@ import (
 	"io/ioutil"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 )
 
 func TestTrailingSlashRoutes(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -96,7 +103,12 @@ func TestTrailingSlashRoutes(t *testing.T) {
 }
 
 func TestRouterNotFound(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -118,7 +130,12 @@ func TestRouterNotFound(t *testing.T) {
 }
 
 func TestRouterInvalidMethod(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -29,12 +29,19 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 )
 
 func TestInvalidStatusCode(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -88,7 +95,13 @@ func TestInvalidStatusCode(t *testing.T) {
 }
 
 func TestCallingWriteJSONWithNil(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
+
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -142,7 +155,12 @@ func (f failingJsonObj) MarshalJSON() ([]byte, error) {
 }
 
 func TestCallWriteJSONWithBadJSON(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -210,7 +228,13 @@ type MyBody struct {
 }
 
 func TestResponsePeekBody(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
+
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -265,7 +289,13 @@ func TestResponsePeekBody(t *testing.T) {
 }
 
 func TestResponsePeekBodyError(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
+
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/tchannel_server_test.go
+++ b/runtime/tchannel_server_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 )
 
@@ -33,6 +35,8 @@ func TestCreatingTChannel(t *testing.T) {
 			"tchannel.serviceName": "",
 		},
 		nil,
+		clients.CreateClients,
+		endpoints.Register,
 	)
 	assert.Error(t, err)
 

--- a/test/endpoints/contacts/save-contacts_test.go
+++ b/test/endpoints/contacts/save-contacts_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	"github.com/uber/zanzibar/examples/example-gateway/endpoints/contacts"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
@@ -37,9 +39,14 @@ import (
 var benchBytes = []byte("{\"contacts\":[{\"fragments\":[{\"type\":\"message\",\"text\":\"foobarbaz\"}],\"attributes\":{\"firstName\":\"steve\",\"lastName\":\"stevenson\",\"hasPhoto\":true,\"numFields\":10,\"timesContacted\":5,\"lastTimeContacted\":0,\"isStarred\":false,\"hasCustomRingtone\":false,\"isSendToVoicemail\":false,\"hasThumbnail\":false,\"namePrefix\":\"\",\"nameSuffix\":\"\"}},{\"fragments\":[{\"type\":\"message\",\"text\":\"foobarbaz\"}],\"attributes\":{\"firstName\":\"steve\",\"lastName\":\"stevenson\",\"hasPhoto\":true,\"numFields\":10,\"timesContacted\":5,\"lastTimeContacted\":0,\"isStarred\":false,\"hasCustomRingtone\":false,\"isSendToVoicemail\":false,\"hasThumbnail\":false,\"namePrefix\":\"\",\"nameSuffix\":\"\"}},{\"fragments\":[],\"attributes\":{\"firstName\":\"steve\",\"lastName\":\"stevenson\",\"hasPhoto\":true,\"numFields\":10,\"timesContacted\":5,\"lastTimeContacted\":0,\"isStarred\":false,\"hasCustomRingtone\":false,\"isSendToVoicemail\":false,\"hasThumbnail\":false,\"namePrefix\":\"\",\"nameSuffix\":\"\"}},{\"fragments\":[],\"attributes\":{\"firstName\":\"steve\",\"lastName\":\"stevenson\",\"hasPhoto\":true,\"numFields\":10,\"timesContacted\":5,\"lastTimeContacted\":0,\"isStarred\":false,\"hasCustomRingtone\":false,\"isSendToVoicemail\":false,\"hasThumbnail\":false,\"namePrefix\":\"\",\"nameSuffix\":\"\"}}],\"appType\":\"MY_APP\"}")
 
 func BenchmarkSaveContacts(b *testing.B) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"contacts"},
-	})
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		&testGateway.Options{
+			KnownHTTPBackends: []string{"contacts"},
+		},
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if err != nil {
 		b.Error("got bootstrap err: " + err.Error())
 		return

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -30,6 +30,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
+
 	"encoding/json"
 
 	"github.com/pkg/errors"
@@ -46,9 +49,14 @@ var headers map[string]string = map[string]string{
 }
 
 func BenchmarkGoogleNowAddCredentials(b *testing.B) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"googleNow"},
-	})
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		&testGateway.Options{
+			KnownHTTPBackends: []string{"googleNow"},
+		},
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if err != nil {
 		b.Error("got bootstrap err: " + err.Error())
 		return

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -31,6 +31,9 @@ import (
 	m3 "github.com/uber-go/tally/m3/thrift"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
+
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 )
 
 var testBinary = filepath.Join(
@@ -63,7 +66,13 @@ func TestHealthCall(t *testing.T) {
 }
 
 func BenchmarkHealthCall(b *testing.B) {
-	gateway, err := benchGateway.CreateGateway(nil, nil)
+	gateway, err := benchGateway.CreateGateway(
+		nil,
+		nil,
+		clients.CreateClients,
+		endpoints.Register,
+	)
+
 	if err != nil {
 		b.Error("got bootstrap err: " + err.Error())
 		return

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -60,21 +60,6 @@ func getZanzibarDirName() string {
 	return filepath.Join(getDirName(), "..", "..", "..")
 }
 
-type clientsInterface interface {
-	CreateClients(
-		config *zanzibar.StaticConfig,
-		gateway *zanzibar.Gateway,
-	) *Clients
-}
-
-// Clients interface is a placeholder for the generated clients
-type Clients interface {
-}
-
-type endpointsInterface interface {
-	Register(g *zanzibar.Gateway, router *zanzibar.Router)
-}
-
 // CreateGateway bootstrap gateway for testing
 func CreateGateway(
 	seedConfig map[string]interface{},


### PR DESCRIPTION
Change benchGateway.CreateGateway to accept endpoint and clients funcs. This allows us to decouple the benchGateway used in testing from the example gateway's generated clients and endpoints/register files. Now new gateway repos (ie edge gateway) can use the benchmarkGateway for testing without pulling in the example gateway as a dependency.