### PR TITLE
Refactor endpoints to have an init pattern

### DIFF
--- a/codegen/template.go
+++ b/codegen/template.go
@@ -475,7 +475,10 @@ type EndpointRegisterInfo struct {
 	HTTPPath    string
 	EndpointID  string
 	HandlerID   string
+	PackageName string
 	HandlerType string
+	MethodName  string
+	HandlerName string
 	Middlewares []MiddlewareSpec
 }
 
@@ -560,14 +563,17 @@ func (t *Template) GenerateEndpointRegisterFile(
 		}
 
 		handlerType := espec.ModuleSpec.PackageName +
-			".Handle" + strings.Title(method.Name) + "Request"
+			"." + strings.Title(method.Name) + "Handler"
 
 		info := EndpointRegisterInfo{
 			EndpointID:  espec.EndpointID,
 			HandlerID:   espec.HandleID,
 			Method:      method.HTTPMethod,
 			HTTPPath:    method.HTTPPath,
+			PackageName: espec.ModuleSpec.PackageName,
 			HandlerType: handlerType,
+			MethodName:  strings.Title(method.Name),
+			HandlerName: strings.Title(method.Name) + "Handler",
 			Middlewares: espec.Middlewares,
 		}
 		endpointsInfo = append(endpointsInfo, info)

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -28,14 +28,28 @@ import (
 
 {{ $workflow := .WorkflowName -}}
 {{ $clientName := title .ClientName -}}
+{{ $handlerName := title .Method.Name | printf "%sHandler" }}pattern
 {{with .Method -}}
 
-// Handle{{title .Name}}Request handles "{{.HTTPPath}}".
-func Handle{{title .Name}}Request(
+// {{$handlerName}} is the handler for "{{.HTTPPath}}"
+type {{$handlerName}} struct {
+	Clients *clients.Clients
+}
+
+// New{{title .Name}}Endpoint creates a handler
+func New{{title .Name}}Endpoint(
+	gateway *zanzibar.Gateway,
+) *{{$handlerName}} {
+	return &{{$handlerName}}{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "{{.HTTPPath}}".
+func (handler *{{$handlerName}}) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	{{- if .Headers -}}
 	if !req.CheckHeaders({{.Headers | printf "%#v" }}) {
@@ -53,7 +67,7 @@ func Handle{{title .Name}}Request(
 	headers := map[string]string{}
 
 	workflow := {{$workflow}}{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger: req.Logger,
 		Request: req,
 	}

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -28,7 +28,7 @@ import (
 
 {{ $workflow := .WorkflowName -}}
 {{ $clientName := title .ClientName -}}
-{{ $handlerName := title .Method.Name | printf "%sHandler" }}pattern
+{{ $handlerName := title .Method.Name | printf "%sHandler" }}
 {{with .Method -}}
 
 // {{$handlerName}} is the handler for "{{.HTTPPath}}"

--- a/codegen/templates/endpoint_register.tmpl
+++ b/codegen/templates/endpoint_register.tmpl
@@ -14,63 +14,39 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-type handlerFn func(
-	ctx context.Context,
-	req *zanzibar.ServerHTTPRequest,
-	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
-)
-
-type myEndpoint struct {
-	HandlerFn handlerFn
-	Clients   *clients.Clients
+// Endpoints is a struct that holds all the endpoints
+type Endpoints struct {
+	{{range $idx, $endpoint := .Endpoints -}}
+	{{$endpoint.HandlerName}} *{{$endpoint.HandlerType}}
+	{{end}}
 }
 
-func (endpoint *myEndpoint) handle(
-	ctx context.Context,
-	req *zanzibar.ServerHTTPRequest,
-	res *zanzibar.ServerHTTPResponse,
-) {
-	fn := endpoint.HandlerFn
-	fn(ctx, req, res, endpoint.Clients)
-}
-
-func makeEndpoint(
-	g *zanzibar.Gateway,
-	endpointName string,
-	handlerName string,
-	middlewares []zanzibar.MiddlewareHandle,
-	handlerFn handlerFn,
-) *zanzibar.Endpoint {
-	myEndpoint := &myEndpoint{
-		Clients:   g.Clients.(*clients.Clients),
-		HandlerFn: handlerFn,
+// CreateEndpoints bootstraps the endpoints.
+func CreateEndpoints(
+	gateway *zanzibar.Gateway,
+) interface{} {
+	return &Endpoints{
+		{{range $idx, $e := .Endpoints -}}
+		{{$e.HandlerName}}: {{$e.PackageName}}.
+			New{{$e.MethodName}}Endpoint(gateway),
+		{{end}}
 	}
-
-	return zanzibar.NewEndpoint(
-		g,
-		endpointName,
-		handlerName,
-		zanzibar.NewStack(
-			middlewares,
-			myEndpoint.handle,
-		).Handle,
-	)
 }
 
 // Register will register all endpoints
 func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
+	endpoints := CreateEndpoints(g).(*Endpoints)
+
 	{{range $idx, $endpoint := .Endpoints -}}
 	router.Register(
 		"{{$endpoint.Method}}", "{{$endpoint.HTTPPath}}",
-		makeEndpoint(
+		zanzibar.NewEndpoint(
 			g,
 			"{{$endpoint.EndpointID}}",
 			"{{$endpoint.HandlerID}}",
 			{{ if len $endpoint.Middlewares | ne 0 -}}
-			
-			[]zanzibar.MiddlewareHandle{
-			{{range $idx, $middleware := $endpoint.Middlewares -}}
+			zanzibar.NewStack([]zanzibar.MiddlewareHandle{
+				{{range $idx, $middleware := $endpoint.Middlewares -}}
 				{{$middleware.Name}}.NewMiddleWare(
 					g,
 						{{$middleware.Name}}.Options{
@@ -79,12 +55,12 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 						{{end -}}
 						},
 				),
-			{{end -}}
-			},
+				{{end -}}
+			}, endpoints.{{$endpoint.HandlerName}}.HandleRequest).Handle,
 			{{- else -}}
-			nil,
+			endpoints.{{$endpoint.HandlerName}}.HandleRequest,
 			{{- end}}
-			{{$endpoint.HandlerType}},
+			
 		),
 	)
 	{{end}}

--- a/codegen/templates/endpoint_register.tmpl
+++ b/codegen/templates/endpoint_register.tmpl
@@ -27,8 +27,8 @@ func CreateEndpoints(
 ) interface{} {
 	return &Endpoints{
 		{{range $idx, $e := .Endpoints -}}
-		{{$e.HandlerName}}: {{$e.PackageName}}.
-			New{{$e.MethodName}}Endpoint(gateway),
+		{{$e.HandlerName}}:
+			{{$e.PackageName}}.New{{$e.MethodName}}Endpoint(gateway),
 		{{end}}
 	}
 }

--- a/codegen/templates/endpoint_register.tmpl
+++ b/codegen/templates/endpoint_register.tmpl
@@ -40,7 +40,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	{{range $idx, $endpoint := .Endpoints -}}
 	router.Register(
 		"{{$endpoint.Method}}", "{{$endpoint.HTTPPath}}",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"{{$endpoint.EndpointID}}",
 			"{{$endpoint.HandlerID}}",

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -28,11 +28,10 @@ type {{$clientName}} struct {
 
 // NewClient returns a new http client for service {{.Name}}.
 func NewClient(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) *{{$clientName}} {
-	ip := config.MustGetString("clients.{{.Name | camel}}.ip")
-	port := config.MustGetInt("clients.{{.Name | camel}}.port")
+	ip := gateway.Config.MustGetString("clients.{{.Name | camel}}.ip")
+	port := gateway.Config.MustGetInt("clients.{{.Name | camel}}.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{

--- a/codegen/templates/init_clients.tmpl
+++ b/codegen/templates/init_clients.tmpl
@@ -21,14 +21,11 @@ type Clients struct {
 
 // CreateClients will make all clients
 func CreateClients(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) interface{} {
 	return &Clients{
 		{{range $idx, $cinfo := .ClientInfo -}}
-		{{$cinfo.FieldName}}: {{$cinfo.PackageName}}.NewClient(
-			config, gateway,
-		),
+		{{$cinfo.FieldName}}: {{$cinfo.PackageName}}.NewClient(gateway),
 		{{end}}
 	}
 }

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -45,7 +45,7 @@ func createGateway() (*zanzibar.Gateway, error) {
 		return nil, err
 	}
 
-	clients := clients.CreateClients(config, gateway)
+	clients := clients.CreateClients(gateway)
 	gateway.Clients = clients
 
 	return gateway, nil

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -20,11 +20,10 @@ type BarClient struct {
 
 // NewClient returns a new http client for service Bar.
 func NewClient(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) *BarClient {
-	ip := config.MustGetString("clients.bar.ip")
-	port := config.MustGetInt("clients.bar.port")
+	ip := gateway.Config.MustGetString("clients.bar.ip")
+	port := gateway.Config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -13,12 +13,25 @@ import (
 	"github.com/uber/zanzibar/.tmp_gen/clients/bar"
 )
 
-// HandleArgNotStructRequest handles "/bar/arg-not-struct-path".
-func HandleArgNotStructRequest(
+// ArgNotStructHandler is the handler for "/bar/arg-not-struct-path"
+type ArgNotStructHandler struct {
+	Clients *clients.Clients
+}
+
+// NewArgNotStructEndpoint creates a handler
+func NewArgNotStructEndpoint(
+	gateway *zanzibar.Gateway,
+) *ArgNotStructHandler {
+	return &ArgNotStructHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/arg-not-struct-path".
+func (handler *ArgNotStructHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody ArgNotStructHTTPRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -28,7 +41,7 @@ func HandleArgNotStructRequest(
 	headers := map[string]string{}
 
 	workflow := ArgNotStructEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -14,18 +14,31 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleMissingArgRequest handles "/bar/missing-arg-path".
-func HandleMissingArgRequest(
+// MissingArgHandler is the handler for "/bar/missing-arg-path"
+type MissingArgHandler struct {
+	Clients *clients.Clients
+}
+
+// NewMissingArgEndpoint creates a handler
+func NewMissingArgEndpoint(
+	gateway *zanzibar.Gateway,
+) *MissingArgHandler {
+	return &MissingArgHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/missing-arg-path".
+func (handler *MissingArgHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := MissingArgEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -14,18 +14,31 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleNoRequestRequest handles "/bar/no-request-path".
-func HandleNoRequestRequest(
+// NoRequestHandler is the handler for "/bar/no-request-path"
+type NoRequestHandler struct {
+	Clients *clients.Clients
+}
+
+// NewNoRequestEndpoint creates a handler
+func NewNoRequestEndpoint(
+	gateway *zanzibar.Gateway,
+) *NoRequestHandler {
+	return &NoRequestHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/no-request-path".
+func (handler *NoRequestHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := NoRequestEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -15,12 +15,25 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleNormalRequest handles "/bar/bar-path".
-func HandleNormalRequest(
+// NormalHandler is the handler for "/bar/bar-path"
+type NormalHandler struct {
+	Clients *clients.Clients
+}
+
+// NewNormalEndpoint creates a handler
+func NewNormalEndpoint(
+	gateway *zanzibar.Gateway,
+) *NormalHandler {
+	return &NormalHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/bar-path".
+func (handler *NormalHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody NormalHTTPRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -30,7 +43,7 @@ func HandleNormalRequest(
 	headers := map[string]string{}
 
 	workflow := NormalEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -16,12 +16,25 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleTooManyArgsRequest handles "/bar/too-many-args-path".
-func HandleTooManyArgsRequest(
+// TooManyArgsHandler is the handler for "/bar/too-many-args-path"
+type TooManyArgsHandler struct {
+	Clients *clients.Clients
+}
+
+// NewTooManyArgsEndpoint creates a handler
+func NewTooManyArgsEndpoint(
+	gateway *zanzibar.Gateway,
+) *TooManyArgsHandler {
+	return &TooManyArgsHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/too-many-args-path".
+func (handler *TooManyArgsHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
@@ -34,7 +47,7 @@ func HandleTooManyArgsRequest(
 	headers := map[string]string{}
 
 	workflow := TooManyArgsEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -20,11 +20,10 @@ type BarClient struct {
 
 // NewClient returns a new http client for service Bar.
 func NewClient(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) *BarClient {
-	ip := config.MustGetString("clients.bar.ip")
-	port := config.MustGetInt("clients.bar.port")
+	ip := gateway.Config.MustGetString("clients.bar.ip")
+	port := gateway.Config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &BarClient{

--- a/examples/example-gateway/build/clients/clients.go
+++ b/examples/example-gateway/build/clients/clients.go
@@ -23,21 +23,12 @@ type Clients struct {
 
 // CreateClients will make all clients
 func CreateClients(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) interface{} {
 	return &Clients{
-		Bar: barClient.NewClient(
-			config, gateway,
-		),
-		Baz: bazClient.NewClient(
-			config, gateway,
-		),
-		Contacts: contactsClient.NewClient(
-			config, gateway,
-		),
-		GoogleNow: googlenowClient.NewClient(
-			config, gateway,
-		),
+		Bar:       barClient.NewClient(gateway),
+		Baz:       bazClient.NewClient(gateway),
+		Contacts:  contactsClient.NewClient(gateway),
+		GoogleNow: googlenowClient.NewClient(gateway),
 	}
 }

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -19,11 +19,10 @@ type ContactsClient struct {
 
 // NewClient returns a new http client for service Contacts.
 func NewClient(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) *ContactsClient {
-	ip := config.MustGetString("clients.contacts.ip")
-	port := config.MustGetInt("clients.contacts.port")
+	ip := gateway.Config.MustGetString("clients.contacts.ip")
+	port := gateway.Config.MustGetInt("clients.contacts.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &ContactsClient{

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -18,11 +18,10 @@ type GoogleNowClient struct {
 
 // NewClient returns a new http client for service GoogleNow.
 func NewClient(
-	config *zanzibar.StaticConfig,
 	gateway *zanzibar.Gateway,
 ) *GoogleNowClient {
-	ip := config.MustGetString("clients.googleNow.ip")
-	port := config.MustGetInt("clients.googleNow.port")
+	ip := gateway.Config.MustGetString("clients.googleNow.ip")
+	port := gateway.Config.MustGetInt("clients.googleNow.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &GoogleNowClient{

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -13,12 +13,25 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
 )
 
-// HandleArgNotStructRequest handles "/bar/arg-not-struct-path".
-func HandleArgNotStructRequest(
+// ArgNotStructHandler is the handler for "/bar/arg-not-struct-path"
+type ArgNotStructHandler struct {
+	Clients *clients.Clients
+}
+
+// NewArgNotStructEndpoint creates a handler
+func NewArgNotStructEndpoint(
+	gateway *zanzibar.Gateway,
+) *ArgNotStructHandler {
+	return &ArgNotStructHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/arg-not-struct-path".
+func (handler *ArgNotStructHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody ArgNotStructHTTPRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -28,7 +41,7 @@ func HandleArgNotStructRequest(
 	headers := map[string]string{}
 
 	workflow := ArgNotStructEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -14,18 +14,31 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleMissingArgRequest handles "/bar/missing-arg-path".
-func HandleMissingArgRequest(
+// MissingArgHandler is the handler for "/bar/missing-arg-path"
+type MissingArgHandler struct {
+	Clients *clients.Clients
+}
+
+// NewMissingArgEndpoint creates a handler
+func NewMissingArgEndpoint(
+	gateway *zanzibar.Gateway,
+) *MissingArgHandler {
+	return &MissingArgHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/missing-arg-path".
+func (handler *MissingArgHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := MissingArgEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -14,18 +14,31 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleNoRequestRequest handles "/bar/no-request-path".
-func HandleNoRequestRequest(
+// NoRequestHandler is the handler for "/bar/no-request-path"
+type NoRequestHandler struct {
+	Clients *clients.Clients
+}
+
+// NewNoRequestEndpoint creates a handler
+func NewNoRequestEndpoint(
+	gateway *zanzibar.Gateway,
+) *NoRequestHandler {
+	return &NoRequestHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/no-request-path".
+func (handler *NoRequestHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := NoRequestEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -15,12 +15,25 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleNormalRequest handles "/bar/bar-path".
-func HandleNormalRequest(
+// NormalHandler is the handler for "/bar/bar-path"
+type NormalHandler struct {
+	Clients *clients.Clients
+}
+
+// NewNormalEndpoint creates a handler
+func NewNormalEndpoint(
+	gateway *zanzibar.Gateway,
+) *NormalHandler {
+	return &NormalHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/bar-path".
+func (handler *NormalHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody NormalHTTPRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -30,7 +43,7 @@ func HandleNormalRequest(
 	headers := map[string]string{}
 
 	workflow := NormalEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -16,12 +16,25 @@ import (
 	endpointsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/bar/bar"
 )
 
-// HandleTooManyArgsRequest handles "/bar/too-many-args-path".
-func HandleTooManyArgsRequest(
+// TooManyArgsHandler is the handler for "/bar/too-many-args-path"
+type TooManyArgsHandler struct {
+	Clients *clients.Clients
+}
+
+// NewTooManyArgsEndpoint creates a handler
+func NewTooManyArgsEndpoint(
+	gateway *zanzibar.Gateway,
+) *TooManyArgsHandler {
+	return &TooManyArgsHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/bar/too-many-args-path".
+func (handler *TooManyArgsHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
@@ -34,7 +47,7 @@ func HandleTooManyArgsRequest(
 	headers := map[string]string{}
 
 	workflow := TooManyArgsEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -14,12 +14,25 @@ import (
 	endpointsBazBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/baz/baz"
 )
 
-// HandleCallRequest handles "/baz/call-path".
-func HandleCallRequest(
+// CallHandler is the handler for "/baz/call-path"
+type CallHandler struct {
+	Clients *clients.Clients
+}
+
+// NewCallEndpoint creates a handler
+func NewCallEndpoint(
+	gateway *zanzibar.Gateway,
+) *CallHandler {
+	return &CallHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/baz/call-path".
+func (handler *CallHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody CallHTTPRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -29,7 +42,7 @@ func HandleCallRequest(
 	headers := map[string]string{}
 
 	workflow := CallEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_simple.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_simple.go
@@ -11,18 +11,31 @@ import (
 	"go.uber.org/zap"
 )
 
-// HandleSimpleRequest handles "/baz/simple-path".
-func HandleSimpleRequest(
+// SimpleHandler is the handler for "/baz/simple-path"
+type SimpleHandler struct {
+	Clients *clients.Clients
+}
+
+// NewSimpleEndpoint creates a handler
+func NewSimpleEndpoint(
+	gateway *zanzibar.Gateway,
+) *SimpleHandler {
+	return &SimpleHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/baz/simple-path".
+func (handler *SimpleHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := SimpleEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_simplefuture.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_simplefuture.go
@@ -11,18 +11,31 @@ import (
 	"go.uber.org/zap"
 )
 
-// HandleSimpleFutureRequest handles "/baz/simple-future-path".
-func HandleSimpleFutureRequest(
+// SimpleFutureHandler is the handler for "/baz/simple-future-path"
+type SimpleFutureHandler struct {
+	Clients *clients.Clients
+}
+
+// NewSimpleFutureEndpoint creates a handler
+func NewSimpleFutureEndpoint(
+	gateway *zanzibar.Gateway,
+) *SimpleFutureHandler {
+	return &SimpleFutureHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/baz/simple-future-path".
+func (handler *SimpleFutureHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 
 	headers := map[string]string{}
 
 	workflow := SimpleFutureEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -14,12 +14,25 @@ import (
 	customContacts "github.com/uber/zanzibar/examples/example-gateway/endpoints/contacts"
 )
 
-// HandleSaveContactsRequest handles "/contacts/:userUUID/contacts".
-func HandleSaveContactsRequest(
+// SaveContactsHandler is the handler for "/contacts/:userUUID/contacts"
+type SaveContactsHandler struct {
+	Clients *clients.Clients
+}
+
+// NewSaveContactsEndpoint creates a handler
+func NewSaveContactsEndpoint(
+	gateway *zanzibar.Gateway,
+) *SaveContactsHandler {
+	return &SaveContactsHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/contacts/:userUUID/contacts".
+func (handler *SaveContactsHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	var requestBody endpointsContactsContacts.SaveContactsRequest
 	if ok := req.ReadAndUnmarshalBody(&requestBody); !ok {
@@ -29,7 +42,7 @@ func HandleSaveContactsRequest(
 	headers := map[string]string{}
 
 	workflow := customContacts.SaveContactsEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -13,12 +13,25 @@ import (
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients/googlenow"
 )
 
-// HandleAddCredentialsRequest handles "/googlenow/add-credentials".
-func HandleAddCredentialsRequest(
+// AddCredentialsHandler is the handler for "/googlenow/add-credentials"
+type AddCredentialsHandler struct {
+	Clients *clients.Clients
+}
+
+// NewAddCredentialsEndpoint creates a handler
+func NewAddCredentialsEndpoint(
+	gateway *zanzibar.Gateway,
+) *AddCredentialsHandler {
+	return &AddCredentialsHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/googlenow/add-credentials".
+func (handler *AddCredentialsHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
@@ -31,7 +44,7 @@ func HandleAddCredentialsRequest(
 	headers := map[string]string{}
 
 	workflow := AddCredentialsEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -11,12 +11,25 @@ import (
 	"go.uber.org/zap"
 )
 
-// HandleCheckCredentialsRequest handles "/googlenow/check-credentials".
-func HandleCheckCredentialsRequest(
+// CheckCredentialsHandler is the handler for "/googlenow/check-credentials"
+type CheckCredentialsHandler struct {
+	Clients *clients.Clients
+}
+
+// NewCheckCredentialsEndpoint creates a handler
+func NewCheckCredentialsEndpoint(
+	gateway *zanzibar.Gateway,
+) *CheckCredentialsHandler {
+	return &CheckCredentialsHandler{
+		Clients: gateway.Clients.(*clients.Clients),
+	}
+}
+
+// HandleRequest handles "/googlenow/check-credentials".
+func (handler *CheckCredentialsHandler) HandleRequest(
 	ctx context.Context,
 	req *zanzibar.ServerHTTPRequest,
 	res *zanzibar.ServerHTTPResponse,
-	clients *clients.Clients,
 ) {
 	if !req.CheckHeaders([]string{"x-uuid", "x-token"}) {
 		return
@@ -25,7 +38,7 @@ func HandleCheckCredentialsRequest(
 	headers := map[string]string{}
 
 	workflow := CheckCredentialsEndpoint{
-		Clients: clients,
+		Clients: handler.Clients,
 		Logger:  req.Logger,
 		Request: req,
 	}

--- a/examples/example-gateway/build/endpoints/register.go
+++ b/examples/example-gateway/build/endpoints/register.go
@@ -34,28 +34,17 @@ func CreateEndpoints(
 	gateway *zanzibar.Gateway,
 ) interface{} {
 	return &Endpoints{
-		ArgNotStructHandler: bar.
-			NewArgNotStructEndpoint(gateway),
-		MissingArgHandler: bar.
-			NewMissingArgEndpoint(gateway),
-		NoRequestHandler: bar.
-			NewNoRequestEndpoint(gateway),
-		NormalHandler: bar.
-			NewNormalEndpoint(gateway),
-		TooManyArgsHandler: bar.
-			NewTooManyArgsEndpoint(gateway),
-		CallHandler: baz.
-			NewCallEndpoint(gateway),
-		SimpleHandler: baz.
-			NewSimpleEndpoint(gateway),
-		SimpleFutureHandler: baz.
-			NewSimpleFutureEndpoint(gateway),
-		SaveContactsHandler: contacts.
-			NewSaveContactsEndpoint(gateway),
-		AddCredentialsHandler: googlenow.
-			NewAddCredentialsEndpoint(gateway),
-		CheckCredentialsHandler: googlenow.
-			NewCheckCredentialsEndpoint(gateway),
+		ArgNotStructHandler:     bar.NewArgNotStructEndpoint(gateway),
+		MissingArgHandler:       bar.NewMissingArgEndpoint(gateway),
+		NoRequestHandler:        bar.NewNoRequestEndpoint(gateway),
+		NormalHandler:           bar.NewNormalEndpoint(gateway),
+		TooManyArgsHandler:      bar.NewTooManyArgsEndpoint(gateway),
+		CallHandler:             baz.NewCallEndpoint(gateway),
+		SimpleHandler:           baz.NewSimpleEndpoint(gateway),
+		SimpleFutureHandler:     baz.NewSimpleFutureEndpoint(gateway),
+		SaveContactsHandler:     contacts.NewSaveContactsEndpoint(gateway),
+		AddCredentialsHandler:   googlenow.NewAddCredentialsEndpoint(gateway),
+		CheckCredentialsHandler: googlenow.NewCheckCredentialsEndpoint(gateway),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/register.go
+++ b/examples/example-gateway/build/endpoints/register.go
@@ -54,7 +54,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 
 	router.Register(
 		"POST", "/bar/arg-not-struct-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"bar",
 			"argNotStruct",
@@ -63,7 +63,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"GET", "/bar/missing-arg-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"bar",
 			"missingArg",
@@ -72,7 +72,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"GET", "/bar/no-request-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"bar",
 			"noRequest",
@@ -81,7 +81,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/bar/bar-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"bar",
 			"normal",
@@ -101,7 +101,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/bar/too-many-args-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"bar",
 			"tooManyArgs",
@@ -110,7 +110,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/baz/call-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"baz",
 			"call",
@@ -119,7 +119,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"GET", "/baz/simple-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"baz",
 			"simple",
@@ -128,7 +128,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"GET", "/baz/simple-future-path",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"baz",
 			"simpleFuture",
@@ -137,7 +137,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/contacts/:userUUID/contacts",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"contacts",
 			"saveContacts",
@@ -146,7 +146,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/googlenow/add-credentials",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"googlenow",
 			"addCredentials",
@@ -155,7 +155,7 @@ func Register(g *zanzibar.Gateway, router *zanzibar.Router) {
 	)
 	router.Register(
 		"POST", "/googlenow/check-credentials",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			g,
 			"googlenow",
 			"checkCredentials",

--- a/examples/example-gateway/build/main.go
+++ b/examples/example-gateway/build/main.go
@@ -43,7 +43,7 @@ func createGateway() (*zanzibar.Gateway, error) {
 		return nil, err
 	}
 
-	clients := clients.CreateClients(config, gateway)
+	clients := clients.CreateClients(gateway)
 	gateway.Clients = clients
 
 	return gateway, nil

--- a/examples/example-gateway/clients/baz/baz.go
+++ b/examples/example-gateway/clients/baz/baz.go
@@ -21,18 +21,22 @@ type TChanBaz interface {
 }
 
 // NewClient returns a new http client for service Bar.
-func NewClient(config *zanzibar.StaticConfig, gateway *zanzibar.Gateway) *BazClient {
+func NewClient(gateway *zanzibar.Gateway) *BazClient {
 	// this is the service discovery service name
-	serviceName := config.MustGetString("clients.baz.serviceName")
+	serviceName := gateway.Config.MustGetString("clients.baz.serviceName")
 	sc := gateway.Channel.GetSubChannel(serviceName)
 
-	ip := config.MustGetString("clients.baz.ip")
-	port := config.MustGetInt("clients.baz.port")
+	ip := gateway.Config.MustGetString("clients.baz.ip")
+	port := gateway.Config.MustGetInt("clients.baz.port")
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	// TODO: (lu) maybe set these at per method level
-	timeout := time.Duration(config.MustGetInt("clients.baz.timeout")) * time.Millisecond
-	timeoutPerAttempt := time.Duration(config.MustGetInt("clients.baz.timeoutPerAttempt")) * time.Millisecond
+	timeout := time.Duration(
+		gateway.Config.MustGetInt("clients.baz.timeout"),
+	) * time.Millisecond
+	timeoutPerAttempt := time.Duration(
+		gateway.Config.MustGetInt("clients.baz.timeoutPerAttempt"),
+	) * time.Millisecond
 
 	client := zanzibar.NewTChannelClient(gateway.Channel,
 		&zanzibar.TChannelClientOption{

--- a/module/module.go
+++ b/module/module.go
@@ -305,12 +305,17 @@ func (moduleSystem *System) GenerateBuild(
 				targetGenDir,
 				classInstance.Directory,
 			)
+			prettyBuildPath := filepath.Join(
+				".",
+				filepath.Base(targetGenDir),
+				classInstance.Directory,
+			)
 			fmt.Printf(
-				"Generating %s %s %s in %s %d/%d\n",
+				"Generating %8s %s %-10s in %-30s %d/%d\n",
 				classInstance.ClassType,
 				classInstance.ClassName,
 				classInstance.InstanceName,
-				buildPath,
+				prettyBuildPath,
 				moduleIndex,
 				moduleCount,
 			)

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -187,7 +187,7 @@ func (gateway *Gateway) register(register RegisterFn) {
 		"GET", "/debug/pprof/block", pprof.Handler("block").ServeHTTP,
 	)
 
-	gateway.Router.Register("GET", "/health", NewEndpoint(
+	gateway.Router.Register("GET", "/health", NewRouterEndpoint(
 		gateway, "health", "health", gateway.handleHealthRequest,
 	))
 

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -71,7 +71,7 @@ func TestHandlers(t *testing.T) {
 
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/foo",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -157,7 +157,7 @@ func TestMiddlewareRequestAbort(t *testing.T) {
 
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/foo",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -211,7 +211,7 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/foo",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -273,7 +273,7 @@ func TestMiddlewareSharedStates(t *testing.T) {
 
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/foo",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -110,9 +110,9 @@ type EndpointMetrics struct {
 	statusCodes    map[int]tally.Counter
 }
 
-// Endpoint struct represents an endpoint that can be registered
+// RouterEndpoint struct represents an endpoint that can be registered
 // into the router itself.
-type Endpoint struct {
+type RouterEndpoint struct {
 	EndpointName string
 	HandlerName  string
 	HandlerFn    HandlerFn
@@ -121,13 +121,13 @@ type Endpoint struct {
 	gateway *Gateway
 }
 
-// NewEndpoint creates an endpoint with all the necessary data
-func NewEndpoint(
+// NewRouterEndpoint creates an endpoint with all the necessary data
+func NewRouterEndpoint(
 	gateway *Gateway,
 	endpointName string,
 	handlerName string,
 	handler HandlerFn,
-) *Endpoint {
+) *RouterEndpoint {
 	endpointTags := map[string]string{
 		"endpoint": endpointName,
 		"handler":  handlerName,
@@ -142,7 +142,7 @@ func NewEndpoint(
 		statusCodes[statusCode] = endpointScope.Counter(metricName)
 	}
 
-	return &Endpoint{
+	return &RouterEndpoint{
 		EndpointName: endpointName,
 		HandlerName:  handlerName,
 		HandlerFn:    handler,
@@ -157,11 +157,10 @@ func NewEndpoint(
 }
 
 // HandleRequest is called by the router and starts the request
-func (endpoint *Endpoint) HandleRequest(
+func (endpoint *RouterEndpoint) HandleRequest(
 	w http.ResponseWriter, r *http.Request, params httprouter.Params,
 ) {
 	req := NewServerHTTPRequest(w, r, params, endpoint)
-
 	fn := endpoint.HandlerFn
 
 	ctx := r.Context()
@@ -220,7 +219,7 @@ func (router *Router) RegisterRaw(
 
 // Register will register an endpoint with the router.
 func (router *Router) Register(
-	method string, urlpattern string, endpoint *Endpoint,
+	method string, urlpattern string, endpoint *RouterEndpoint,
 ) {
 	canonicalPattern := urlpattern
 	if canonicalPattern[len(canonicalPattern)-1] == '/' {

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -48,7 +48,7 @@ func TestTrailingSlashRoutes(t *testing.T) {
 
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/foo",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -63,7 +63,7 @@ func TestTrailingSlashRoutes(t *testing.T) {
 	)
 	bgateway.ActualGateway.Router.Register(
 		"GET", "/bar/",
-		zanzibar.NewEndpoint(
+		zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"bar",
 			"bar",

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -56,7 +56,7 @@ type ServerHTTPRequest struct {
 // NewServerHTTPRequest is helper function to alloc ServerHTTPRequest
 func NewServerHTTPRequest(
 	w http.ResponseWriter, r *http.Request,
-	params httprouter.Params, endpoint *Endpoint,
+	params httprouter.Params, endpoint *RouterEndpoint,
 ) *ServerHTTPRequest {
 	req := &ServerHTTPRequest{
 		gateway:     endpoint.gateway,

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -48,7 +48,7 @@ func TestInvalidStatusCode(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 	bgateway.ActualGateway.Router.Register(
-		"GET", "/foo", zanzibar.NewEndpoint(
+		"GET", "/foo", zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -108,7 +108,7 @@ func TestCallingWriteJSONWithNil(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 	bgateway.ActualGateway.Router.Register(
-		"GET", "/foo", zanzibar.NewEndpoint(
+		"GET", "/foo", zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -167,7 +167,7 @@ func TestCallWriteJSONWithBadJSON(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 	bgateway.ActualGateway.Router.Register(
-		"GET", "/foo", zanzibar.NewEndpoint(
+		"GET", "/foo", zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -241,7 +241,7 @@ func TestResponsePeekBody(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 	bgateway.ActualGateway.Router.Register(
-		"GET", "/foo", zanzibar.NewEndpoint(
+		"GET", "/foo", zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",
@@ -302,7 +302,7 @@ func TestResponsePeekBodyError(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 	bgateway.ActualGateway.Router.Register(
-		"GET", "/foo", zanzibar.NewEndpoint(
+		"GET", "/foo", zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway,
 			"foo",
 			"foo",

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -61,12 +61,18 @@ func getZanzibarDirName() string {
 	return filepath.Join(getDirName(), "..", "..", "..")
 }
 
+// CreateClientsFn ...
+type CreateClientsFn func(gateway *zanzibar.Gateway) interface{}
+
+// RegisterFn ...
+type RegisterFn func(g *zanzibar.Gateway, router *zanzibar.Router)
+
 // CreateGateway bootstrap gateway for testing
 func CreateGateway(
 	seedConfig map[string]interface{},
 	opts *testGateway.Options,
-	createClients func(config *zanzibar.StaticConfig, gateway *zanzibar.Gateway) interface{},
-	regEndpoints func(g *zanzibar.Gateway, router *zanzibar.Router),
+	createClients CreateClientsFn,
+	regEndpoints RegisterFn,
 ) (testGateway.TestGateway, error) {
 	if seedConfig == nil {
 		seedConfig = map[string]interface{}{}
@@ -138,10 +144,10 @@ func CreateGateway(
 	if err != nil {
 		return nil, err
 	}
-	gateway.Clients = createClients(config, gateway)
+	gateway.Clients = createClients(gateway)
 
 	benchGateway.ActualGateway = gateway
-	err = gateway.Bootstrap(regEndpoints)
+	err = gateway.Bootstrap(zanzibar.RegisterFn(regEndpoints))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently our clients module all have a stable pattern
of each client being a struct with a NewX() function.

However our endpoint handlers are just flat functions.

This PR refactors each endpoint to be a struct with
a method and a constructor.

This means its dependencies ( in this case clients ) are
passed into the constructor instead of passed as an extra
argument in the handler method.

I've also updated endpoints_register.tmpl to set up
an Endpoints struct and a NewEndpoints to bootstrap all
of the endpoints. 

In the feature both the NewEndpoints and NewClients file
will be generate from the module system.

r: @uber/zanzibar-team @Matt-Esch