### PR TITLE
Improve client status code handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ scripts/easy_json/easy_json
 *.pprof
 *.prof
 node_modules/
-./test/.cached_binary_test_info.json
+test/.cached_binary_test_info.json

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ test: generate lint
 .PHONY: test-only
 test-only:
 	rm -f ./test/.cached_binary_test_info.json
-	go test ./test/health_test.go # preload the binary cache.
-	go test \
+	ZANZIBAR_CACHE=1 go test ./test/health_test.go # preload the binary cache.
+	ZANZIBAR_CACHE=1 go test \
 		./examples/example-gateway/... \
 		./codegen/... \
 		./runtime/... \

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -105,20 +105,26 @@ func (c *{{$clientName}}) {{title .Name}}(
 	})
 
 	{{if and (eq .ResponseType "") (eq (len .Exceptions) 0)}}
-	// TODO: log about unexpected body bytes?
-	_, err = res.ReadAll()
-	if err != nil {
-		return respHeaders, err
+	switch res.StatusCode {
+		case {{.OKStatusCode.Code}}:
+			// TODO: log about unexpected body bytes?
+			_, err = res.ReadAll()
+			if err != nil {
+				return respHeaders, err
+			}
+			return respHeaders, nil
 	}
-	return respHeaders, nil
 	{{else if eq (len .Exceptions) 0}}
-	var responseBody {{.ResponseType}}
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
-	}
+	switch res.StatusCode {
+		case {{.OKStatusCode.Code}}:
+			var responseBody {{.ResponseType}}
+			err = res.ReadAndUnmarshalBody(&responseBody)
+			if err != nil {
+				return nil, respHeaders, err
+			}
 
-	return &responseBody, respHeaders, nil
+			return &responseBody, respHeaders, nil
+	}
 	{{else if eq .ResponseType ""}}
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
@@ -145,10 +151,6 @@ func (c *{{$clientName}}) {{title .Name}}(
 				return respHeaders, err
 			}
 	}
-
-	return respHeaders, errors.Errorf(
-		"Unexpected http client response (%d)", res.StatusCode,
-	)
 	{{else}}
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
@@ -175,11 +177,11 @@ func (c *{{$clientName}}) {{title .Name}}(
 				return nil, respHeaders, err
 			}
 	}
+	{{end}}
 
-	return nil, respHeaders, errors.Errorf(
+	return {{if ne .ResponseType ""}}nil, {{end}}respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-	{{end}}
 }
 {{end}} {{- /* <range .Methods> */ -}}
 {{end}} {{- /* <range .Services> */ -}}

