### PR TITLE
Makefile: do more caching in make test-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ scripts/easy_json/easy_json
 *.pprof
 *.prof
 node_modules/
+./test/.cached_binary_test_info.json

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,15 @@ test: generate lint
 
 .PHONY: test-only
 test-only:
-	go test ./examples/example-gateway/... | grep -v '\[no test files\]'
-	go test ./codegen/... | grep -v '\[no test files\]'
-	go test ./runtime/... | grep -v '\[no test files\]'
-	go test ./test/... | grep -v '\[no test files\]'
+	rm -f ./test/.cached_binary_test_info.json
+	go test ./test/health_test.go # preload the binary cache.
+	go test \
+		./examples/example-gateway/... \
+		./codegen/... \
+		./runtime/... \
+		./test/... | \
+		grep -v '\[no test files\]'
+	rm -f ./test/.cached_binary_test_info.json
 	echo "<coverage />" > ./coverage/cobertura-coverage.xml
 
 .PHONY: travis-coveralls

--- a/test/lib/test_gateway/test_gateway_cover.go
+++ b/test/lib/test_gateway/test_gateway_cover.go
@@ -153,7 +153,7 @@ func createTestBinaryFile(
 	mainPath string,
 	config map[string]interface{},
 ) (*testBinaryInfo, error) {
-	if os.Getenv("COVER_ON") == "1" && cachedBinaryFile == nil {
+	if cachedBinaryFile == nil {
 		// Try to load cachedBinaryFile from disk
 		tryLoadCachedBinaryTestInfo(mainPath)
 	}
@@ -227,8 +227,6 @@ func createTestBinaryFile(
 		CoverProfileFile: coverProfileFile,
 		MainFile:         mainPath,
 	}
-	if os.Getenv("COVER_ON") == "1" {
-		tryWriteCachedBinaryTestInfo()
-	}
+	tryWriteCachedBinaryTestInfo()
 	return cachedBinaryFile, nil
 }


### PR DESCRIPTION
This should speed up test times.

On master:

```
raynos at raynos-ThinkPad-T440p  
~/gocode/src/github.com/uber/zanzibar on master
$ time make test-only
go test ./examples/example-gateway/... | grep -v '\[no test files\]'
ok      github.com/uber/zanzibar/examples/example-gateway/build 0.022s
ok      github.com/uber/zanzibar/examples/example-gateway/build/endpoints/bar   7.570s
ok      github.com/uber/zanzibar/examples/example-gateway/build/endpoints/googlenow     7.836s
ok      github.com/uber/zanzibar/examples/example-gateway/endpoints/baz 7.221s
ok      github.com/uber/zanzibar/examples/example-gateway/middlewares/example   0.010s
ok      github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader    0.004s
go test ./codegen/... | grep -v '\[no test files\]'
ok      github.com/uber/zanzibar/codegen        0.521s
go test ./runtime/... | grep -v '\[no test files\]'
ok      github.com/uber/zanzibar/runtime        0.206s
go test ./test/... | grep -v '\[no test files\]'
ok      github.com/uber/zanzibar/test   13.123s
ok      github.com/uber/zanzibar/test/endpoints/bar     13.430s
ok      github.com/uber/zanzibar/test/endpoints/contacts        12.887s
ok      github.com/uber/zanzibar/test/endpoints/google_now      3.656s
echo "<coverage />" > ./coverage/cobertura-coverage.xml

real    0m42.169s
user    1m21.652s
sys     0m6.504s
```

This branch :

```
raynos at raynos-ThinkPad-T440p  
~/gocode/src/github.com/uber/zanzibar on master
$ time make test-only
rm -f ./test/.cached_binary_test_info.json
go test ./test/health_test.go # preload the binary cache.
ok      command-line-arguments  2.907s
go test \
    ./examples/example-gateway/... \
    ./codegen/... \
    ./runtime/... \
    ./test/... | \
    grep -v '\[no test files\]'
ok      github.com/uber/zanzibar/examples/example-gateway/build 0.006s
ok      github.com/uber/zanzibar/examples/example-gateway/build/endpoints/bar   0.253s
ok      github.com/uber/zanzibar/examples/example-gateway/build/endpoints/googlenow     0.150s
ok      github.com/uber/zanzibar/examples/example-gateway/endpoints/baz 0.139s
ok      github.com/uber/zanzibar/examples/example-gateway/middlewares/example   0.008s
ok      github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader    0.007s
ok      github.com/uber/zanzibar/codegen        0.532s
ok      github.com/uber/zanzibar/runtime        0.376s
ok      github.com/uber/zanzibar/test   0.176s
ok      github.com/uber/zanzibar/test/endpoints/bar     0.062s
ok      github.com/uber/zanzibar/test/endpoints/contacts        0.038s
ok      github.com/uber/zanzibar/test/endpoints/google_now      0.246s
rm -f ./test/.cached_binary_test_info.json
echo "<coverage />" > ./coverage/cobertura-coverage.xml

real    0m17.280s
user    0m35.340s
sys     0m2.848s
```

Test time from ~45s -> ~15s.

r: @uber/zanzibar-team