### PR TITLE
Add a GetOrEmpty convenience method to zanzibar.Headers

### DIFF
--- a/runtime/server_header.go
+++ b/runtime/server_header.go
@@ -53,6 +53,18 @@ func (zh ServerHTTPHeader) Get(
 	return "", false
 }
 
+// GetOrEmptyStr retrieves the first string stored on a given header or
+// the empty string (golang's zero vlaue for string types)
+func (zh ServerHTTPHeader) GetOrEmptyStr(
+	key string,
+) string {
+	value, ok := zh.Get(key)
+	if ok {
+		return value
+	}
+	return ""
+}
+
 // Add appends a value for a given header.
 func (zh ServerHTTPHeader) Add(
 	key string, value string,

--- a/runtime/server_header.go
+++ b/runtime/server_header.go
@@ -41,9 +41,7 @@ type ServerHTTPHeader http.Header
 // Get retrieves the first string stored on a given header. Bool
 // return value is used to distinguish between the presence of a
 // header with golang's zerovalue string and the absence of the string.
-func (zh ServerHTTPHeader) Get(
-	key string,
-) (string, bool) {
+func (zh ServerHTTPHeader) Get(key string) (string, bool) {
 	// TODO: Canonicalize strings before lookup.
 	// Use textproto.CanonicalMIMEHeaderKey
 	h := zh[key]
@@ -55,9 +53,7 @@ func (zh ServerHTTPHeader) Get(
 
 // GetOrEmptyStr retrieves the first string stored on a given header or
 // the empty string (golang's zero vlaue for string types)
-func (zh ServerHTTPHeader) GetOrEmptyStr(
-	key string,
-) string {
+func (zh ServerHTTPHeader) GetOrEmptyStr(key string) string {
 	value, ok := zh.Get(key)
 	if ok {
 		return value
@@ -66,18 +62,14 @@ func (zh ServerHTTPHeader) GetOrEmptyStr(
 }
 
 // Add appends a value for a given header.
-func (zh ServerHTTPHeader) Add(
-	key string, value string,
-) {
+func (zh ServerHTTPHeader) Add(key string, value string) {
 	// TODO: Canonicalize strings before inserting
 	// Use textproto.CanonicalMIMEHeaderKey
 	zh[key] = append(zh[key], value)
 }
 
 // Set sets a value for a given header, overwriting all previous values.
-func (zh ServerHTTPHeader) Set(
-	key string, value string,
-) {
+func (zh ServerHTTPHeader) Set(key string, value string) {
 	// TODO: Canonicalize strings before inserting
 	// Use textproto.CanonicalMIMEHeaderKey
 	h := make([]string, 1)

--- a/runtime/server_header_test.go
+++ b/runtime/server_header_test.go
@@ -37,6 +37,21 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "headOne", v)
 }
 
+func TestGetOrEmpty(t *testing.T) {
+	zh := zanzibar.ServerHTTPHeader{}
+	zh["foo"] = []string{"headOne"}
+	zh["bar"] = []string{""}
+
+	v := zh.GetOrEmptyStr("foo")
+	assert.Equal(t, "headOne", v)
+
+	v = zh.GetOrEmptyStr("missing")
+	assert.Equal(t, "", v)
+
+	v = zh.GetOrEmptyStr("bar")
+	assert.Equal(t, "", v)
+}
+
 func TestGetMissingKey(t *testing.T) {
 	zh := zanzibar.ServerHTTPHeader{}
 


### PR DESCRIPTION
Add a GetOrEmpty convenience method to zanzibar.Headers that does not return an error for missing keys. Allows logging and middlewares to inline assignments without if statements for every field.