### PR TITLE
Add go benchmark tests to baz endpoints

### DIFF
--- a/test/endpoints/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_call_test.go
@@ -30,9 +30,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	bazServer "github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/baz"
 )
 
@@ -85,4 +88,49 @@ func TestCallSuccessfulRequestOKResponse(t *testing.T) {
 
 	assert.Equal(t, 1, testCallCounter)
 	assert.Equal(t, "204 No Content", res.Status)
+}
+
+func BenchmarkCall(b *testing.B) {
+	gateway, err := benchGateway.CreateGateway(
+		map[string]interface{}{
+			"clients.baz.serviceName": "Qux",
+		},
+		&testGateway.Options{
+			KnownTChannelBackends: []string{"baz"},
+		},
+		clients.CreateClients,
+		endpoints.Register,
+	)
+	if err != nil {
+		b.Error("got bootstrap err: " + err.Error())
+		return
+	}
+
+	gateway.TChannelBackends()["baz"].Register(
+		"SimpleService",
+		"Call",
+		bazServer.NewSimpleServiceCallHandler(call),
+	)
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			res, err := gateway.MakeRequest(
+				"POST", "/baz/call", nil,
+				bytes.NewReader([]byte(`{"arg":{"b1":true,"s2":"hello","i3":42}}`)),
+			)
+			if err != nil {
+				b.Error("got http error: " + err.Error())
+				break
+			}
+			if res.Status != "204 No Content" {
+				b.Error("got bad status error: " + res.Status)
+				break
+			}
+		}
+	})
+
+	b.StopTimer()
+	gateway.Close()
 }

--- a/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
@@ -29,9 +29,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
 	bazServer "github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
+	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
 )
 
 var testSillyNoopCounter int
@@ -78,4 +81,49 @@ func TestSillyNoopFutureSuccessfulRequestOKResponse(t *testing.T) {
 
 	assert.Equal(t, 1, testSillyNoopCounter)
 	assert.Equal(t, "204 No Content", res.Status)
+}
+
+func BenchmarkSillyNoop(b *testing.B) {
+	gateway, err := benchGateway.CreateGateway(
+		map[string]interface{}{
+			"clients.baz.serviceName": "Qux",
+		},
+		&testGateway.Options{
+			KnownTChannelBackends: []string{"baz"},
+		},
+		clients.CreateClients,
+		endpoints.Register,
+	)
+	if err != nil {
+		b.Error("got bootstrap err: " + err.Error())
+		return
+	}
+
+	gateway.TChannelBackends()["baz"].Register(
+		"SimpleService",
+		"SillyNoop",
+		bazServer.NewSimpleServiceSillyNoopHandler(sillyNoop),
+	)
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			res, err := gateway.MakeRequest(
+				"GET", "/baz/silly-noop", nil,
+				bytes.NewReader([]byte(`{}`)),
+			)
+			if err != nil {
+				b.Error("got http error: " + err.Error())
+				break
+			}
+			if res.Status != "204 No Content" {
+				b.Error("got bad status error: " + res.Status)
+				break
+			}
+		}
+	})
+
+	b.StopTimer()
+	gateway.Close()
 }