--- a/codegen/templates/structs.tmpl
+++ b/codegen/templates/structs.tmpl
@@ -27,8 +27,9 @@ func getDirName() string {
 {{if len .RequestStruct | ne 0}} {{- /* generate struct to wrap request args*/ -}}
 // {{.RequestType}} is the http body type for endpoint {{.Name}}.
 type {{.RequestType}} struct {
-{{range .RequestStruct}} {{- printf "    %s %s\n" (title .Name) .Type -}}
-{{end -}}
+	{{range .RequestStruct -}}
+	{{title .Name}} {{.Type}} `json:"{{.Name}}"`
+	{{end -}}
 }{{end -}}
 
 {{end}} {{- /* <range .Methods> */ -}}

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -91,7 +91,6 @@ func (c *BarClient) ArgNotStruct(
 	return respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
@@ -152,7 +151,6 @@ func (c *BarClient) MissingArg(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // NoRequest calls "/no-request-path" endpoint.
@@ -213,7 +211,6 @@ func (c *BarClient) NoRequest(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // Normal calls "/bar-path" endpoint.
@@ -275,7 +272,6 @@ func (c *BarClient) Normal(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
@@ -337,5 +333,4 @@ func (c *BarClient) TooManyArgs(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }

--- a/codegen/test_data/clients/bar_structs.gogen
+++ b/codegen/test_data/clients/bar_structs.gogen
@@ -18,16 +18,16 @@ func getDirName() string {
 
 // ArgNotStructHTTPRequest is the http body type for endpoint argNotStruct.
 type ArgNotStructHTTPRequest struct {
-	Request string
+	Request string `json:"request"`
 }
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *clientsBarBar.BarRequest
+	Request *clientsBarBar.BarRequest `json:"request"`
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *clientsBarBar.BarRequest
-	Foo     *clientsFooFoo.FooStruct
+	Request *clientsBarBar.BarRequest `json:"request"`
+	Foo     *clientsFooFoo.FooStruct  `json:"foo"`
 }

--- a/codegen/test_data/endpoints/bar_structs.gogen
+++ b/codegen/test_data/endpoints/bar_structs.gogen
@@ -18,16 +18,16 @@ func getDirName() string {
 
 // ArgNotStructHTTPRequest is the http body type for endpoint argNotStruct.
 type ArgNotStructHTTPRequest struct {
-	Request string
+	Request string `json:"request"`
 }
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *endpointsBarBar.BarRequest
+	Request *endpointsBarBar.BarRequest `json:"request"`
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *endpointsBarBar.BarRequest
-	Foo     *endpointsFooFoo.FooStruct
+	Request *endpointsBarBar.BarRequest `json:"request"`
+	Foo     *endpointsFooFoo.FooStruct  `json:"foo"`
 }

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -91,7 +91,6 @@ func (c *BarClient) ArgNotStruct(
 	return respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
@@ -152,7 +151,6 @@ func (c *BarClient) MissingArg(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // NoRequest calls "/no-request-path" endpoint.
@@ -213,7 +211,6 @@ func (c *BarClient) NoRequest(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // Normal calls "/bar-path" endpoint.
@@ -275,7 +272,6 @@ func (c *BarClient) Normal(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
@@ -337,5 +333,4 @@ func (c *BarClient) TooManyArgs(
 	return nil, respHeaders, errors.Errorf(
 		"Unexpected http client response (%d)", res.StatusCode,
 	)
-
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs.go
@@ -18,16 +18,16 @@ func getDirName() string {
 
 // ArgNotStructHTTPRequest is the http body type for endpoint argNotStruct.
 type ArgNotStructHTTPRequest struct {
-	Request string
+	Request string `json:"request"`
 }
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *clientsBarBar.BarRequest
+	Request *clientsBarBar.BarRequest `json:"request"`
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *clientsBarBar.BarRequest
-	Foo     *clientsFooFoo.FooStruct
+	Request *clientsBarBar.BarRequest `json:"request"`
+	Foo     *clientsFooFoo.FooStruct  `json:"foo"`
 }

--- a/examples/example-gateway/build/clients/bar/bar_structs_easyjson.go
+++ b/examples/example-gateway/build/clients/bar/bar_structs_easyjson.go
@@ -40,7 +40,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			if in.IsNull() {
 				in.Skip()
 				out.Request = nil
@@ -50,7 +50,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 				}
 				(*out.Request).UnmarshalEasyJSON(in)
 			}
-		case "Foo":
+		case "foo":
 			if in.IsNull() {
 				in.Skip()
 				out.Foo = nil
@@ -78,7 +78,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	if in.Request == nil {
 		out.RawString("null")
 	} else {
@@ -88,7 +88,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Foo\":")
+	out.RawString("\"foo\":")
 	if in.Foo == nil {
 		out.RawString("null")
 	} else {
@@ -139,7 +139,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			if in.IsNull() {
 				in.Skip()
 				out.Request = nil
@@ -167,7 +167,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	if in.Request == nil {
 		out.RawString("null")
 	} else {
@@ -218,7 +218,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			out.Request = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -238,7 +238,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	out.String(string(in.Request))
 	out.RawByte('}')
 }

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
 	clientsContactsContacts "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/contacts/contacts"
 	"github.com/uber/zanzibar/runtime"
 )
@@ -61,12 +62,18 @@ func (c *ContactsClient) SaveContacts(
 
 	res.CheckOKResponse([]int{202})
 
-	var responseBody clientsContactsContacts.SaveContactsResponse
-	err = res.ReadAndUnmarshalBody(&responseBody)
-	if err != nil {
-		return nil, respHeaders, err
+	switch res.StatusCode {
+	case 202:
+		var responseBody clientsContactsContacts.SaveContactsResponse
+		err = res.ReadAndUnmarshalBody(&responseBody)
+		if err != nil {
+			return nil, respHeaders, err
+		}
+
+		return &responseBody, respHeaders, nil
 	}
 
-	return &responseBody, respHeaders, nil
-
+	return nil, respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 }

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/uber/zanzibar/runtime"
 )
 
@@ -60,13 +61,19 @@ func (c *GoogleNowClient) AddCredentials(
 
 	res.CheckOKResponse([]int{202})
 
-	// TODO: log about unexpected body bytes?
-	_, err = res.ReadAll()
-	if err != nil {
-		return respHeaders, err
+	switch res.StatusCode {
+	case 202:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
+		return respHeaders, nil
 	}
-	return respHeaders, nil
 
+	return respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 }
 
 // CheckCredentials calls "/check-credentials" endpoint.
@@ -98,11 +105,17 @@ func (c *GoogleNowClient) CheckCredentials(
 
 	res.CheckOKResponse([]int{202})
 
-	// TODO: log about unexpected body bytes?
-	_, err = res.ReadAll()
-	if err != nil {
-		return respHeaders, err
+	switch res.StatusCode {
+	case 202:
+		// TODO: log about unexpected body bytes?
+		_, err = res.ReadAll()
+		if err != nil {
+			return respHeaders, err
+		}
+		return respHeaders, nil
 	}
-	return respHeaders, nil
 
+	return respHeaders, errors.Errorf(
+		"Unexpected http client response (%d)", res.StatusCode,
+	)
 }

--- a/examples/example-gateway/build/clients/googlenow/googlenow_structs.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow_structs.go
@@ -16,5 +16,5 @@ func getDirName() string {
 
 // AddCredentialsHTTPRequest is the http body type for endpoint addCredentials.
 type AddCredentialsHTTPRequest struct {
-	AuthCode string
+	AuthCode string `json:"authCode"`
 }

--- a/examples/example-gateway/build/clients/googlenow/googlenow_structs_easyjson.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow_structs_easyjson.go
@@ -38,7 +38,7 @@ func easyjson5cf1a88aDecodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 			continue
 		}
 		switch key {
-		case "AuthCode":
+		case "authCode":
 			out.AuthCode = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -58,7 +58,7 @@ func easyjson5cf1a88aEncodeGithubComUberZanzibarExamplesExampleGatewayBuildClien
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"AuthCode\":")
+	out.RawString("\"authCode\":")
 	out.String(string(in.AuthCode))
 	out.RawByte('}')
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs.go
@@ -18,16 +18,16 @@ func getDirName() string {
 
 // ArgNotStructHTTPRequest is the http body type for endpoint argNotStruct.
 type ArgNotStructHTTPRequest struct {
-	Request string
+	Request string `json:"request"`
 }
 
 // NormalHTTPRequest is the http body type for endpoint normal.
 type NormalHTTPRequest struct {
-	Request *endpointsBarBar.BarRequest
+	Request *endpointsBarBar.BarRequest `json:"request"`
 }
 
 // TooManyArgsHTTPRequest is the http body type for endpoint tooManyArgs.
 type TooManyArgsHTTPRequest struct {
-	Request *endpointsBarBar.BarRequest
-	Foo     *endpointsFooFoo.FooStruct
+	Request *endpointsBarBar.BarRequest `json:"request"`
+	Foo     *endpointsFooFoo.FooStruct  `json:"foo"`
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_structs_easyjson.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_structs_easyjson.go
@@ -40,7 +40,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			if in.IsNull() {
 				in.Skip()
 				out.Request = nil
@@ -50,7 +50,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 				}
 				(*out.Request).UnmarshalEasyJSON(in)
 			}
-		case "Foo":
+		case "foo":
 			if in.IsNull() {
 				in.Skip()
 				out.Foo = nil
@@ -78,7 +78,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	if in.Request == nil {
 		out.RawString("null")
 	} else {
@@ -88,7 +88,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Foo\":")
+	out.RawString("\"foo\":")
 	if in.Foo == nil {
 		out.RawString("null")
 	} else {
@@ -139,7 +139,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			if in.IsNull() {
 				in.Skip()
 				out.Request = nil
@@ -167,7 +167,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	if in.Request == nil {
 		out.RawString("null")
 	} else {
@@ -218,7 +218,7 @@ func easyjsonCa6a3ed2DecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 			continue
 		}
 		switch key {
-		case "Request":
+		case "request":
 			out.Request = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -238,7 +238,7 @@ func easyjsonCa6a3ed2EncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Request\":")
+	out.RawString("\"request\":")
 	out.String(string(in.Request))
 	out.RawByte('}')
 }

--- a/examples/example-gateway/build/endpoints/baz/baz_structs.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_structs.go
@@ -17,5 +17,5 @@ func getDirName() string {
 
 // CallHTTPRequest is the http body type for endpoint Call.
 type CallHTTPRequest struct {
-	Arg *endpointsBazBaz.BazRequest
+	Arg *endpointsBazBaz.BazRequest `json:"arg"`
 }

--- a/examples/example-gateway/build/endpoints/baz/baz_structs_easyjson.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_structs_easyjson.go
@@ -39,7 +39,7 @@ func easyjson62ef335aDecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 			continue
 		}
 		switch key {
-		case "Arg":
+		case "arg":
 			if in.IsNull() {
 				in.Skip()
 				out.Arg = nil
@@ -67,7 +67,7 @@ func easyjson62ef335aEncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"Arg\":")
+	out.RawString("\"arg\":")
 	if in.Arg == nil {
 		out.RawString("null")
 	} else {

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_structs.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_structs.go
@@ -16,5 +16,5 @@ func getDirName() string {
 
 // AddCredentialsHTTPRequest is the http body type for endpoint addCredentials.
 type AddCredentialsHTTPRequest struct {
-	AuthCode string
+	AuthCode string `json:"authCode"`
 }

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_structs_easyjson.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_structs_easyjson.go
@@ -38,7 +38,7 @@ func easyjson5cf1a88aDecodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 			continue
 		}
 		switch key {
-		case "AuthCode":
+		case "authCode":
 			out.AuthCode = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -58,7 +58,7 @@ func easyjson5cf1a88aEncodeGithubComUberZanzibarExamplesExampleGatewayBuildEndpo
 		out.RawByte(',')
 	}
 	first = false
-	out.RawString("\"AuthCode\":")
+	out.RawString("\"authCode\":")
 	out.String(string(in.AuthCode))
 	out.RawByte('}')
 }

--- a/examples/example-gateway/endpoints/baz/baz_simpleservice_method_call_test.go
+++ b/examples/example-gateway/endpoints/baz/baz_simpleservice_method_call_test.go
@@ -74,7 +74,7 @@ func TestCallSuccessfulRequestOKResponse(t *testing.T) {
 		"POST",
 		"/baz/call-path",
 		headers,
-		bytes.NewReader([]byte(`{"Arg":{"b1":true,"s2":"hello","i3":42}}`)),
+		bytes.NewReader([]byte(`{"arg":{"b1":true,"s2":"hello","i3":42}}`)),
 	)
 
 	if !assert.NoError(t, err, "got http error") {

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -40,7 +40,8 @@ for file in "${FILES_ARR[@]}"; do
 	RAND=$(hexdump -n 8 -v -e '/1 "%02X"' /dev/urandom)
 	COVERNAME="./coverage/cover-unit-$RAND.out"
 
-	COVER_ON=1 go test -cover -coverprofile coverage.tmp $file 2>&1 | \
+	COVER_ON=1 ZANZIBAR_CACHE=1 go test \
+		-cover -coverprofile coverage.tmp $file 2>&1 | \
 		tee test.tmp.out >>test.out && \
 		mv coverage.tmp "$COVERNAME" 2>/dev/null || true
 

--- a/test/lib/test_gateway/test_gateway_cover.go
+++ b/test/lib/test_gateway/test_gateway_cover.go
@@ -153,7 +153,7 @@ func createTestBinaryFile(
 	mainPath string,
 	config map[string]interface{},
 ) (*testBinaryInfo, error) {
-	if cachedBinaryFile == nil {
+	if os.Getenv("ZANZIBAR_CACHE") == "1" && cachedBinaryFile == nil {
 		// Try to load cachedBinaryFile from disk
 		tryLoadCachedBinaryTestInfo(mainPath)
 	}
@@ -227,6 +227,8 @@ func createTestBinaryFile(
 		CoverProfileFile: coverProfileFile,
 		MainFile:         mainPath,
 	}
-	tryWriteCachedBinaryTestInfo()
+	if os.Getenv("ZANZIBAR_CACHE") == "1" {
+		tryWriteCachedBinaryTestInfo()
+	}
 	return cachedBinaryFile, nil
 }


### PR DESCRIPTION
This PR makes the status code validation in the client
mandatory even if there are no exceptions of response body.

This means that if the client returns an unexpected status
code the client will return an error and the endpoint handler
will write a 500 to the caller of edge-gateway

Also cleaned up some things :

 - templates/structs: add json annotations
 - Fix some tests
 - Make testing cache optional

r: @uber/zanzibar-team