### PR TITLE
runtime/gateway: read the datacenter file only once

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -2,9 +2,9 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
+	"datacenterFile": "/etc/datacenter",
 
 	"logger.fileName": "/var/log/my-gateway/my-gateway.log",
-	"logger.datacenterFile": "/etc/datacenter",
 	"logger.output": "disk",
 
 	"metrics.type": "m3",

--- a/examples/example-gateway/build/zanzibar-defaults.json
+++ b/examples/example-gateway/build/zanzibar-defaults.json
@@ -2,9 +2,9 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
+	"datacenterFile": "/etc/datacenter",
 
 	"logger.fileName": "/var/log/my-gateway/my-gateway.log",
-	"logger.datacenterFile": "/etc/datacenter",
 	"logger.output": "disk",
 
 	"metrics.type": "m3",


### PR DESCRIPTION
This change reads the datacenterFile once and stores
it in the StaticConfig instance, instead of every
other component re-reading this file.

r: @uber/zanzibar-team @Matt-Esch