### PR TITLE
Cleanup usage of status code thrift annotation

### DIFF
--- a/codegen/method.go
+++ b/codegen/method.go
@@ -47,7 +47,7 @@ type MethodSpec struct {
 	Headers             []string
 	RequestType         string
 	ResponseType        string
-	OKStatusCode        []StatusCode
+	OKStatusCode        StatusCode
 	ExceptionStatusCode []StatusCode
 	// Additional struct generated from the bundle of request args.
 	RequestBoxed  bool
@@ -155,15 +155,18 @@ func (ms *MethodSpec) setOKStatusCode(statusCode string) error {
 	if statusCode == "" {
 		return errors.Errorf("no http OK status code set by annotation '%s' ", antHTTPStatus)
 	}
-	scode := strings.Split(statusCode, ",")
-	ms.OKStatusCode = make([]StatusCode, len(scode))
-	var err error
-	for i, c := range scode {
-		ms.OKStatusCode[i].Code, err = strconv.Atoi(c)
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse the annotation %s for ok response status")
-		}
+
+	code, err := strconv.Atoi(statusCode)
+	if err != nil {
+		return errors.Wrapf(err,
+			"Could not parse status code annotation (%s) for ok response",
+			statusCode,
+		)
 	}
+	ms.OKStatusCode = StatusCode{
+		Code: code,
+	}
+
 	return nil
 }
 

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -30,7 +30,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	tmpl "text/template"
 
@@ -100,7 +99,6 @@ var funcMap = tmpl.FuncMap{
 	"title":        strings.Title,
 	"Title":        strings.Title,
 	"fullTypeName": fullTypeName,
-	"statusCodes":  statusCodes,
 	"camel":        camelCase,
 	"split":        strings.Split,
 	"dec":          decrement,
@@ -114,22 +112,6 @@ func fullTypeName(typeName, packageName string) string {
 		return typeName
 	}
 	return packageName + "." + typeName
-}
-
-func statusCodes(codes []StatusCode) string {
-	if len(codes) == 0 {
-		return "[]int{}"
-	}
-	buf := bytes.NewBufferString("[]int{")
-	for i := 0; i < len(codes)-1; i++ {
-		if _, err := buf.WriteString(strconv.Itoa(codes[i].Code) + ","); err != nil {
-			return err.Error()
-		}
-	}
-	if _, err := buf.WriteString(strconv.Itoa(codes[len(codes)-1].Code) + "}"); err != nil {
-		return err.Error()
-	}
-	return string(buf.Bytes())
 }
 
 func camelCase(src string) string {

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -71,7 +71,8 @@ func Handle{{title .Name}}Request(
     }()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, {{statusCodes .OKStatusCode}}) {
+	expectedStatusCode := []int{ {{.DownstreamMethod.OKStatusCode.Code}} }
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -77,7 +77,7 @@ func Handle{{title .Name}}Request(
 		)
 	}
 	{{if or (eq $clientMethodResponseType "") (eq .ResponseType "") -}}
-	res.WriteJSONBytes(clientResp.StatusCode, nil)
+	res.WriteJSONBytes({{.OKStatusCode.Code}}, nil)
 	{{- else -}}
 	b, err := ioutil.ReadAll(clientResp.Body)
 	if err != nil {
@@ -90,7 +90,7 @@ func Handle{{title .Name}}Request(
 	 	return
 	}
 	response := convert{{title .Name}}ClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON({{.OKStatusCode.Code}}, response)
 	{{- end -}}
 }
 

--- a/codegen/templates/endpoint_test.tmpl
+++ b/codegen/templates/endpoint_test.tmpl
@@ -75,7 +75,7 @@ func Test{{.HandlerID | Title}}{{.TestName | Title}}OKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "{{$.Method.OKStatusCode.Code}} OK", res.Status)
+	assert.Equal(t, {{$.Method.OKStatusCode.Code}}, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }
 

