### PR TITLE
Improve import statements in generate code.

### DIFF
--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -524,6 +524,7 @@ func (e *EndpointSpec) EndpointTestConfigPath() string {
 // SetDownstream configures the downstream client for this endpoint spec
 func (e *EndpointSpec) SetDownstream(
 	gatewaySpec *GatewaySpec,
+	h *PackageHelper,
 ) error {
 	if e.WorkflowType == "custom" {
 		return nil
@@ -547,7 +548,7 @@ func (e *EndpointSpec) SetDownstream(
 
 	return e.ModuleSpec.SetDownstream(
 		e.ThriftServiceName, e.ThriftMethodName,
-		clientSpec, e.ClientName, e.ClientMethod,
+		clientSpec, e.ClientName, e.ClientMethod, h,
 	)
 }
 
@@ -775,7 +776,7 @@ func NewGatewaySpec(
 			)
 		}
 
-		err = espec.SetDownstream(spec)
+		err = espec.SetDownstream(spec, packageHelper)
 		if err != nil {
 			return nil, errors.Wrapf(
 				err, "Cannot parse downstream info for endpoint : %s", json,

--- a/codegen/method.go
+++ b/codegen/method.go
@@ -304,6 +304,7 @@ func (ms *MethodSpec) setDownstream(
 func (ms *MethodSpec) setRequestFieldMap(
 	funcSpec *compile.FunctionSpec,
 	downstreamSpec *compile.FunctionSpec,
+	h *PackageHelper,
 ) error {
 	// TODO(sindelar): Iterate over fields that are structs (for foo/bar examples).
 	ms.RequestFieldMap = map[string]string{}
@@ -338,9 +339,12 @@ func (ms *MethodSpec) setRequestFieldMap(
 			*compile.I64Spec, *compile.DoubleSpec, *compile.StringSpec:
 			ms.RequestTypeMap[field.Name] = field.Type.ThriftName()
 		default:
-			thriftPkgNameParts := strings.Split(field.Type.ThriftFile(), "/")
-			thriftPkgName := thriftPkgNameParts[len(thriftPkgNameParts)-2]
-			ms.RequestTypeMap[field.Name] = "(*clientType" + strings.Title(thriftPkgName) + "." + field.Type.ThriftName() + ")"
+			pkgName, err := h.TypePackageName(downstreamField.Type.ThriftFile())
+			if err != nil {
+				return err
+			}
+			ms.RequestTypeMap[field.Name] =
+				"(*" + pkgName + "." + field.Type.ThriftName() + ")"
 		}
 	}
 	return nil

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -162,8 +162,8 @@ func (p PackageHelper) TypePackageName(thrift string) (string, error) {
 	// Strip the leading / and strip the .thrift on the end.
 	thriftSegment := thrift[idx+len(root)+1 : len(thrift)-7]
 
-	thriftPackageName := strings.Replace(thriftSegment, "/", "_", 100)
-	return thriftPackageName, nil
+	thriftPackageName := strings.Replace(thriftSegment, "/", "_", -1)
+	return camelCase(thriftPackageName), nil
 }
 
 func (p PackageHelper) getRelativeFileName(thrift string) (string, error) {

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -159,6 +159,7 @@ func (p PackageHelper) TypePackageName(thrift string) (string, error) {
 		)
 	}
 
+	// Strip the leading / and strip the .thrift on the end.
 	thriftSegment := thrift[idx+len(root)+1 : len(thrift)-7]
 
 	thriftPackageName := strings.Replace(thriftSegment, "/", "_", 100)

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -149,8 +149,20 @@ func (p PackageHelper) TypePackageName(thrift string) (string, error) {
 	if !strings.HasSuffix(thrift, ".thrift") {
 		return "", errors.Errorf("file %s is not .thrift", thrift)
 	}
-	file := path.Base(thrift)
-	return file[:len(file)-7], nil
+	root := path.Clean(p.gatewayThriftRootDir)
+
+	idx := strings.Index(thrift, root)
+	if idx == -1 {
+		return "", errors.Errorf(
+			"file %s is not in thrift dir (%s)",
+			thrift, p.gatewayThriftRootDir,
+		)
+	}
+
+	thriftSegment := thrift[idx+len(root)+1 : len(thrift)-7]
+
+	thriftPackageName := strings.Replace(thriftSegment, "/", "_", 100)
+	return thriftPackageName, nil
 }
 
 func (p PackageHelper) getRelativeFileName(thrift string) (string, error) {

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -69,7 +69,7 @@ func TestTypePackageName(t *testing.T) {
 	h := newPackageHelper(t)
 	packageName, err := h.TypePackageName(fooThrift)
 	assert.Nil(t, err, "should not return error")
-	assert.Equal(t, "clients_foo_foo", packageName, "wrong package name")
+	assert.Equal(t, "clientsFooFoo", packageName, "wrong package name")
 	_, err = h.TypeImportPath("/Users/xxx/go/src/github.com/uber/zanzibar/examples/example-gateway/build/idl/github.com/uber/zanzibar/clients/foo/foo.txt")
 	assert.Error(t, err, "should return error for not a thrift file")
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -69,7 +69,7 @@ func TestTypePackageName(t *testing.T) {
 	h := newPackageHelper(t)
 	packageName, err := h.TypePackageName(fooThrift)
 	assert.Nil(t, err, "should not return error")
-	assert.Equal(t, "foo", packageName, "wrong package name")
+	assert.Equal(t, "clients_foo_foo", packageName, "wrong package name")
 	_, err = h.TypeImportPath("/Users/xxx/go/src/github.com/uber/zanzibar/examples/example-gateway/build/idl/github.com/uber/zanzibar/clients/foo/foo.txt")
 	assert.Error(t, err, "should return error for not a thrift file")
 }

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -97,7 +97,6 @@ func (ms *ModuleSpec) AddImports(module *compile.Module, packageHelper *PackageH
 		return errors.Wrapf(err, "can't add import %s", ms.ThriftFile)
 	}
 
-	// sort.Strings(ms.IncludedPackages)
 	return nil
 }
 

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -38,8 +38,14 @@ type ModuleSpec struct {
 	// Go client types file path, generated from thrift file.
 	GoThriftTypesFilePath string
 	// Generated imports
-	IncludedPackages []string
+	IncludedPackages []GoPackageImport
 	Services         []*ServiceSpec
+}
+
+// GoPackageImport ...
+type GoPackageImport struct {
+	PackageName string
+	AliasName   string
 }
 
 // ServiceSpec specifies a service.
@@ -91,7 +97,7 @@ func (ms *ModuleSpec) AddImports(module *compile.Module, packageHelper *PackageH
 		return errors.Wrapf(err, "can't add import %s", ms.ThriftFile)
 	}
 
-	sort.Strings(ms.IncludedPackages)
+	// sort.Strings(ms.IncludedPackages)
 	return nil
 }
 
@@ -138,6 +144,7 @@ func NewServiceSpec(spec *compile.ServiceSpec, packageHelper *PackageHelper) (*S
 func (ms *ModuleSpec) SetDownstream(
 	serviceName string, methodName string,
 	clientSpec *ClientSpec, clientService string, clientMethod string,
+	h *PackageHelper,
 ) error {
 	var service *ServiceSpec
 	for _, v := range ms.Services {
@@ -190,7 +197,7 @@ func (ms *ModuleSpec) SetDownstream(
 		downstreamSpec := downstreamMethod.CompiledThriftSpec
 		funcSpec := method.CompiledThriftSpec
 
-		err := method.setRequestFieldMap(funcSpec, downstreamSpec)
+		err := method.setRequestFieldMap(funcSpec, downstreamSpec, h)
 		if err != nil {
 			return err
 		}
@@ -198,8 +205,12 @@ func (ms *ModuleSpec) SetDownstream(
 
 	// Adds imports for downstream services.
 	if !ms.isPackageIncluded(clientSpec.GoPackageName) {
+
 		ms.IncludedPackages = append(
-			ms.IncludedPackages, clientSpec.GoPackageName,
+			ms.IncludedPackages, GoPackageImport{
+				PackageName: clientSpec.GoPackageName,
+				AliasName:   "",
+			},
 		)
 	}
 
@@ -214,7 +225,10 @@ func (ms *ModuleSpec) SetDownstream(
 				}
 
 				ms.IncludedPackages = append(
-					ms.IncludedPackages, method.Downstream.GoThriftTypesFilePath,
+					ms.IncludedPackages, GoPackageImport{
+						PackageName: method.Downstream.GoThriftTypesFilePath,
+						AliasName:   "",
+					},
 				)
 			}
 		}
@@ -267,15 +281,25 @@ func (ms *ModuleSpec) addTypeImport(thriftPath string, packageHelper *PackageHel
 	if err != nil {
 		return err
 	}
+	aliasName, err := packageHelper.TypePackageName(thriftPath)
+	if err != nil {
+		return err
+	}
+
 	if !ms.isPackageIncluded(newPkg) {
-		ms.IncludedPackages = append(ms.IncludedPackages, newPkg)
+		ms.IncludedPackages = append(
+			ms.IncludedPackages, GoPackageImport{
+				PackageName: newPkg,
+				AliasName:   aliasName,
+			},
+		)
 	}
 	return nil
 }
 
 func (ms *ModuleSpec) isPackageIncluded(pkg string) bool {
 	for _, includedPkg := range ms.IncludedPackages {
-		if pkg == includedPkg {
+		if pkg == includedPkg.PackageName {
 			return true
 		}
 	}

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -15,12 +15,12 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 
 	{{range $idx, $pkg := .Method.Downstream.IncludedPackages -}}
-	{{$file := basePath $pkg -}}
-	clientType{{ title $file }} "{{$pkg}}"
+	{{$file := basePath $pkg.PackageName -}}
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 )
 

--- a/codegen/templates/endpoint_register.tmpl
+++ b/codegen/templates/endpoint_register.tmpl
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 
 	"github.com/uber/zanzibar/runtime"

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -13,7 +13,7 @@ import (
 
 	"github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 )
 

--- a/codegen/templates/init_clients.tmpl
+++ b/codegen/templates/init_clients.tmpl
@@ -6,7 +6,7 @@ package clients
 
 import (
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 	"github.com/uber/zanzibar/runtime"
 

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -12,7 +12,7 @@ import (
 	"github.com/uber-go/zap"
     "github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 )
 

--- a/codegen/templates/main_test.tmpl
+++ b/codegen/templates/main_test.tmpl
@@ -16,7 +16,7 @@ import (
 	"github.com/uber-go/zap"
 	"github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 )
 

--- a/codegen/templates/structs.tmpl
+++ b/codegen/templates/structs.tmpl
@@ -11,7 +11,7 @@ import (
 
 	"github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
-	"{{$pkg}}"
+	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}
 )
 

--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -6,11 +6,11 @@
 	"IncludedPackages": [
 		{
 			"PackageName": "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo",
-			"AliasName": "endpoints_foo_foo"
+			"AliasName": "endpointsFooFoo"
 		},
 		{
 			"PackageName": "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar",
-			"AliasName": "endpoints_bar_bar"
+			"AliasName": "endpointsBarBar"
 		}
 	],
 	"Services": [
@@ -82,7 +82,7 @@
 					],
 					"Headers": null,
 					"RequestType": "",
-					"ResponseType": "endpoints_bar_bar.BarResponse",
+					"ResponseType": "endpointsBarBar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -121,7 +121,7 @@
 					],
 					"Headers": null,
 					"RequestType": "",
-					"ResponseType": "endpoints_bar_bar.BarResponse",
+					"ResponseType": "endpointsBarBar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -160,7 +160,7 @@
 					],
 					"Headers": null,
 					"RequestType": "NormalHTTPRequest",
-					"ResponseType": "endpoints_bar_bar.BarResponse",
+					"ResponseType": "endpointsBarBar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -174,7 +174,7 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "*endpoints_bar_bar.BarRequest",
+							"Type": "*endpointsBarBar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						}
@@ -208,7 +208,7 @@
 						"x-token"
 					],
 					"RequestType": "TooManyArgsHTTPRequest",
-					"ResponseType": "endpoints_bar_bar.BarResponse",
+					"ResponseType": "endpointsBarBar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -222,12 +222,12 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "*endpoints_bar_bar.BarRequest",
+							"Type": "*endpointsBarBar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						},
 						{
-							"Type": "*endpoints_foo_foo.FooStruct",
+							"Type": "*endpointsFooFoo.FooStruct",
 							"Name": "foo",
 							"Annotations": null
 						}

--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -4,8 +4,14 @@
 	"PackageName": "bar",
 	"GoThriftTypesFilePath": "",
 	"IncludedPackages": [
-		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar",
-		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
+		{
+			"PackageName": "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo",
+			"AliasName": "endpoints_foo_foo"
+		},
+		{
+			"PackageName": "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar",
+			"AliasName": "endpoints_bar_bar"
+		}
 	],
 	"Services": [
 		{
@@ -76,7 +82,7 @@
 					],
 					"Headers": null,
 					"RequestType": "",
-					"ResponseType": "bar.BarResponse",
+					"ResponseType": "endpoints_bar_bar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -115,7 +121,7 @@
 					],
 					"Headers": null,
 					"RequestType": "",
-					"ResponseType": "bar.BarResponse",
+					"ResponseType": "endpoints_bar_bar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -154,7 +160,7 @@
 					],
 					"Headers": null,
 					"RequestType": "NormalHTTPRequest",
-					"ResponseType": "bar.BarResponse",
+					"ResponseType": "endpoints_bar_bar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -168,7 +174,7 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "*bar.BarRequest",
+							"Type": "*endpoints_bar_bar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						}
@@ -202,7 +208,7 @@
 						"x-token"
 					],
 					"RequestType": "TooManyArgsHTTPRequest",
-					"ResponseType": "bar.BarResponse",
+					"ResponseType": "endpoints_bar_bar.BarResponse",
 					"OKStatusCode": {
 						"Code": 200,
 						"Message": ""
@@ -216,12 +222,12 @@
 					"RequestBoxed": false,
 					"RequestStruct": [
 						{
-							"Type": "*bar.BarRequest",
+							"Type": "*endpoints_bar_bar.BarRequest",
 							"Name": "request",
 							"Annotations": null
 						},
 						{
-							"Type": "*foo.FooStruct",
+							"Type": "*endpoints_foo_foo.FooStruct",
 							"Name": "foo",
 							"Annotations": null
 						}

--- a/codegen/test_data/clients/bar_structs.gogen
+++ b/codegen/test_data/clients/bar_structs.gogen
@@ -6,8 +6,8 @@ package barClient
 import (
 	"runtime"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *clients_bar_bar.BarRequest
+	Request *clientsBarBar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *clients_bar_bar.BarRequest
-	Foo     *clients_foo_foo.FooStruct
+	Request *clientsBarBar.BarRequest
+	Foo     *clientsFooFoo.FooStruct
 }

--- a/codegen/test_data/clients/bar_structs.gogen
+++ b/codegen/test_data/clients/bar_structs.gogen
@@ -6,8 +6,8 @@ package barClient
 import (
 	"runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *bar.BarRequest
+	Request *clients_bar_bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *bar.BarRequest
-	Foo     *foo.FooStruct
+	Request *clients_bar_bar.BarRequest
+	Foo     *clients_foo_foo.FooStruct
 }

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -12,7 +12,9 @@ import (
 	"github.com/uber/zanzibar/.tmp_gen/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleMissingArgRequest handles "/bar/missing-arg-path".
@@ -51,7 +53,7 @@ func HandleMissingArgRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -60,8 +62,8 @@ func HandleMissingArgRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertMissingArgClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertMissingArgClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -12,9 +12,9 @@ import (
 	"github.com/uber/zanzibar/.tmp_gen/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleMissingArgRequest handles "/bar/missing-arg-path".
@@ -53,7 +53,7 @@ func HandleMissingArgRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -62,8 +62,8 @@ func HandleMissingArgRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertMissingArgClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertMissingArgClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -12,7 +12,9 @@ import (
 	"github.com/uber/zanzibar/.tmp_gen/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNoRequestRequest handles "/bar/no-request-path".
@@ -51,7 +53,7 @@ func HandleNoRequestRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -60,8 +62,8 @@ func HandleNoRequestRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertNoRequestClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertNoRequestClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -12,9 +12,9 @@ import (
 	"github.com/uber/zanzibar/.tmp_gen/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNoRequestRequest handles "/bar/no-request-path".
@@ -53,7 +53,7 @@ func HandleNoRequestRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -62,8 +62,8 @@ func HandleNoRequestRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertNoRequestClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertNoRequestClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -13,9 +13,9 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/.tmp_gen/clients/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clientTypeBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNormalRequest handles "/bar/bar-path".
@@ -59,7 +59,7 @@ func HandleNormalRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -71,12 +71,12 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
+	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertNormalClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertNormalClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -13,9 +13,9 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/.tmp_gen/clients/bar"
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNormalRequest handles "/bar/bar-path".
@@ -59,7 +59,7 @@ func HandleNormalRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -71,12 +71,12 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
+	clientRequest.Request = (*clientsBarBar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertNormalClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertNormalClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -13,10 +13,10 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/.tmp_gen/clients/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clientTypeBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clientTypeFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 )
 
 // HandleTooManyArgsRequest handles "/bar/too-many-args-path".
@@ -63,7 +63,7 @@ func HandleTooManyArgsRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -75,13 +75,13 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = (*clientTypeFoo.FooStruct)(body.Foo)
-	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
+	clientRequest.Foo = (*clients_foo_foo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertTooManyArgsClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertTooManyArgsClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -13,10 +13,10 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/.tmp_gen/clients/bar"
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 )
 
 // HandleTooManyArgsRequest handles "/bar/too-many-args-path".
@@ -63,7 +63,7 @@ func HandleTooManyArgsRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -75,13 +75,13 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = (*clients_foo_foo.FooStruct)(body.Foo)
-	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
+	clientRequest.Foo = (*clientsFooFoo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clientsBarBar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertTooManyArgsClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertTooManyArgsClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/codegen/test_data/endpoints/bar_structs.gogen
+++ b/codegen/test_data/endpoints/bar_structs.gogen
@@ -6,8 +6,8 @@ package bar
 import (
 	"runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
-	endpoints_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *endpoints_bar_bar.BarRequest
+	Request *endpointsBarBar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *endpoints_bar_bar.BarRequest
-	Foo     *endpoints_foo_foo.FooStruct
+	Request *endpointsBarBar.BarRequest
+	Foo     *endpointsFooFoo.FooStruct
 }

--- a/codegen/test_data/endpoints/bar_structs.gogen
+++ b/codegen/test_data/endpoints/bar_structs.gogen
@@ -6,8 +6,8 @@ package bar
 import (
 	"runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *bar.BarRequest
+	Request *endpoints_bar_bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *bar.BarRequest
-	Foo     *foo.FooStruct
+	Request *endpoints_bar_bar.BarRequest
+	Foo     *endpoints_foo_foo.FooStruct
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs.go
@@ -6,8 +6,8 @@ package barClient
 import (
 	"runtime"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *clients_bar_bar.BarRequest
+	Request *clientsBarBar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *clients_bar_bar.BarRequest
-	Foo     *clients_foo_foo.FooStruct
+	Request *clientsBarBar.BarRequest
+	Foo     *clientsFooFoo.FooStruct
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs.go
@@ -6,8 +6,8 @@ package barClient
 import (
 	"runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *bar.BarRequest
+	Request *clients_bar_bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *bar.BarRequest
-	Foo     *foo.FooStruct
+	Request *clients_bar_bar.BarRequest
+	Foo     *clients_foo_foo.FooStruct
 }

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	clients_contacts_contacts "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/contacts/contacts"
+	clientsContactsContacts "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/contacts/contacts"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -34,7 +34,7 @@ func NewClient(
 }
 
 // SaveContacts calls "/:userUUID/contacts" endpoint.
-func (c *ContactsClient) SaveContacts(ctx context.Context, r *clients_contacts_contacts.SaveContactsRequest) (*http.Response, error) {
+func (c *ContactsClient) SaveContacts(ctx context.Context, r *clientsContactsContacts.SaveContactsRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
 		c.ClientID, "saveContacts", c.HTTPClient,
 	)

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/contacts/contacts"
+	clients_contacts_contacts "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/contacts/contacts"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -34,7 +34,7 @@ func NewClient(
 }
 
 // SaveContacts calls "/:userUUID/contacts" endpoint.
-func (c *ContactsClient) SaveContacts(ctx context.Context, r *contacts.SaveContactsRequest) (*http.Response, error) {
+func (c *ContactsClient) SaveContacts(ctx context.Context, r *clients_contacts_contacts.SaveContactsRequest) (*http.Response, error) {
 	req := zanzibar.NewClientHTTPRequest(
 		c.ClientID, "saveContacts", c.HTTPClient,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -12,7 +12,9 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleMissingArgRequest handles "/bar/missing-arg-path".
@@ -51,7 +53,7 @@ func HandleMissingArgRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -60,8 +62,8 @@ func HandleMissingArgRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertMissingArgClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertMissingArgClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -12,9 +12,9 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleMissingArgRequest handles "/bar/missing-arg-path".
@@ -53,7 +53,7 @@ func HandleMissingArgRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -62,8 +62,8 @@ func HandleMissingArgRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertMissingArgClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertMissingArgClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -12,9 +12,9 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNoRequestRequest handles "/bar/no-request-path".
@@ -53,7 +53,7 @@ func HandleNoRequestRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -62,8 +62,8 @@ func HandleNoRequestRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertNoRequestClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertNoRequestClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -12,7 +12,9 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNoRequestRequest handles "/bar/no-request-path".
@@ -51,7 +53,7 @@ func HandleNoRequestRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -60,8 +62,8 @@ func HandleNoRequestRequest(
 	res.WriteJSON(200, response)
 }
 
-func convertNoRequestClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertNoRequestClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -13,9 +13,9 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNormalRequest handles "/bar/bar-path".
@@ -59,7 +59,7 @@ func HandleNormalRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -71,12 +71,12 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
+	clientRequest.Request = (*clientsBarBar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertNormalClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertNormalClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -13,9 +13,9 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clientTypeBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
 )
 
 // HandleNormalRequest handles "/bar/bar-path".
@@ -59,7 +59,7 @@ func HandleNormalRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -71,12 +71,12 @@ func HandleNormalRequest(
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {
 	clientRequest := &barClient.NormalHTTPRequest{}
 
-	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
+	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertNormalClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertNormalClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -13,10 +13,10 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 )
 
 // HandleTooManyArgsRequest handles "/bar/too-many-args-path".
@@ -63,7 +63,7 @@ func HandleTooManyArgsRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody clients_bar_bar.BarResponse
+	var clientRespBody clientsBarBar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -75,13 +75,13 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = (*clients_foo_foo.FooStruct)(body.Foo)
-	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
+	clientRequest.Foo = (*clientsFooFoo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clientsBarBar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertTooManyArgsClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
+func convertTooManyArgsClientResponse(body *clientsBarBar.BarResponse) *endpointsBarBar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &endpoints_bar_bar.BarResponse{}
+	downstreamResponse := &endpointsBarBar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -13,10 +13,10 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
 
-	clientTypeBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
-	clientTypeFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
+	clients_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clients_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/foo/foo"
 )
 
 // HandleTooManyArgsRequest handles "/bar/too-many-args-path".
@@ -63,7 +63,7 @@ func HandleTooManyArgsRequest(
 		res.SendError(500, errors.Wrap(err, "could not read client response body:"))
 		return
 	}
-	var clientRespBody bar.BarResponse
+	var clientRespBody clients_bar_bar.BarResponse
 	if err := clientRespBody.UnmarshalJSON(b); err != nil {
 		res.SendError(500, errors.Wrap(err, "could not unmarshal client response body:"))
 		return
@@ -75,13 +75,13 @@ func HandleTooManyArgsRequest(
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {
 	clientRequest := &barClient.TooManyArgsHTTPRequest{}
 
-	clientRequest.Foo = (*clientTypeFoo.FooStruct)(body.Foo)
-	clientRequest.Request = (*clientTypeBar.BarRequest)(body.Request)
+	clientRequest.Foo = (*clients_foo_foo.FooStruct)(body.Foo)
+	clientRequest.Request = (*clients_bar_bar.BarRequest)(body.Request)
 
 	return clientRequest
 }
-func convertTooManyArgsClientResponse(body *bar.BarResponse) *bar.BarResponse {
+func convertTooManyArgsClientResponse(body *clients_bar_bar.BarResponse) *endpoints_bar_bar.BarResponse {
 	// TODO: Add response fields mapping here.
-	downstreamResponse := &bar.BarResponse{}
+	downstreamResponse := &endpoints_bar_bar.BarResponse{}
 	return downstreamResponse
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs.go
@@ -6,8 +6,8 @@ package bar
 import (
 	"runtime"
 
-	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
-	endpoints_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
+	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpointsFooFoo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *endpoints_bar_bar.BarRequest
+	Request *endpointsBarBar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *endpoints_bar_bar.BarRequest
-	Foo     *endpoints_foo_foo.FooStruct
+	Request *endpointsBarBar.BarRequest
+	Foo     *endpointsFooFoo.FooStruct
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs.go
@@ -6,8 +6,8 @@ package bar
 import (
 	"runtime"
 
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
+	endpoints_bar_bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/bar/bar"
+	endpoints_foo_foo "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/endpoints/foo/foo"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -23,11 +23,11 @@ type ArgNotStructHTTPRequest struct {
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *bar.BarRequest
+	Request *endpoints_bar_bar.BarRequest
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *bar.BarRequest
-	Foo     *foo.FooStruct
+	Request *endpoints_bar_bar.BarRequest
+	Foo     *endpoints_foo_foo.FooStruct
 }


### PR DESCRIPTION
We have multiple different packages that have the same basename
for example `examples/bar/bar` and `clients/bar/bar`.

This PR adds support for using AliasName for included packages.
For each thrift struct generated by thriftrw we generate
a unique "alias" to refer to it in our generated code.

r: @uber/zanzibar-team