### PR TITLE
Lint .json and .tmpl files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{tmpl,json}]
+indent_style = tab
+tab_width = 4

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-
-
 PKGS = $(shell glide novendor)
 PKG_FILES = benchmarks codegen examples runtime test
 
@@ -20,12 +18,12 @@ PROGS = examples/example-gateway/build/example-gateway \
 
 .PHONY: check-licence
 check-licence:
-	ls ./node_modules/.bin/uber-licence 2>/dev/null || npm i uber-licence
+	ls ./node_modules/.bin/uber-licence >/dev/null 2>&1 || npm i uber-licence
 	./node_modules/.bin/uber-licence --dry --file '*.go' --dir '!vendor' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
 
 .PHONY: fix-licence
 fix-licence:
-	ls ./node_modules/.bin/uber-licence 2>/dev/null || npm i uber-licence
+	ls ./node_modules/.bin/uber-licence >/dev/null 2>&1 || npm i uber-licence
 	./node_modules/.bin/uber-licence --file '*.go' --dir '!vendor' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
 
 .PHONY: install
@@ -36,8 +34,18 @@ install:
 	glide --version || go get -u -f github.com/Masterminds/glide
 	glide install
 
+.PHONY: eclint-check
+eclint-check:
+	ls ./node_modules/.bin/eclint >/dev/null 2>&1 || npm i eclint@v1.1.5
+	./node_modules/.bin/eclint check "./{codegen,example}/**/*.{json,tmpl}"
+
+.PHONY: eclint-fix
+eclint-fix:
+	ls ./node_modules/.bin/eclint >/dev/null 2>&1 || npm i eclint@v1.1.5
+	./node_modules/.bin/eclint fix "./{codegen,example}/**/*.{json,tmpl}"
+
 .PHONY: lint