--- a/test/endpoints/contacts/save-contacts_test.go
+++ b/test/endpoints/contacts/save-contacts_test.go
@@ -79,7 +79,7 @@ func BenchmarkSaveContacts(b *testing.B) {
 
 			_, err = ioutil.ReadAll(res.Body)
 			if err != nil {
-				b.Error("could not write response: " + res.Status)
+				b.Error("could not read response: " + res.Status)
 				break
 			}
 			_ = res.Body.Close()


### PR DESCRIPTION
```bash
➜  zanzibar git:(lu.bench) go test -v ./test/endpoints/baz -bench . -run ^BenchMark.*$
{"level":"info","ts":1493086224.0435946,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":2,"service":"bench-gateway","process":"bench-gateway","connID":2,"localAddr":"127.0.0.1:55821","remoteAddr":"127.0.0.1:55817","remoteHostPort":"127.0.0.1:55817","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55817","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
BenchmarkCall-8        	{"level":"info","ts":1493086224.0506685,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":4,"service":"bench-gateway","process":"bench-gateway","connID":3,"localAddr":"127.0.0.1:55833","remoteAddr":"127.0.0.1:55822","remoteHostPort":"127.0.0.1:55822","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55822","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086224.0638263,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":6,"service":"bench-gateway","process":"bench-gateway","connID":5,"localAddr":"127.0.0.1:55845","remoteAddr":"127.0.0.1:55834","remoteHostPort":"127.0.0.1:55834","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55834","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086224.7132769,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":8,"service":"bench-gateway","process":"bench-gateway","connID":8,"localAddr":"127.0.0.1:55857","remoteAddr":"127.0.0.1:55846","remoteHostPort":"127.0.0.1:55846","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55846","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
   20000	     71996 ns/op
{"level":"info","ts":1493086226.2114887,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":10,"service":"bench-gateway","process":"bench-gateway","connID":9,"localAddr":"127.0.0.1:55862","remoteAddr":"127.0.0.1:55858","remoteHostPort":"127.0.0.1:55858","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55858","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
BenchmarkCompare-8     	{"level":"info","ts":1493086226.2640169,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":12,"service":"bench-gateway","process":"bench-gateway","connID":12,"localAddr":"127.0.0.1:55874","remoteAddr":"127.0.0.1:55863","remoteHostPort":"127.0.0.1:55863","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55863","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086226.3203967,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":14,"service":"bench-gateway","process":"bench-gateway","connID":13,"localAddr":"127.0.0.1:55886","remoteAddr":"127.0.0.1:55875","remoteHostPort":"127.0.0.1:55875","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55875","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086227.0935369,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":16,"service":"bench-gateway","process":"bench-gateway","connID":16,"localAddr":"127.0.0.1:55898","remoteAddr":"127.0.0.1:55887","remoteHostPort":"127.0.0.1:55887","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55887","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
   20000	     74517 ns/op
{"level":"info","ts":1493086228.637236,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":18,"service":"bench-gateway","process":"bench-gateway","connID":17,"localAddr":"127.0.0.1:55903","remoteAddr":"127.0.0.1:55899","remoteHostPort":"127.0.0.1:55899","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55899","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
BenchmarkPing-8        	{"level":"info","ts":1493086228.6942732,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":20,"service":"bench-gateway","process":"bench-gateway","connID":20,"localAddr":"127.0.0.1:55915","remoteAddr":"127.0.0.1:55904","remoteHostPort":"127.0.0.1:55904","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55904","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086228.7533994,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":22,"service":"bench-gateway","process":"bench-gateway","connID":22,"localAddr":"127.0.0.1:55927","remoteAddr":"127.0.0.1:55916","remoteHostPort":"127.0.0.1:55916","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55916","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086229.5974007,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":24,"service":"bench-gateway","process":"bench-gateway","connID":23,"localAddr":"127.0.0.1:55939","remoteAddr":"127.0.0.1:55928","remoteHostPort":"127.0.0.1:55928","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55928","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
   20000	     71881 ns/op
{"level":"info","ts":1493086231.097294,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":26,"service":"bench-gateway","process":"bench-gateway","connID":25,"localAddr":"127.0.0.1:55944","remoteAddr":"127.0.0.1:55940","remoteHostPort":"127.0.0.1:55940","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55940","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
BenchmarkSillyNoop-8   	{"level":"info","ts":1493086231.1644642,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":28,"service":"bench-gateway","process":"bench-gateway","connID":27,"localAddr":"127.0.0.1:55956","remoteAddr":"127.0.0.1:55945","remoteHostPort":"127.0.0.1:55945","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55945","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086231.2326488,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":30,"service":"bench-gateway","process":"bench-gateway","connID":29,"localAddr":"127.0.0.1:55968","remoteAddr":"127.0.0.1:55957","remoteHostPort":"127.0.0.1:55957","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55957","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
{"level":"info","ts":1493086232.0129619,"msg":"Outbound connection is active.","hostname":"clu-C02Q35SFG8WM","pid":94441,"zone":"unknown","service":"bench-gateway","process":"bench-gateway","chID":32,"service":"bench-gateway","process":"bench-gateway","connID":32,"localAddr":"127.0.0.1:55981","remoteAddr":"127.0.0.1:55970","remoteHostPort":"127.0.0.1:55970","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]","remoteHostPort":"127.0.0.1:55970","remoteIsEphemeral":false,"remoteProcess":"baz.test[94441]"}
   20000	     68873 ns/op
PASS
ok  	github.com/uber/zanzibar/test/endpoints/baz	9.394s
```