### PR TITLE
Add support for thrift exception parsing in client.

### DIFF
--- a/codegen/method.go
+++ b/codegen/method.go
@@ -51,11 +51,12 @@ type MethodSpec struct {
 	HTTPPath     string
 	PathSegments []PathSegment
 	// Headers needed, generated from "zanzibar.http.headers"
-	Headers      []string
-	RequestType  string
-	ResponseType string
-	OKStatusCode StatusCode
-	Exceptions   []ExceptionSpec
+	Headers          []string
+	RequestType      string
+	ResponseType     string
+	OKStatusCode     StatusCode
+	Exceptions       []ExceptionSpec
+	ValidStatusCodes []int
 	// Additional struct generated from the bundle of request args.
 	RequestBoxed  bool
 	RequestStruct []StructSpec
@@ -140,6 +141,8 @@ func NewMethod(
 	if err != nil {
 		return nil, err
 	}
+
+	method.setValidStatusCodes()
 
 	if method.HTTPMethod == "GET" && method.RequestType != "" {
 		return nil, errors.Errorf(
@@ -236,6 +239,15 @@ func (ms *MethodSpec) setOKStatusCode(statusCode string) error {
 	}
 
 	return nil
+}
+
+func (ms *MethodSpec) setValidStatusCodes() {
+	ms.ValidStatusCodes = make([]int, len(ms.Exceptions)+1)
+
+	ms.ValidStatusCodes[0] = ms.OKStatusCode.Code
+	for i := 0; i < len(ms.Exceptions); i++ {
+		ms.ValidStatusCodes[i+1] = ms.Exceptions[i].StatusCode.Code
+	}
 }
 
 func (ms *MethodSpec) setExceptions(

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -243,47 +243,10 @@ func (ms *ModuleSpec) SetDownstream(
 }
 
 // NewMethod creates new method specification.
-func (s *ServiceSpec) NewMethod(funcSpec *compile.FunctionSpec, packageHelper *PackageHelper) (*MethodSpec, error) {
-	method := &MethodSpec{}
-	method.CompiledThriftSpec = funcSpec
-	var err error
-	var ok bool
-	method.Name = funcSpec.MethodName()
-	if err = method.setResponseType(s.ThriftFile, funcSpec.ResultSpec, packageHelper); err != nil {
-		return nil, err
-	}
-	if err = method.setRequestType(s.ThriftFile, funcSpec, packageHelper); err != nil {
-		return nil, err
-	}
-	if !s.WantAnnot {
-		return method, nil
-	}
-
-	if method.HTTPMethod, ok = funcSpec.Annotations[antHTTPMethod]; !ok {
-		return nil, errors.Errorf("missing anotation '%s' for HTTP method", antHTTPMethod)
-	}
-
-	method.EndpointName = funcSpec.Annotations[antHandler]
-	method.Headers = headers(funcSpec.Annotations[antHTTPHeaders])
-
-	if err = method.setExceptionStatusCode(funcSpec.ResultSpec); err != nil {
-		return nil, err
-	}
-	if err = method.setOKStatusCode(funcSpec.Annotations[antHTTPStatus]); err != nil {
-		return nil, err
-	}
-
-	if method.HTTPMethod == "GET" && method.RequestType != "" {
-		return nil, errors.Errorf("invalid annotation: HTTP GET method with body type")
-	}
-
-	var httpPath string
-	if httpPath, ok = funcSpec.Annotations[antHTTPPath]; !ok {
-		return nil, errors.Errorf("missing anotation '%s' for HTTP path", antHTTPPath)
-	}
-	method.setHTTPPath(httpPath, funcSpec)
-
-	return method, nil
+func (s *ServiceSpec) NewMethod(
+	funcSpec *compile.FunctionSpec, packageHelper *PackageHelper,
+) (*MethodSpec, error) {
+	return NewMethod(s.ThriftFile, funcSpec, packageHelper, s.WantAnnot)
 }
 
 func (ms *ModuleSpec) addTypeImport(thriftPath string, packageHelper *PackageHelper) error {

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -98,7 +98,11 @@ func (c *{{$clientName}}) {{title .Name}}(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse({{.OKStatusCode.Code}})
+	res.CheckOKResponse([]int{
+		{{- range $index, $code := .ValidStatusCodes -}}
+		{{if $index}},{{end}}{{$code}}
+		{{- end -}}
+	})
 
 	{{if eq .ResponseType ""}}
 	_, err = res.ReadAll()

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -106,27 +106,8 @@ func (c *{{$clientName}}) {{title .Name}}(
 	})
 
 	{{if and (eq .ResponseType "") (eq (len .Exceptions) 0)}}
+	// TODO: log about unexpected body bytes?
 	_, err = res.ReadAll()
-	if err != nil {
-		return respHeaders, err
-	}
-	return respHeaders, nil
-	{{else if eq .ResponseType ""}}
-	switch res.StatusCode {
-		{{range $idx, $exception := .Exceptions}}
-		case {{$exception.StatusCode.Code}}:
-			var exception {{$exception.Type}}
-			err = res.ReadAndUnmarshalBody(&exception)
-			if err != nil {
-				break
-			}
-			return respHeaders, &exception
-		{{end}}
-		default:
-			// TODO: log about unexpected body bytes?
-			_, err = res.ReadAll()
-	}
-
 	if err != nil {
 		return respHeaders, err
 	}
@@ -139,6 +120,36 @@ func (c *{{$clientName}}) {{title .Name}}(
 	}
 
 	return &responseBody, respHeaders, nil
+	{{else if eq .ResponseType ""}}
+	switch res.StatusCode {
+		case {{.OKStatusCode.Code}}:
+			// TODO: log about unexpected body bytes?
+			_, err = res.ReadAll()
+			if err != nil {
+				return respHeaders, err
+			}
+
+			return respHeaders, nil
+		{{range $idx, $exception := .Exceptions}}
+		case {{$exception.StatusCode.Code}}:
+			var exception {{$exception.Type}}
+			err = res.ReadAndUnmarshalBody(&exception)
+			if err != nil {
+				return respHeaders, err
+			}
+			return respHeaders, &exception
+		{{end}}
+		default:
+			// TODO: log about unexpected body bytes?
+			_, err = res.ReadAll()
+			if err != nil {
+				return respHeaders, err
+			}
+	}
+
+	return respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 	{{else}}
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
@@ -164,14 +175,11 @@ func (c *{{$clientName}}) {{title .Name}}(
 			if err != nil {
 				return nil, respHeaders, err
 			}
-
-			return nil, respHeaders, errors.Errorf(
-				"Unexpected http client response (%d)", res.StatusCode,
-			)
 	}
 
-	// TODO: error about dead code?
-
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 	{{end}}
 }
 {{end}} {{- /* <range .Methods> */ -}}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -104,13 +104,41 @@ func (c *{{$clientName}}) {{title .Name}}(
 		{{- end -}}
 	})
 
-	{{if eq .ResponseType ""}}
+	{{if and (eq .ResponseType "") (eq (len .Exceptions) 0)}}
 	_, err = res.ReadAll()
 	if err != nil {
 		return respHeaders, err
 	}
 	return respHeaders, nil
+	{{else if eq .ResponseType ""}}
+	switch res.StatusCode {
+		{{range $idx, $exception := .Exceptions}}
+		case {{$exception.StatusCode.Code}}:
+			var exception {{$exception.Type}}
+			err = res.ReadAndUnmarshalBody(&exception)
+			if err != nil {
+				break
+			}
+			return respHeaders, &exception
+		{{end}}
+		default:
+			_, err = res.ReadAll()
+	}
+
+	if err != nil {
+		return respHeaders, err
+	}
+	return respHeaders, nil
+	{{else if eq (len .Exceptions) 0}}
+	var responseBody {{.ResponseType}}
+	err = res.ReadAndUnmarshalBody(&responseBody)
+	if err != nil {
+		return nil, respHeaders, err
+	}
+
+	return &responseBody, respHeaders, nil
 	{{else}}
+	// TODO also parse Exceptions
 	var responseBody {{.ResponseType}}
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
 	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
@@ -122,6 +123,7 @@ func (c *{{$clientName}}) {{title .Name}}(
 			return respHeaders, &exception
 		{{end}}
 		default:
+			// TODO: log about unexpected body bytes?
 			_, err = res.ReadAll()
 	}
 
@@ -138,14 +140,38 @@ func (c *{{$clientName}}) {{title .Name}}(
 
 	return &responseBody, respHeaders, nil
 	{{else}}
-	// TODO also parse Exceptions
-	var responseBody {{.ResponseType}}
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+		case {{.OKStatusCode.Code}}:
+			var responseBody {{.ResponseType}}
+			err = res.ReadAndUnmarshalBody(&responseBody)
+			if err != nil {
+				return nil, respHeaders, err
+			}
+
+			return &responseBody, respHeaders, nil
+		{{range $idx, $exception := .Exceptions}}
+		case {{$exception.StatusCode.Code}}:
+			var exception {{$exception.Type}}
+			err = res.ReadAndUnmarshalBody(&exception)
+			if err != nil {
+				return nil, respHeaders, err
+			}
+			return nil, respHeaders, &exception
+		{{end}}
+		default:
+			// TODO: log about unexpected body bytes?
+			_, err = res.ReadAll()
+			if err != nil {
+				return nil, respHeaders, err
+			}
+
+			return nil, respHeaders, errors.Errorf(
+				"Unexpected http client response (%d)", res.StatusCode,
+			)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
+
 	{{end}}
 }
 {{end}} {{- /* <range .Methods> */ -}}

--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -44,11 +44,22 @@
 						"Code": 200,
 						"Message": ""
 					},
-					"ExceptionStatusCode": [
+					"Exceptions": [
 						{
-							"Code": 403,
-							"Message": "barException"
+							"Type": "endpointsBarBar.BarException",
+							"Name": "barException",
+							"Annotations": {
+								"zanzibar.http.status": "403"
+							},
+							"StatusCode": {
+								"Code": 403,
+								"Message": "barException"
+							}
 						}
+					],
+					"ValidStatusCodes": [
+						200,
+						403
 					],
 					"RequestBoxed": false,
 					"RequestStruct": [
@@ -89,11 +100,22 @@
 						"Code": 200,
 						"Message": ""
 					},
-					"ExceptionStatusCode": [
+					"Exceptions": [
 						{
-							"Code": 403,
-							"Message": "barException"
+							"Type": "endpointsBarBar.BarException",
+							"Name": "barException",
+							"Annotations": {
+								"zanzibar.http.status": "403"
+							},
+							"StatusCode": {
+								"Code": 403,
+								"Message": "barException"
+							}
 						}
+					],
+					"ValidStatusCodes": [
+						200,
+						403
 					],
 					"RequestBoxed": false,
 					"RequestStruct": null,
@@ -128,11 +150,22 @@
 						"Code": 200,
 						"Message": ""
 					},
-					"ExceptionStatusCode": [
+					"Exceptions": [
 						{
-							"Code": 403,
-							"Message": "barException"
+							"Type": "endpointsBarBar.BarException",
+							"Name": "barException",
+							"Annotations": {
+								"zanzibar.http.status": "403"
+							},
+							"StatusCode": {
+								"Code": 403,
+								"Message": "barException"
+							}
 						}
+					],
+					"ValidStatusCodes": [
+						200,
+						403
 					],
 					"RequestBoxed": false,
 					"RequestStruct": null,
@@ -167,11 +200,22 @@
 						"Code": 200,
 						"Message": ""
 					},
-					"ExceptionStatusCode": [
+					"Exceptions": [
 						{
-							"Code": 403,
-							"Message": "barException"
+							"Type": "endpointsBarBar.BarException",
+							"Name": "barException",
+							"Annotations": {
+								"zanzibar.http.status": "403"
+							},
+							"StatusCode": {
+								"Code": 403,
+								"Message": "barException"
+							}
 						}
+					],
+					"ValidStatusCodes": [
+						200,
+						403
 					],
 					"RequestBoxed": false,
 					"RequestStruct": [
@@ -215,11 +259,22 @@
 						"Code": 200,
 						"Message": ""
 					},
-					"ExceptionStatusCode": [
+					"Exceptions": [
 						{
-							"Code": 403,
-							"Message": "barException"
+							"Type": "endpointsBarBar.BarException",
+							"Name": "barException",
+							"Annotations": {
+								"zanzibar.http.status": "403"
+							},
+							"StatusCode": {
+								"Code": 403,
+								"Message": "barException"
+							}
 						}
+					],
+					"ValidStatusCodes": [
+						200,
+						403
 					],
 					"RequestBoxed": false,
 					"RequestStruct": [

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -64,24 +64,34 @@ func (c *BarClient) ArgNotStruct(
 	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
+	case 200:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
+
+		return respHeaders, nil
 
 	case 403:
 		var exception clientsBarBar.BarException
 		err = res.ReadAndUnmarshalBody(&exception)
 		if err != nil {
-			break
+			return respHeaders, err
 		}
 		return respHeaders, &exception
 
 	default:
 		// TODO: log about unexpected body bytes?
 		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
 	}
 
-	if err != nil {
-		return respHeaders, err
-	}
-	return respHeaders, nil
+	return respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -138,13 +148,11 @@ func (c *BarClient) MissingArg(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -201,13 +209,11 @@ func (c *BarClient) NoRequest(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -265,13 +271,11 @@ func (c *BarClient) Normal(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -329,12 +333,10 @@ func (c *BarClient) TooManyArgs(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
 	"github.com/uber/zanzibar/runtime"
 )
@@ -73,6 +74,7 @@ func (c *BarClient) ArgNotStruct(
 		return respHeaders, &exception
 
 	default:
+		// TODO: log about unexpected body bytes?
 		_, err = res.ReadAll()
 	}
 
@@ -112,14 +114,37 @@ func (c *BarClient) MissingArg(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -152,14 +177,37 @@ func (c *BarClient) NoRequest(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -193,14 +241,37 @@ func (c *BarClient) Normal(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -234,13 +305,36 @@ func (c *BarClient) TooManyArgs(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -60,7 +60,7 @@ func (c *BarClient) ArgNotStruct(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	_, err = res.ReadAll()
 	if err != nil {
@@ -97,7 +97,7 @@ func (c *BarClient) MissingArg(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -136,7 +136,7 @@ func (c *BarClient) NoRequest(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -176,7 +176,7 @@ func (c *BarClient) Normal(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -216,7 +216,7 @@ func (c *BarClient) TooManyArgs(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -62,7 +62,20 @@ func (c *BarClient) ArgNotStruct(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	_, err = res.ReadAll()
+	switch res.StatusCode {
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			break
+		}
+		return respHeaders, &exception
+
+	default:
+		_, err = res.ReadAll()
+	}
+
 	if err != nil {
 		return respHeaders, err
 	}
@@ -99,6 +112,7 @@ func (c *BarClient) MissingArg(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -138,6 +152,7 @@ func (c *BarClient) NoRequest(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -178,6 +193,7 @@ func (c *BarClient) Normal(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -218,6 +234,7 @@ func (c *BarClient) TooManyArgs(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -64,24 +64,34 @@ func (c *BarClient) ArgNotStruct(
 	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
+	case 200:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
+
+		return respHeaders, nil
 
 	case 403:
 		var exception clientsBarBar.BarException
 		err = res.ReadAndUnmarshalBody(&exception)
 		if err != nil {
-			break
+			return respHeaders, err
 		}
 		return respHeaders, &exception
 
 	default:
 		// TODO: log about unexpected body bytes?
 		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
 	}
 
-	if err != nil {
-		return respHeaders, err
-	}
-	return respHeaders, nil
+	return respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -138,13 +148,11 @@ func (c *BarClient) MissingArg(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -201,13 +209,11 @@ func (c *BarClient) NoRequest(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -265,13 +271,11 @@ func (c *BarClient) Normal(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }
 
@@ -329,12 +333,10 @@ func (c *BarClient) TooManyArgs(
 		if err != nil {
 			return nil, respHeaders, err
 		}
-
-		return nil, respHeaders, errors.Errorf(
-			"Unexpected http client response (%d)", res.StatusCode,
-		)
 	}
 
-	// TODO: error about dead code?
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 
 }

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
 	"github.com/uber/zanzibar/runtime"
 )
@@ -73,6 +74,7 @@ func (c *BarClient) ArgNotStruct(
 		return respHeaders, &exception
 
 	default:
+		// TODO: log about unexpected body bytes?
 		_, err = res.ReadAll()
 	}
 
@@ -112,14 +114,37 @@ func (c *BarClient) MissingArg(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -152,14 +177,37 @@ func (c *BarClient) NoRequest(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -193,14 +241,37 @@ func (c *BarClient) Normal(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }
 
@@ -234,13 +305,36 @@ func (c *BarClient) TooManyArgs(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	// TODO also parse Exceptions
-	var responseBody clientsBarBar.BarResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 200:
+		var responseBody clientsBarBar.BarResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+		return nil, respHeaders, &exception
+
+	default:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return nil, respHeaders, errors.Errorf(
+			"Unexpected http client response (%d)", res.StatusCode,
+		)
 	}
 
-	return &responseBody, respHeaders, nil
+	// TODO: error about dead code?
 
 }

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -60,7 +60,7 @@ func (c *BarClient) ArgNotStruct(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	_, err = res.ReadAll()
 	if err != nil {
@@ -97,7 +97,7 @@ func (c *BarClient) MissingArg(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -136,7 +136,7 @@ func (c *BarClient) NoRequest(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -176,7 +176,7 @@ func (c *BarClient) Normal(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
@@ -216,7 +216,7 @@ func (c *BarClient) TooManyArgs(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(200)
+	res.CheckOKResponse([]int{200, 403})
 
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -62,7 +62,20 @@ func (c *BarClient) ArgNotStruct(
 
 	res.CheckOKResponse([]int{200, 403})
 
-	_, err = res.ReadAll()
+	switch res.StatusCode {
+
+	case 403:
+		var exception clientsBarBar.BarException
+		err = res.ReadAndUnmarshalBody(&exception)
+		if err != nil {
+			break
+		}
+		return respHeaders, &exception
+
+	default:
+		_, err = res.ReadAll()
+	}
+
 	if err != nil {
 		return respHeaders, err
 	}
@@ -99,6 +112,7 @@ func (c *BarClient) MissingArg(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -138,6 +152,7 @@ func (c *BarClient) NoRequest(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -178,6 +193,7 @@ func (c *BarClient) Normal(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {
@@ -218,6 +234,7 @@ func (c *BarClient) TooManyArgs(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	// TODO also parse Exceptions
 	var responseBody clientsBarBar.BarResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)
 	if err != nil {

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -60,7 +60,7 @@ func (c *ContactsClient) SaveContacts(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(202)
+	res.CheckOKResponse([]int{202})
 
 	var responseBody clientsContactsContacts.SaveContactsResponse
 	err = res.ReadAndUnmarshalBody(&responseBody)

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -61,6 +61,7 @@ func (c *GoogleNowClient) AddCredentials(
 
 	res.CheckOKResponse([]int{202})
 
+	// TODO: log about unexpected body bytes?
 	_, err = res.ReadAll()
 	if err != nil {
 		return respHeaders, err
@@ -98,6 +99,7 @@ func (c *GoogleNowClient) CheckCredentials(
 
 	res.CheckOKResponse([]int{202})
 
+	// TODO: log about unexpected body bytes?
 	_, err = res.ReadAll()
 	if err != nil {
 		return respHeaders, err

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -59,7 +59,7 @@ func (c *GoogleNowClient) AddCredentials(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(202)
+	res.CheckOKResponse([]int{202})
 
 	_, err = res.ReadAll()
 	if err != nil {
@@ -96,7 +96,7 @@ func (c *GoogleNowClient) CheckCredentials(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse(202)
+	res.CheckOKResponse([]int{202})
 
 	_, err = res.ReadAll()
 	if err != nil {

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
 	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
-	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/github.com/uber/zanzibar/clients/bar/bar"
+	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -118,12 +118,16 @@ func (res *ClientHTTPResponse) ReadAndUnmarshalBody(
 }
 
 // CheckOKResponse checks if the status code is OK.
-func (res *ClientHTTPResponse) CheckOKResponse(okResponse int) {
-	if res.rawResponse.StatusCode != okResponse {
-		res.req.Logger.Warn("Unknown response status code",
-			zap.Int("status code", res.rawResponse.StatusCode),
-		)
+func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
+	for okResponse := range okResponses {
+		if res.rawResponse.StatusCode == okResponse {
+			return
+		}
 	}
+
+	res.req.Logger.Warn("Unknown response status code",
+		zap.Int("status code", res.rawResponse.StatusCode),
+	)
 }
 
 // finish()

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -119,7 +119,7 @@ func (res *ClientHTTPResponse) ReadAndUnmarshalBody(
 
 // CheckOKResponse checks if the status code is OK.
 func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
-	for okResponse := range okResponses {
+	for _, okResponse := range okResponses {
 		if res.rawResponse.StatusCode == okResponse {
 			return
 		}

--- a/test/endpoints/bar/bar_normal_test.go
+++ b/test/endpoints/bar/bar_normal_test.go
@@ -107,7 +107,7 @@ func TestBarNormalMalformedClientResponseReadAll(t *testing.T) {
 	gateway.HTTPBackends()["bar"].Server.ConnState =
 		func(conn net.Conn, state http.ConnState) {
 			_, _ = conn.Write([]byte(
-				"HTTP/1.1 500 Internal Server Error\n" +
+				"HTTP/1.1 200 OK\n" +
 					"Content-Length: 12\n" +
 					"\n" +
 					"abc\n"))


### PR DESCRIPTION
This PR adds initial thrift exception support.

 - Read thrift exceptions in the HTTP client.
 - Add support for thrif exceptions in Method class.
 - Add tests for thrift exception usage.

Next up in future PRs:

 - TODO: Support serializing thrift exceptions in server
 - TODO: Generate struct converter functions for client/server
        exceptions.
 - TODO: Ensure http endpoints convert exceptions properly.

r: @uber/zanzibar-team