-lint: check-licence
+lint: check-licence eclint-check
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -8,7 +8,7 @@ import (
 	"runtime"
 
 	"go.uber.org/zap"
-    "github.com/uber/zanzibar/runtime"
+	"github.com/uber/zanzibar/runtime"
 	{{range $idx, $pkg := .IncludedPackages -}}
 	{{$pkg.AliasName}} "{{$pkg.PackageName}}"
 	{{end}}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -23,48 +23,48 @@ import (
 // TChan{{title $clientID}} is the interface that defines the server handler and client interface.
 type TChan{{title $clientID}} interface {
 	{{range .Methods}}
-	    {{if and (eq .RequestType "") (eq .ResponseType "")}}
-		    {{- .Name}}(
-		        ctx context.Context,
-		        reqHeaders map[string]string,
-		    ) (
-		        map[string]string,
-		        error,
-		    )
-	    {{else if eq .RequestType ""}}
-		    {{- .Name}}(
-		        ctx context.Context,
-		        reqHeaders map[string]string,
-		    ) (
-		        *{{.ResponseType}},
-		        map[string]string,
-		        error,
-		    )
-	    {{else if eq .ResponseType ""}}
-		    {{- .Name}}(
-		        ctx context.Context,
-		        reqHeaders map[string]string,
-		        args *{{.RequestType}},
-		    ) (
-		        map[string]string, error,
-		    )
+		{{if and (eq .RequestType "") (eq .ResponseType "")}}
+			{{- .Name}}(
+				ctx context.Context,
+				reqHeaders map[string]string,
+			) (
+				map[string]string,
+				error,
+			)
+		{{else if eq .RequestType ""}}
+			{{- .Name}}(
+				ctx context.Context,
+				reqHeaders map[string]string,
+			) (
+				*{{.ResponseType}},
+				map[string]string,
+				error,
+			)
+		{{else if eq .ResponseType ""}}
+			{{- .Name}}(
+				ctx context.Context,
+				reqHeaders map[string]string,
+				args *{{.RequestType}},
+			) (
+				map[string]string, error,
+			)
 		{{else}}
-		    {{- .Name}}(
-		        ctx context.Context,
-		        reqHeaders map[string]string,
-		        args *{{.RequestType}},
-		    ) (
-		        *{{.ResponseType}},
-		        map[string]string,
-		        error,
-		    )
+			{{- .Name}}(
+				ctx context.Context,
+				reqHeaders map[string]string,
+				args *{{.RequestType}},
+			) (
+				*{{.ResponseType}},
+				map[string]string,
+				error,
+			)
 		{{end}}
 	{{end -}}
 }
 
 // NewClient returns a new TChannel client for service {{$clientID}}.
 func NewClient(gateway *zanzibar.Gateway) *{{$clientName}} {
-    {{- /* this is the service discovery service name */}}
+	{{- /* this is the service discovery service name */}}
 	serviceName := gateway.Config.MustGetString("clients.{{$clientID}}.serviceName")
 	sc := gateway.Channel.GetSubChannel(serviceName)
 
@@ -74,10 +74,10 @@ func NewClient(gateway *zanzibar.Gateway) *{{$clientName}} {
 
 	{{/* TODO: (lu) maybe set these at per method level */ -}}
 	timeout := time.Millisecond * time.Duration(
-	    gateway.Config.MustGetInt("clients.{{$clientID}}.timeout"),
+		gateway.Config.MustGetInt("clients.{{$clientID}}.timeout"),
 	)
 	timeoutPerAttempt := time.Millisecond * time.Duration(
-	    gateway.Config.MustGetInt("clients.{{$clientID}}.timeoutPerAttempt"),
+		gateway.Config.MustGetInt("clients.{{$clientID}}.timeoutPerAttempt"),
 	)
 
 	client := zanzibar.NewTChannelClient(gateway.Channel,
@@ -89,7 +89,7 @@ func NewClient(gateway *zanzibar.Gateway) *{{$clientName}} {
 	)
 
 	return &{{$clientName}}{
-    	{{- /* this is the thrift service name, different from service discovery service name */}}
+		{{- /* this is the thrift service name, different from service discovery service name */}}
 		thriftService: "{{$svc.Name}}",
 		client:        client,
 	}
@@ -102,126 +102,126 @@ type {{$clientName}} struct {
 }
 
 {{range .Methods}}
-    {{- if and (eq .RequestType "") (eq .ResponseType "")}}
-        // {{.Name}} ...
-        func (c *{{$clientName}}) {{.Name}}(
-            ctx context.Context,
-            reqHeaders map[string]string,
-            ) (map[string]string, error) {
-            var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
+	{{- if and (eq .RequestType "") (eq .ResponseType "")}}
+		// {{.Name}} ...
+		func (c *{{$clientName}}) {{.Name}}(
+			ctx context.Context,
+			reqHeaders map[string]string,
+			) (map[string]string, error) {
+			var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
 
-            args := &{{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Args{}
-	        success, respHeaders, err := c.client.Call(
-	            ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
-	        )
+			args := &{{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Args{}
+			success, respHeaders, err := c.client.Call(
+				ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
+			)
 
-	        if err == nil && !success {
-		        switch {
-		            {{range .Exceptions -}}
-		            case result.{{.Name}} != nil:
-			            err = result.{{.Name}}
-		            {{end -}}
-		            default:
-			            err = errors.New("received no result or unknown exception for {{$svc.Name}}")
-		        }
-	        }
-	        if err != nil {
-	            return nil, err
-	        }
+			if err == nil && !success {
+				switch {
+					{{range .Exceptions -}}
+					case result.{{.Name}} != nil:
+						err = result.{{.Name}}
+					{{end -}}
+					default:
+						err = errors.New("received no result or unknown exception for {{$svc.Name}}")
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
 
-		    return respHeaders, err
-        }
-    {{- else if eq .RequestType ""}}
-        // {{.Name}} ...
-        func (c *{{$clientName}}) {{.Name}}(
-            ctx context.Context,
-            reqHeaders map[string]string,
-        ) (*{{.ResponseType}}, map[string]string, error) {
-            var result {{.ResponseType}}
+			return respHeaders, err
+		}
+	{{- else if eq .RequestType ""}}
+		// {{.Name}} ...
+		func (c *{{$clientName}}) {{.Name}}(
+			ctx context.Context,
+			reqHeaders map[string]string,
+		) (*{{.ResponseType}}, map[string]string, error) {
+			var result {{.ResponseType}}
 
-            args := &{{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Args{}
-	        success, respHeaders, err := c.client.Call(
-	            ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
-	        )
+			args := &{{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Args{}
+			success, respHeaders, err := c.client.Call(
+				ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
+			)
 
-	        if err == nil && !success {
-		        switch {
-		            {{range .Exceptions -}}
-		            case result.{{.Name}} != nil:
-			            err = result.{{.Name}}
-		            {{end -}}
-		            default:
-			            err = errors.New("received no result or unknown exception for {{.Name}}")
-		        }
-	        }
-	        if err != nil {
-	            return nil, nil, err
-	        }
+			if err == nil && !success {
+				switch {
+					{{range .Exceptions -}}
+					case result.{{.Name}} != nil:
+						err = result.{{.Name}}
+					{{end -}}
+					default:
+						err = errors.New("received no result or unknown exception for {{.Name}}")
+				}
+			}
+			if err != nil {
+				return nil, nil, err
+			}
 
-	        resp, err := {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Helper.UnwrapResponse(&result)
+			resp, err := {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Helper.UnwrapResponse(&result)
 
-		    return resp, respHeaders, err
-        }
-    {{- else if eq .ResponseType ""}}
-        // {{.Name}} ...
-        func (c *{{$clientName}}) {{.Name}}(
-	        ctx context.Context,
-	        reqHeaders map[string]string,
-	        args *{{.RequestType}},
-	    ) (map[string]string, error) {
-            var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
+			return resp, respHeaders, err
+		}
+	{{- else if eq .ResponseType ""}}
+		// {{.Name}} ...
+		func (c *{{$clientName}}) {{.Name}}(
+			ctx context.Context,
+			reqHeaders map[string]string,
+			args *{{.RequestType}},
+		) (map[string]string, error) {
+			var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
 
-	        success, respHeaders, err := c.client.Call(
-	            ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
-	        )
+			success, respHeaders, err := c.client.Call(
+				ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
+			)
 
-	        if err == nil && !success {
-		        switch {
-		        {{range .Exceptions -}}
-		            case result.{{.Name}} != nil:
-			            err = result.{{.Name}}
-		        {{end -}}
-		            default:
-			            err = errors.New("received no result or unknown exception for {{.Name}}")
-		        }
-	        }
-	        if err != nil {
-	            return nil, err
-	        }
+			if err == nil && !success {
+				switch {
+				{{range .Exceptions -}}
+					case result.{{.Name}} != nil:
+						err = result.{{.Name}}
+				{{end -}}
+					default:
+						err = errors.New("received no result or unknown exception for {{.Name}}")
+				}
+			}
+			if err != nil {
+				return nil, err
+			}
 
-		    return respHeaders, err
-        }
+			return respHeaders, err
+		}
 	{{- else}}
-        // {{.Name}} ...
-	    func (c *{{$clientName}}) {{.Name}}(
-	        ctx context.Context,
-	        reqHeaders map[string]string,
-	        args *{{.RequestType}},
-	    ) (*{{.ResponseType}}, map[string]string, error) {
-            var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
+		// {{.Name}} ...
+		func (c *{{$clientName}}) {{.Name}}(
+			ctx context.Context,
+			reqHeaders map[string]string,
+			args *{{.RequestType}},
+		) (*{{.ResponseType}}, map[string]string, error) {
+			var result {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Result
 
-	        success, respHeaders, err := c.client.Call(
-	            ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
-	        )
+			success, respHeaders, err := c.client.Call(
+				ctx, c.thriftService, "{{.Name}}", reqHeaders, args, &result,
+			)
 
-	        if err == nil && !success {
-		        switch {
-		            {{range .Exceptions -}}
-		            case result.{{.Name}} != nil:
-			            err = result.{{.Name}}
-		            {{end -}}
-		            default:
-			            err = errors.New("received no result or unknown exception for {{.Name}}")
-		        }
-	        }
-	        if err != nil {
-	            return nil, nil, err
-	        }
+			if err == nil && !success {
+				switch {
+					{{range .Exceptions -}}
+					case result.{{.Name}} != nil:
+						err = result.{{.Name}}
+					{{end -}}
+					default:
+						err = errors.New("received no result or unknown exception for {{.Name}}")
+				}
+			}
+			if err != nil {
+				return nil, nil, err
+			}
 
-	        resp, err := {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Helper.UnwrapResponse(&result)
+			resp, err := {{.GenCodePkgName}}.{{$svc.Name}}_{{.Name}}_Helper.UnwrapResponse(&result)
 
-		    return resp, respHeaders, err
-        }
+			return resp, respHeaders, err
+		}
 	{{- end}}
 {{end -}}
 {{end}}

--- a/codegen/templates/tchannel_handler.tmpl
+++ b/codegen/templates/tchannel_handler.tmpl
@@ -19,80 +19,80 @@ import (
 // {{$handler}} is the handler struct for TChannel service {{$svc.Name}}.
 type {{$handler}} struct {
 	{{range .Methods -}}
-	    {{.Name}}Func {{$svc.Name}}{{.Name}}Func
+		{{.Name}}Func {{$svc.Name}}{{.Name}}Func
 	{{end -}}
 }
 
 {{range .Methods -}}
-    {{- $func := printf "%s%sFunc" $svc.Name .Name -}}
-    // {{$func}} ...
-    {{- if and (eq .RequestType "") (eq .ResponseType "")}}
-        type {{$func}} func(
-            context.Context, map[string]string,
-        ) (map[string]string, error)
-    {{- else if eq .RequestType ""}}
-        type {{$func}} func(
-            context.Context, map[string]string,
-        ) (*{{.ResponseType}}, map[string]string, error)
-    {{- else if eq .ResponseType ""}}
-        type {{$func}} func(
-            context.Context, map[string]string, *{{.RequestType}},
-            ) (map[string]string, error)
+	{{- $func := printf "%s%sFunc" $svc.Name .Name -}}
+	// {{$func}} ...
+	{{- if and (eq .RequestType "") (eq .ResponseType "")}}
+		type {{$func}} func(
+			context.Context, map[string]string,
+		) (map[string]string, error)
+	{{- else if eq .RequestType ""}}
+		type {{$func}} func(
+			context.Context, map[string]string,
+		) (*{{.ResponseType}}, map[string]string, error)
+	{{- else if eq .ResponseType ""}}
+		type {{$func}} func(
+			context.Context, map[string]string, *{{.RequestType}},
+			) (map[string]string, error)
 	{{- else}}
-        type {{$func}} func(
-            context.Context, map[string]string, *{{.RequestType}},
-        ) (*{{.ResponseType}}, map[string]string, error)
+		type {{$func}} func(
+			context.Context, map[string]string, *{{.RequestType}},
+		) (*{{.ResponseType}}, map[string]string, error)
 	{{- end}}
 {{end -}}
 
 {{range .Methods -}}
-    {{- $type := printf "%s%sFunc" $svc.Name .Name -}}
-    // NewServerWith{{$svc.Name}}{{.Name}} creates a TChanServer with given handler function registered.
-    func NewServerWith{{$svc.Name}}{{.Name}}(arg {{$type}}) zanzibar.TChanServer {
-        return New{{$svc.Name}}Server(&{{$svc.Name}}Handler{
-            {{.Name}}Func: arg,
-        })
-    }
+	{{- $type := printf "%s%sFunc" $svc.Name .Name -}}
+	// NewServerWith{{$svc.Name}}{{.Name}} creates a TChanServer with given handler function registered.
+	func NewServerWith{{$svc.Name}}{{.Name}}(arg {{$type}}) zanzibar.TChanServer {
+		return New{{$svc.Name}}Server(&{{$svc.Name}}Handler{
+			{{.Name}}Func: arg,
+		})
+	}
 {{end -}}
 
 {{range .Methods -}}
-    // {{.Name}} ...
-    {{- if and (eq .RequestType "") (eq .ResponseType "")}}
-        func (h *{{$handler}}) {{.Name}}(
-            ctx context.Context, reqHeaders map[string]string,
-        ) (map[string]string, error) {
-            if h.{{.Name}}Func == nil {
-                return nil, errors.New("{{.Name}}Func is not defined")
-            }
-            return h.{{.Name}}Func(ctx, reqHeaders)
-        }
-    {{- else if eq .RequestType ""}}
-        func (h *{{$handler}}) {{.Name}}(
-            ctx context.Context, reqHeaders map[string]string,
-        ) (*{{.ResponseType}}, map[string]string, error) {
-            if h.{{.Name}}Func == nil {
-                return nil, nil, errors.New("{{.Name}}Func is not defined")
-            }
-            return h.{{.Name}}Func(ctx, reqHeaders)
-        }
-    {{- else if eq .ResponseType ""}}
-        func (h *{{$handler}}) {{.Name}}(
-            ctx context.Context, reqHeaders map[string]string, args *{{.RequestType}},
-        ) (map[string]string, error) {
-            if h.{{.Name}}Func == nil {
-                return nil, errors.New("{{.Name}}Func is not defined")
-            }
-            return h.{{.Name}}Func(ctx, reqHeaders, args)
-        }
+	// {{.Name}} ...
+	{{- if and (eq .RequestType "") (eq .ResponseType "")}}
+		func (h *{{$handler}}) {{.Name}}(
+			ctx context.Context, reqHeaders map[string]string,
+		) (map[string]string, error) {
+			if h.{{.Name}}Func == nil {
+				return nil, errors.New("{{.Name}}Func is not defined")
+			}
+			return h.{{.Name}}Func(ctx, reqHeaders)
+		}
+	{{- else if eq .RequestType ""}}
+		func (h *{{$handler}}) {{.Name}}(
+			ctx context.Context, reqHeaders map[string]string,
+		) (*{{.ResponseType}}, map[string]string, error) {
+			if h.{{.Name}}Func == nil {
+				return nil, nil, errors.New("{{.Name}}Func is not defined")
+			}
+			return h.{{.Name}}Func(ctx, reqHeaders)
+		}
+	{{- else if eq .ResponseType ""}}
+		func (h *{{$handler}}) {{.Name}}(
+			ctx context.Context, reqHeaders map[string]string, args *{{.RequestType}},
+		) (map[string]string, error) {
+			if h.{{.Name}}Func == nil {
+				return nil, errors.New("{{.Name}}Func is not defined")
+			}
+			return h.{{.Name}}Func(ctx, reqHeaders, args)
+		}
 	{{- else}}
-	    func (h *{{$handler}}) {{.Name}}(
-            ctx context.Context, reqHeaders map[string]string, args *{{.RequestType}},
-        ) (*{{.ResponseType}}, map[string]string, error) {
-            if h.{{.Name}}Func == nil {
-                return nil, nil, errors.New("{{.Name}}Func is not defined")
-            }
-            return h.{{.Name}}Func(ctx, reqHeaders, args)
-        }
+		func (h *{{$handler}}) {{.Name}}(
+			ctx context.Context, reqHeaders map[string]string, args *{{.RequestType}},
+		) (*{{.ResponseType}}, map[string]string, error) {
+			if h.{{.Name}}Func == nil {
+				return nil, nil, errors.New("{{.Name}}Func is not defined")
+			}
+			return h.{{.Name}}Func(ctx, reqHeaders, args)
+		}
 	{{- end}}
 {{end -}}
 

--- a/codegen/templates/tchannel_server.tmpl
+++ b/codegen/templates/tchannel_server.tmpl
@@ -23,7 +23,7 @@ import (
 {{$server := $svc.Name | printf "%sServer"}}
 // {{$server}} is the TChannel backend for {{$svc.Name}} service.
 type {{$server}} struct {
-    handler {{$interface}}
+	handler {{$interface}}
 }
 
 // New{{$server}} wraps a handler for {{title $clientID}} so it can be registered with a thrift server.
@@ -42,26 +42,26 @@ func (s *{{$server}}) Service() string {
 func (s *{{$server}}) Methods() []string {
 	return []string{
 	{{range .Methods -}}
-	    "{{.Name}}",
+		"{{.Name}}",
 	{{end -}}
 	}
 }
 
 // Handle dispatches a method call to corresponding handler.
 func (s *{{$server}}) Handle(
-    ctx context.Context,
-    methodName string,
-    reqHeaders map[string]string,
-    wireValue *wire.Value,
+	ctx context.Context,
+	methodName string,
+	reqHeaders map[string]string,
+	wireValue *wire.Value,
 ) (bool, zanzibar.RWTStruct, map[string]string, error) {
 	switch methodName {
 	{{range .Methods -}}
-	    case "{{.Name}}":
-		    return s.handle{{.Name}}(ctx, reqHeaders, wireValue)
+		case "{{.Name}}":
+			return s.handle{{.Name}}(ctx, reqHeaders, wireValue)
 	{{end -}}
 	default:
 		return false, nil, nil, fmt.Errorf(
-		    "method %v not found in service %v", methodName, s.Service(),
+			"method %v not found in service %v", methodName, s.Service(),
 		)
 	}
 }
@@ -69,9 +69,9 @@ func (s *{{$server}}) Handle(
 {{range .Methods}}
 {{$genCodePkg := .GenCodePkgName -}}
 func (s *{{$server}}) handle{{.Name}}(
-    ctx context.Context,
-    reqHeaders map[string]string,
-    wireValue *wire.Value,
+	ctx context.Context,
+	reqHeaders map[string]string,
+	wireValue *wire.Value,
 ) (bool, zanzibar.RWTStruct, map[string]string, error) {
 	var req {{$genCodePkg}}.{{$svc.Name}}_{{.Name}}_Args
 	var res {{$genCodePkg}}.{{$svc.Name}}_{{.Name}}_Result
@@ -80,40 +80,40 @@ func (s *{{$server}}) handle{{.Name}}(
 		return false, nil, nil, err
 	}
 
-    {{- if and (eq .RequestType "") (eq .ResponseType "")}}
-	    respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders)
-    {{- else if eq .RequestType ""}}
-	    r, respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
-    {{- else if eq .ResponseType ""}}
-	    respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
+	{{- if and (eq .RequestType "") (eq .ResponseType "")}}
+		respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders)
+	{{- else if eq .RequestType ""}}
+		r, respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
+	{{- else if eq .ResponseType ""}}
+		respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
 	{{- else}}
-	    r, respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
+		r, respHeaders, err := s.handler.{{.Name}}(ctx, reqHeaders, &req)
 	{{- end}}
 
 	{{if eq (len .Exceptions) 0 -}}
-	    if err != nil {
-            return false, nil, nil, err
-	    }
-	    res.Success = r
-    {{else -}}
-	    if err != nil {
-	        switch v := err.(type) {
-		    {{range .Exceptions -}}
-		        case *{{$genCodePkg}}.{{.Name}}:
-		            if v == nil {
-		                return false, nil, nil, errors.New(
-		                    "Handler for {{.Name}} returned non-nil error type *{{.Name}} but nil value",
-		                )
-		            }
-		            res.{{.Name}} = v
-            {{end -}}
-		        default:
-		            return false, nil, nil, err
-            }
-        } {{if ne .ResponseType "" -}} else {
-            res.Success = r
-        } {{end -}}
-    {{end}}
+		if err != nil {
+			return false, nil, nil, err
+		}
+		res.Success = r
+	{{else -}}
+		if err != nil {
+			switch v := err.(type) {
+			{{range .Exceptions -}}
+				case *{{$genCodePkg}}.{{.Name}}:
+					if v == nil {
+						return false, nil, nil, errors.New(
+							"Handler for {{.Name}} returned non-nil error type *{{.Name}} but nil value",
+						)
+					}
+					res.{{.Name}} = v
+			{{end -}}
+				default:
+					return false, nil, nil, err
+			}
+		} {{if ne .ResponseType "" -}} else {
+			res.Success = r
+		} {{end -}}
+	{{end}}
 
 	return err == nil, &res, respHeaders, nil
 }

--- a/codegen/test_data/test-configs/bar/argnotstruct_test.json
+++ b/codegen/test_data/test-configs/bar/argnotstruct_test.json
@@ -1,14 +1,14 @@
 [{
-    "testName": "successfulRequest",
-    "endpointId": "bar",
-    "handlerId": "argNotStruct",
-    "endpointRequest": "{}",
-    "endpointResponse": "{}",
+	"testName": "successfulRequest",
+	"endpointId": "bar",
+	"handlerId": "argNotStruct",
+	"endpointRequest": "{}",
+	"endpointResponse": "{}",
 
-    "clientStubs": [{
-        "clientId": "bar",
-        "clientMethod": "argNotStruct",
-        "clientRequest": "{}",
-        "clientResponse": "{}"
-    }]
+	"clientStubs": [{
+		"clientId": "bar",
+		"clientMethod": "argNotStruct",
+		"clientRequest": "{}",
+		"clientResponse": "{}"
+	}]
 }]

--- a/codegen/test_data/test-configs/bar/missingarg_test.json
+++ b/codegen/test_data/test-configs/bar/missingarg_test.json
@@ -1,14 +1,14 @@
 [{
-    "testName": "successfulRequest",
-    "endpointId": "bar",
-    "handlerId": "missingArg",
-    "endpointRequest": "{}",
-    "endpointResponse": "{}",
+	"testName": "successfulRequest",
+	"endpointId": "bar",
+	"handlerId": "missingArg",
+	"endpointRequest": "{}",
+	"endpointResponse": "{}",
 
-    "clientStubs": [{
-        "clientId": "bar",
-        "clientMethod": "missingArg",
-        "clientRequest": "{}",
-        "clientResponse": "{}"
-    }]
+	"clientStubs": [{
+		"clientId": "bar",
+		"clientMethod": "missingArg",
+		"clientRequest": "{}",
+		"clientResponse": "{}"
+	}]
 }]

--- a/codegen/test_data/test-configs/bar/norequest_test.json
+++ b/codegen/test_data/test-configs/bar/norequest_test.json
@@ -1,14 +1,14 @@
 [{
-    "testName": "successfulRequest",
-    "endpointId": "bar",
-    "handlerId": "noRequest",
-    "endpointRequest": "{}",
-    "endpointResponse": "{}",
+	"testName": "successfulRequest",
+	"endpointId": "bar",
+	"handlerId": "noRequest",
+	"endpointRequest": "{}",
+	"endpointResponse": "{}",
 
-    "clientStubs": [{
-        "clientId": "bar",
-        "clientMethod": "noRequest",
-        "clientRequest": "{}",
-        "clientResponse": "{}"
-    }]
+	"clientStubs": [{
+		"clientId": "bar",
+		"clientMethod": "noRequest",
+		"clientRequest": "{}",
+		"clientResponse": "{}"
+	}]
 }]

--- a/codegen/test_data/test-configs/bar/normal_test.json
+++ b/codegen/test_data/test-configs/bar/normal_test.json
@@ -1,14 +1,14 @@
 [{
-    "testName": "successfulRequest",
-    "endpointId": "bar",
-    "handlerId": "normal",
-    "endpointRequest": "{}",
-    "endpointResponse": "{}",
+	"testName": "successfulRequest",
+	"endpointId": "bar",
+	"handlerId": "normal",
+	"endpointRequest": "{}",
+	"endpointResponse": "{}",
 
-    "clientStubs": [{
-        "clientId": "bar",
-        "clientMethod": "normal",
-        "clientRequest": "{}",
-        "clientResponse": "{}"
-    }]
+	"clientStubs": [{
+		"clientId": "bar",
+		"clientMethod": "normal",
+		"clientRequest": "{}",
+		"clientResponse": "{}"
+	}]
 }]

--- a/codegen/test_data/test-configs/bar/toomanyargs_test.json
+++ b/codegen/test_data/test-configs/bar/toomanyargs_test.json
@@ -1,14 +1,14 @@
 [{
-    "testName": "successfulRequest",
-    "endpointId": "bar",
-    "handlerId": "tooManyArgs",
-    "endpointRequest": "{}",
-    "endpointResponse": "{}",
+	"testName": "successfulRequest",
+	"endpointId": "bar",
+	"handlerId": "tooManyArgs",
+	"endpointRequest": "{}",
+	"endpointResponse": "{}",
 
-    "clientStubs": [{
-        "clientId": "bar",
-        "clientMethod": "tooManyArgs",
-        "clientRequest": "{}",
-        "clientResponse": "{}"
-    }]
+	"clientStubs": [{
+		"clientId": "bar",
+		"clientMethod": "tooManyArgs",
+		"clientRequest": "{}",
+		"clientResponse": "{}"
+	}]
 }]


### PR DESCRIPTION
This PR adds linting for .json and .tmpl files to fix the issue of missing tabs/spaces.
The indentation rule is defined in `./.editorconfig` file, which instructs your editor how to indentate specified files automatically.
If you use vim/vscode/sublime, you will need install a [plugin](http://editorconfig.org/#download) for it to work.