--- a/codegen/templates/endpoint_test.tmpl
+++ b/codegen/templates/endpoint_test.tmpl
@@ -44,7 +44,7 @@ func Test{{.HandlerID | Title}}{{.TestName | Title}}OKResponse(t *testing.T) {
 
 	{{range .ClientStubs}}
 	fake{{.ClientMethod | Title}} := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader({{(index $.Method.OKStatusCode 0).Code}})
+		w.WriteHeader({{$.Method.OKStatusCode.Code}})
 		// TODO(zw): generate client response.
 		if _, err := w.Write([]byte( `{{.ClientResponseString}}`)); err != nil {
 			t.Fatal("can't write fake response")
@@ -75,7 +75,7 @@ func Test{{.HandlerID | Title}}{{.TestName | Title}}OKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "{{(index $.Method.OKStatusCode 0).Code}} OK", res.Status)
+	assert.Equal(t, "{{$.Method.OKStatusCode.Code}} OK", res.Status)
 	assert.Equal(t, 1, counter)
 }
 

--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -32,12 +32,10 @@
 					"Headers": null,
 					"RequestType": "ArgNotStructHTTPRequest",
 					"ResponseType": "",
-					"OKStatusCode": [
-						{
-							"Code": 200,
-							"Message": ""
-						}
-					],
+					"OKStatusCode": {
+						"Code": 200,
+						"Message": ""
+					},
 					"ExceptionStatusCode": [
 						{
 							"Code": 403,
@@ -79,12 +77,10 @@
 					"Headers": null,
 					"RequestType": "",
 					"ResponseType": "bar.BarResponse",
-					"OKStatusCode": [
-						{
-							"Code": 200,
-							"Message": ""
-						}
-					],
+					"OKStatusCode": {
+						"Code": 200,
+						"Message": ""
+					},
 					"ExceptionStatusCode": [
 						{
 							"Code": 403,
@@ -120,12 +116,10 @@
 					"Headers": null,
 					"RequestType": "",
 					"ResponseType": "bar.BarResponse",
-					"OKStatusCode": [
-						{
-							"Code": 200,
-							"Message": ""
-						}
-					],
+					"OKStatusCode": {
+						"Code": 200,
+						"Message": ""
+					},
 					"ExceptionStatusCode": [
 						{
 							"Code": 403,
@@ -161,12 +155,10 @@
 					"Headers": null,
 					"RequestType": "NormalHTTPRequest",
 					"ResponseType": "bar.BarResponse",
-					"OKStatusCode": [
-						{
-							"Code": 200,
-							"Message": ""
-						}
-					],
+					"OKStatusCode": {
+						"Code": 200,
+						"Message": ""
+					},
 					"ExceptionStatusCode": [
 						{
 							"Code": 403,
@@ -211,12 +203,10 @@
 					],
 					"RequestType": "TooManyArgsHTTPRequest",
 					"ResponseType": "bar.BarResponse",
-					"OKStatusCode": [
-						{
-							"Code": 200,
-							"Message": ""
-						}
-					],
+					"OKStatusCode": {
+						"Code": 200,
+						"Message": ""
+					},
 					"ExceptionStatusCode": [
 						{
 							"Code": 403,

--- a/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
@@ -52,6 +52,6 @@ func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
@@ -52,6 +52,6 @@ func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
@@ -52,6 +52,6 @@ func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
@@ -52,6 +52,6 @@ func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
@@ -54,6 +54,6 @@ func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -44,12 +44,13 @@ func HandleArgNotStructRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
 	}
-	res.WriteJSONBytes(clientResp.StatusCode, nil)
+	res.WriteJSONBytes(200, nil)
 }
 
 func convertToArgNotStructClientRequest(body *ArgNotStructHTTPRequest) *barClient.ArgNotStructHTTPRequest {

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -40,7 +40,8 @@ func HandleMissingArgRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -56,7 +57,7 @@ func HandleMissingArgRequest(
 		return
 	}
 	response := convertMissingArgClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertMissingArgClientResponse(body *bar.BarResponse) *bar.BarResponse {

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -40,7 +40,8 @@ func HandleNoRequestRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -56,7 +57,7 @@ func HandleNoRequestRequest(
 		return
 	}
 	response := convertNoRequestClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertNoRequestClientResponse(body *bar.BarResponse) *bar.BarResponse {

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -48,7 +48,8 @@ func HandleNormalRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -64,7 +65,7 @@ func HandleNormalRequest(
 		return
 	}
 	response := convertNormalClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -52,7 +52,8 @@ func HandleTooManyArgsRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -68,7 +69,7 @@ func HandleTooManyArgsRequest(
 		return
 	}
 	response := convertTooManyArgsClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -44,12 +44,13 @@ func HandleArgNotStructRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
 	}
-	res.WriteJSONBytes(clientResp.StatusCode, nil)
+	res.WriteJSONBytes(200, nil)
 }
 
 func convertToArgNotStructClientRequest(body *ArgNotStructHTTPRequest) *barClient.ArgNotStructHTTPRequest {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
@@ -52,6 +52,6 @@ func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -40,7 +40,8 @@ func HandleMissingArgRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -56,7 +57,7 @@ func HandleMissingArgRequest(
 		return
 	}
 	response := convertMissingArgClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertMissingArgClientResponse(body *bar.BarResponse) *bar.BarResponse {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
@@ -52,6 +52,6 @@ func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -40,7 +40,8 @@ func HandleNoRequestRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -56,7 +57,7 @@ func HandleNoRequestRequest(
 		return
 	}
 	response := convertNoRequestClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertNoRequestClientResponse(body *bar.BarResponse) *bar.BarResponse {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
@@ -52,6 +52,6 @@ func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -48,7 +48,8 @@ func HandleNormalRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -64,7 +65,7 @@ func HandleNormalRequest(
 		return
 	}
 	response := convertNormalClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertToNormalClientRequest(body *NormalHTTPRequest) *barClient.NormalHTTPRequest {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
@@ -52,6 +52,6 @@ func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -52,7 +52,8 @@ func HandleTooManyArgsRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200}) {
+	expectedStatusCode := []int{200}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
@@ -68,7 +69,7 @@ func HandleTooManyArgsRequest(
 		return
 	}
 	response := convertTooManyArgsClientResponse(&clientRespBody)
-	res.WriteJSON(clientResp.StatusCode, response)
+	res.WriteJSON(200, response)
 }
 
 func convertToTooManyArgsClientRequest(body *TooManyArgsHTTPRequest) *barClient.TooManyArgsHTTPRequest {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
@@ -54,6 +54,6 @@ func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -47,12 +47,13 @@ func HandleAddCredentialsRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200, 202}) {
+	expectedStatusCode := []int{202}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
 	}
-	res.WriteJSONBytes(clientResp.StatusCode, nil)
+	res.WriteJSONBytes(202, nil)
 }
 
 func convertToAddCredentialsClientRequest(body *AddCredentialsHTTPRequest) *googlenowClient.AddCredentialsHTTPRequest {

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
@@ -28,7 +28,7 @@ func TestAddCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 	defer gateway.Close()
 
 	fakeAddCredentials := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(202)
 		// TODO(zw): generate client response.
 		if _, err := w.Write([]byte(`{"status":"200 OK"}`)); err != nil {
 			t.Fatal("can't write fake response")
@@ -54,6 +54,6 @@ func TestAddCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 202, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -40,10 +40,11 @@ func HandleCheckCredentialsRequest(
 	}()
 
 	// Handle client respnse.
-	if !res.IsOKResponse(clientResp.StatusCode, []int{200, 202}) {
+	expectedStatusCode := []int{202}
+	if !res.IsOKResponse(clientResp.StatusCode, expectedStatusCode) {
 		req.Logger.Warn("Unknown response status code",
 			zap.Int("status code", clientResp.StatusCode),
 		)
 	}
-	res.WriteJSONBytes(clientResp.StatusCode, nil)
+	res.WriteJSONBytes(202, nil)
 }

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
@@ -28,7 +28,7 @@ func TestCheckCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 	defer gateway.Close()
 
 	fakeCheckCredentials := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(202)
 		// TODO(zw): generate client response.
 		if _, err := w.Write([]byte(`{"status":"200 OK"}`)); err != nil {
 			t.Fatal("can't write fake response")
@@ -54,6 +54,6 @@ func TestCheckCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, 202, res.StatusCode)
 	assert.Equal(t, 1, counter)
 }

--- a/examples/example-gateway/endpoints/contacts/save-contacts.go
+++ b/examples/example-gateway/endpoints/contacts/save-contacts.go
@@ -67,7 +67,7 @@ func HandleSaveContactsRequest(
 		return
 	}
 	response := convertToResponse(&clientRespBody)
-	res.WriteJSON(cres.StatusCode, response)
+	res.WriteJSON(202, response)
 }
 
 func convertToResponse(

--- a/examples/example-gateway/idl/github.com/uber/zanzibar/clients/googlenow/googlenow.thrift
+++ b/examples/example-gateway/idl/github.com/uber/zanzibar/clients/googlenow/googlenow.thrift
@@ -7,14 +7,14 @@ service GoogleNow {
     ) (  // can throws exceptions here for non 2XX response
         zanzibar.http.method = "POST"
         zanzibar.http.path = "/add-credentials"
-        zanzibar.http.status = "200,202"
+        zanzibar.http.status = "202"
         zanzibar.http.headers = "x-uuid,x-token"
     )
     void checkCredentials(
     ) (
         zanzibar.http.method = "POST"
         zanzibar.http.path = "/check-credentials"
-        zanzibar.http.status = "200,202"
+        zanzibar.http.status = "202"
         // comma sparated list for required headers
         zanzibar.http.headers = "x-uuid,x-token"
     )

--- a/examples/example-gateway/idl/github.com/uber/zanzibar/endpoints/googlenow/googlenow.thrift
+++ b/examples/example-gateway/idl/github.com/uber/zanzibar/endpoints/googlenow/googlenow.thrift
@@ -7,14 +7,14 @@ service GoogleNow {
     ) (  // can throws exceptions here for non 2XX response
         zanzibar.http.method = "POST"
         zanzibar.http.path = "/googlenow/add-credentials"
-        zanzibar.http.status = "200,202"
+        zanzibar.http.status = "202"
         zanzibar.http.headers = "x-uuid,x-token"
     )
     void checkCredentials(
     ) (
         zanzibar.http.method = "POST"
         zanzibar.http.path = "/googlenow/check-credentials"
-        zanzibar.http.status = "200,202"
+        zanzibar.http.status = "202"
         // comma sparated list for required headers
         zanzibar.http.headers = "x-uuid,x-token"
     )

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -126,7 +126,7 @@ func TestAddCredentials(t *testing.T) {
 
 	gateway.HTTPBackends()["googleNow"].HandleFunc(
 		"POST", "/add-credentials", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(200)
+			w.WriteHeader(202)
 			if _, err := w.Write([]byte("{\"statusCode\":200}")); err != nil {
 				t.Fatal("can't write fake response")
 			}
@@ -142,7 +142,7 @@ func TestAddCredentials(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, "202 Accepted", res.Status)
 	assert.Equal(t, 1, counter)
 }
 
@@ -283,6 +283,7 @@ func TestGoogleNowFailJSONParsing(t *testing.T) {
 	)
 }
 
+// TODO: what this test even do ?
 func TestAddCredentialsMissingAuthCode(t *testing.T) {
 	var counter int = 0
 
@@ -322,7 +323,7 @@ func TestAddCredentialsMissingAuthCode(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "200 OK", res.Status)
+	assert.Equal(t, "202 Accepted", res.Status)
 	assert.Equal(t, 0, counter)
 }
 
@@ -385,6 +386,7 @@ func TestAddCredentialsBackendDown(t *testing.T) {
 	assert.Contains(t, errorMsg, "dial tcp")
 }
 
+// TODO: how do we want to test this edge case ?
 func TestAddCredentialsWrongStatusCode(t *testing.T) {
 	var counter int = 0
 
@@ -418,7 +420,7 @@ func TestAddCredentialsWrongStatusCode(t *testing.T) {
 		return
 	}
 
-	assert.Equal(t, "201 Created", res.Status)
+	assert.Equal(t, "202 Accepted", res.Status)
 
 	bytes, err := ioutil.ReadAll(res.Body)
 	if !assert.NoError(t, err, "got bytes read error") {


### PR DESCRIPTION
- Use client status code to verify client status code.
 - Only allow one status code per method
 - Use endpoint status code in the response writing.

This change allows us to cleanup the endpoint code to
not need the client status code when the client becomes
a thrift based interface.

The client status code checking logic will move to the
generated client itself.

r: @uber/zanzibar-team