### PR TITLE
Make datacenterFile config optional

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -2,7 +2,6 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
-	"datacenterFile": "/etc/datacenter",
 
 	"logger.fileName": "/var/log/my-gateway/my-gateway.log",
 	"logger.output": "disk",

--- a/config/production.json
+++ b/config/production.json
@@ -3,8 +3,7 @@
 	"port": 4000,
 	"env": "production",
 
-	"logger.fileName": "/var/log/my-gateway/my-gateway.log",
-	"logger.output": "disk",
+	"logger.output": "stdout",
 
 	"metrics.type": "m3",
 	"metrics.tally.flushInterval": 1000,

--- a/examples/example-gateway/build/zanzibar-defaults.json
+++ b/examples/example-gateway/build/zanzibar-defaults.json
@@ -2,10 +2,8 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
-	"datacenterFile": "/etc/datacenter",
 
-	"logger.fileName": "/var/log/my-gateway/my-gateway.log",
-	"logger.output": "disk",
+	"logger.output": "stdout",
 
 	"metrics.type": "m3",
 	"metrics.tally.flushInterval": 1000,

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -1,6 +1,7 @@
 {
 	"serviceName": "example-gateway",
 	"port": 7783,
+	"useDatacenter": false,
 
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -233,13 +233,19 @@ func (gateway *Gateway) Wait() {
 }
 
 func (gateway *Gateway) setupConfig(config *StaticConfig) {
-	dcFile := config.MustGetString("datacenterFile")
-	bytes, err := ioutil.ReadFile(dcFile)
-	if err != nil {
-		bytes = []byte("unknown")
-	}
+	useDC := config.MustGetBoolean("useDatacenter")
 
-	config.SetOrDie("datacenter", string(bytes))
+	if useDC {
+		dcFile := config.MustGetString("datacenterFile")
+		bytes, err := ioutil.ReadFile(dcFile)
+		if err != nil {
+			panic("expected datacenterFile: " + dcFile + " to exist")
+		}
+
+		config.SetOrDie("datacenter", string(bytes))
+	} else {
+		config.SetOrDie("datacenter", "unknown")
+	}
 }
 
 func (gateway *Gateway) setupMetrics(config *StaticConfig) error {


### PR DESCRIPTION
The datacenterFile config might not make sense
in other environment so it's now optional.

The "useDatacenter" config field is mandatory
and has to be set in any gateway, if its true
then the "datacenterFile" config has to exist.

r: @Matt-Esch