### PR TITLE
Add support for map/list/typedef/enum to converter

### DIFF
--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -147,6 +147,14 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -147,6 +147,14 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -167,6 +167,14 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -175,6 +175,10 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooI16 = (*int16)(in.Foo.FooI16)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
+		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
+		for key, value := range in.Foo.FooMap {
+			out.Foo.FooMap[key] = string(value)
+		}
 	} else {
 		out.Foo = nil
 	}
@@ -196,6 +200,14 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -401,7 +401,7 @@ func (c *TypeConverter) genStructConverter(
 			// 	return nil, err
 			// }
 			// typeName := pkgName + "." + toField.Type.ThriftName()
-			// line := prefix + "(*" + typeName + ")" + postfix
+			// line := toIdentifier + "(*" + typeName + ")" + postfix
 			// c.Lines = append(c.Lines, line)
 		}
 	}

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -179,8 +179,8 @@ func (c *TypeConverter) genStructConverter(
 
 			subFromFields := fromFieldType.Fields
 			err = c.genStructConverter(
-				strings.Title(toField.Name)+".",
-				"	",
+				keyPrefix+strings.Title(toField.Name)+".",
+				indent+"	",
 				subFromFields,
 				subToFields,
 			)

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -49,6 +49,12 @@ func (c *TypeConverter) append(parts ...string) {
 	c.Lines = append(c.Lines, line)
 }
 
+// appendf helper will add a formatted line to TypeConverter
+func (c *TypeConverter) appendf(format string, parts ...interface{}) {
+	line := fmt.Sprintf(format, parts...)
+	c.Lines = append(c.Lines, line)
+}
+
 func (c *TypeConverter) getGoTypeName(
 	valueType compile.TypeSpec,
 ) (string, error) {
@@ -184,14 +190,14 @@ func (c *TypeConverter) genConverterForList(
 
 	valueStruct, isStruct := toFieldType.ValueSpec.(*compile.StructSpec)
 	if isStruct {
-		c.append(
-			toIdentifier, " = make([]*", typeName,
-			", len(", fromIdentifier, "))",
+		c.appendf(
+			"%s = make([]*%s, len(%s))",
+			toIdentifier, typeName, fromIdentifier,
 		)
 	} else {
-		c.append(
-			toIdentifier, " = make([]", typeName,
-			", len(", fromIdentifier, "))",
+		c.appendf(
+			"%s = make([]%s, len(%s))",
+			toIdentifier, typeName, fromIdentifier,
 		)
 	}
 
@@ -249,14 +255,14 @@ func (c *TypeConverter) genConverterForMap(
 
 	valueStruct, isStruct := toFieldType.ValueSpec.(*compile.StructSpec)
 	if isStruct {
-		c.append(
-			toIdentifier, " = make(map[string]*", typeName,
-			", len(", fromIdentifier, "))",
+		c.appendf(
+			"%s = make(map[string]*%s, len(%s))",
+			toIdentifier, typeName, fromIdentifier,
 		)
 	} else {
-		c.append(
-			toIdentifier, " = make(map[string]", typeName,
-			", len(", fromIdentifier, "))",
+		c.appendf(
+			"%s = make(map[string]%s, len(%s))",
+			toIdentifier, typeName, fromIdentifier,
 		)
 	}
 

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -64,14 +64,18 @@ func (c *TypeConverter) getGoTypeName(
 	case *compile.BinarySpec:
 		return "[]byte", nil
 	case *compile.MapSpec:
+		/* coverage ignore next line */
 		panic("Not Implemented")
 	case *compile.SetSpec:
+		/* coverage ignore next line */
 		panic("Not Implemented")
 	case *compile.ListSpec:
+		/* coverage ignore next line */
 		panic("Not Implemented")
 	case *compile.EnumSpec, *compile.StructSpec, *compile.TypedefSpec:
 		return c.getIdentifierName(s)
 	default:
+		/* coverage ignore next line */
 		panic(fmt.Sprintf("Unknown type (%T) %v", valueType, valueType))
 	}
 }

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -43,6 +43,39 @@ type PackageNameResolver interface {
 	TypePackageName(thriftFile string) (string, error)
 }
 
+func (c *TypeConverter) getGoTypeName(
+	valueType compile.TypeSpec,
+) (string, error) {
+	switch s := valueType.(type) {
+	case *compile.BoolSpec:
+		return "bool", nil
+	case *compile.I8Spec:
+		return "int8", nil
+	case *compile.I16Spec:
+		return "int16", nil
+	case *compile.I32Spec:
+		return "int32", nil
+	case *compile.I64Spec:
+		return "int64", nil
+	case *compile.DoubleSpec:
+		return "float64", nil
+	case *compile.StringSpec:
+		return "string", nil
+	case *compile.BinarySpec:
+		return "[]byte", nil
+	case *compile.MapSpec:
+		panic("Not Implemented")
+	case *compile.SetSpec:
+		panic("Not Implemented")
+	case *compile.ListSpec:
+		panic("Not Implemented")
+	case *compile.EnumSpec, *compile.StructSpec, *compile.TypedefSpec:
+		return c.getIdentifierName(s)
+	default:
+		panic(fmt.Sprintf("Unknown type (%T) %v", valueType, valueType))
+	}
+}
+
 func (c *TypeConverter) getIdentifierName(
 	fieldType compile.TypeSpec,
 ) (string, error) {

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -115,8 +115,8 @@ func (c *TypeConverter) genStructConverter(
 			)
 		}
 
-		prefix := indent + "out." + keyPrefix + strings.Title(toField.Name)
-		postfix := "in." + keyPrefix + strings.Title(fromField.Name)
+		toIdentifier := indent + "out." + keyPrefix + strings.Title(toField.Name)
+		fromIdentifier := "in." + keyPrefix + strings.Title(fromField.Name)
 
 		// Override thrift type names to avoid naming collisions between endpoint
 		// and client types.
@@ -124,33 +124,33 @@ func (c *TypeConverter) genStructConverter(
 		case *compile.BoolSpec:
 			var line string
 			if toField.Required {
-				line = prefix + " = bool(" + postfix + ")"
+				line = toIdentifier + " = bool(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*bool)(" + postfix + ")"
+				line = toIdentifier + " = (*bool)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.I8Spec:
 			var line string
 			if toField.Required {
-				line = prefix + " = int8(" + postfix + ")"
+				line = toIdentifier + " = int8(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*int8)(" + postfix + ")"
+				line = toIdentifier + " = (*int8)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.I16Spec:
 			var line string
 			if toField.Required {
-				line = prefix + " = int16(" + postfix + ")"
+				line = toIdentifier + " = int16(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*int16)(" + postfix + ")"
+				line = toIdentifier + " = (*int16)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.I32Spec:
 			var line string
 			if toField.Required {
-				line = prefix + " = int32(" + postfix + ")"
+				line = toIdentifier + " = int32(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*int32)(" + postfix + ")"
+				line = toIdentifier + " = (*int32)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.EnumSpec:
@@ -161,37 +161,37 @@ func (c *TypeConverter) genStructConverter(
 
 			var line string
 			if toField.Required {
-				line = prefix + " = " + typeName + "(" + postfix + ")"
+				line = toIdentifier + " = " + typeName + "(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*" + typeName + ")(" + postfix + ")"
+				line = toIdentifier + " = (*" + typeName + ")(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.I64Spec:
 			var line string
 			if toField.Required {
-				line = prefix + " = int64(" + postfix + ")"
+				line = toIdentifier + " = int64(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*int64)(" + postfix + ")"
+				line = toIdentifier + " = (*int64)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.DoubleSpec:
 			var line string
 			if toField.Required {
-				line = prefix + " = float64(" + postfix + ")"
+				line = toIdentifier + " = float64(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*float64)(" + postfix + ")"
+				line = toIdentifier + " = (*float64)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.StringSpec:
 			var line string
 			if toField.Required {
-				line = prefix + " = string(" + postfix + ")"
+				line = toIdentifier + " = string(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*string)(" + postfix + ")"
+				line = toIdentifier + " = (*string)(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.BinarySpec:
-			line := prefix + " = []byte(" + postfix + ")"
+			line := toIdentifier + " = []byte(" + fromIdentifier + ")"
 			c.Lines = append(c.Lines, line)
 		case *compile.TypedefSpec:
 			typeName, err := c.getIdentifierName(toField.Type)
@@ -201,9 +201,9 @@ func (c *TypeConverter) genStructConverter(
 
 			var line string
 			if toField.Required {
-				line = prefix + " = " + typeName + "(" + postfix + ")"
+				line = toIdentifier + " = " + typeName + "(" + fromIdentifier + ")"
 			} else {
-				line = prefix + " = (*" + typeName + ")(" + postfix + ")"
+				line = toIdentifier + " = (*" + typeName + ")(" + fromIdentifier + ")"
 			}
 			c.Lines = append(c.Lines, line)
 
@@ -223,10 +223,10 @@ func (c *TypeConverter) genStructConverter(
 				)
 			}
 
-			line := "if " + postfix + " != nil {"
+			line := "if " + fromIdentifier + " != nil {"
 			c.Lines = append(c.Lines, line)
 
-			line = "	" + prefix + " = &" + typeName + "{}"
+			line = "	" + toIdentifier + " = &" + typeName + "{}"
 			c.Lines = append(c.Lines, line)
 
 			subFromFields := fromFieldType.Fields
@@ -243,7 +243,7 @@ func (c *TypeConverter) genStructConverter(
 			line = "} else {"
 			c.Lines = append(c.Lines, line)
 
-			line = "	" + prefix + " = nil"
+			line = "	" + toIdentifier + " = nil"
 			c.Lines = append(c.Lines, line)
 
 			line = "}"
@@ -257,23 +257,25 @@ func (c *TypeConverter) genStructConverter(
 
 			_, isStruct := toFieldType.ValueSpec.(*compile.StructSpec)
 			if isStruct {
-				line := prefix + " = make([]*" +
-					typeName + ", len(" + postfix + "))"
+				line := toIdentifier + " = make([]*" +
+					typeName + ", len(" + fromIdentifier + "))"
 				c.Lines = append(c.Lines, line)
 			} else {
-				line := prefix + " = make([]" +
-					typeName + ", len(" + postfix + "))"
+				line := toIdentifier + " = make([]" +
+					typeName + ", len(" + fromIdentifier + "))"
 				c.Lines = append(c.Lines, line)
 			}
 
-			line := "for index, value := range " + postfix + " {"
+			line := "for index, value := range " + fromIdentifier + " {"
 			c.Lines = append(c.Lines, line)
 
 			if isStruct {
-				line = prefix + "[index] = " + "(*" + typeName + ")(value)"
+				line = toIdentifier + "[index] = " +
+					"(*" + typeName + ")(value)"
 				c.Lines = append(c.Lines, line)
 			} else {
-				line = prefix + "[index] = " + typeName + "(value)"
+				line = toIdentifier + "[index] = " +
+					typeName + "(value)"
 				c.Lines = append(c.Lines, line)
 			}
 

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -160,6 +160,20 @@ func (c *TypeConverter) genStructConverter(
 		case *compile.BinarySpec:
 			line := prefix + " = []byte(" + postfix + ")"
 			c.Lines = append(c.Lines, line)
+		case *compile.TypedefSpec:
+			typeName, err := c.getIdentifierName(toField.Type)
+			if err != nil {
+				return err
+			}
+
+			var line string
+			if toField.Required {
+				line = prefix + " = " + typeName + "(" + postfix + ")"
+			} else {
+				line = prefix + " = (*" + typeName + ")(" + postfix + ")"
+			}
+			c.Lines = append(c.Lines, line)
+
 		case *compile.StructSpec:
 			typeName, err := c.getIdentifierName(toField.Type)
 			if err != nil {

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -21,6 +21,7 @@
 package codegen
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -102,6 +103,24 @@ func (c *TypeConverter) genStructConverter(
 				line = prefix + " = int32(" + postfix + ")"
 			} else {
 				line = prefix + " = (*int32)(" + postfix + ")"
+			}
+			c.Lines = append(c.Lines, line)
+		case *compile.EnumSpec:
+			pkgName, err := c.Helper.TypePackageName(toField.Type.ThriftFile())
+			if err != nil {
+				return errors.Wrapf(
+					err,
+					"could not lookup struct when building converter for %s :",
+					toField.Name,
+				)
+			}
+			typeName := pkgName + "." + toField.Type.ThriftName()
+
+			var line string
+			if toField.Required {
+				line = prefix + " = " + typeName + "(" + postfix + ")"
+			} else {
+				line = prefix + " = (*" + typeName + ")(" + postfix + ")"
 			}
 			c.Lines = append(c.Lines, line)
 		case *compile.I64Spec:

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -99,7 +99,7 @@ func (c *TypeConverter) genConverterForStruct(
 	keyPrefix string,
 	indent string,
 ) error {
-	toIdentifier := indent + "out." + keyPrefix
+	toIdentifier := "out." + keyPrefix
 
 	typeName, err := c.getIdentifierName(toFieldType)
 	if err != nil {
@@ -116,10 +116,10 @@ func (c *TypeConverter) genConverterForStruct(
 		)
 	}
 
-	line := "if " + fromIdentifier + " != nil {"
+	line := indent + "if " + fromIdentifier + " != nil {"
 	c.Lines = append(c.Lines, line)
 
-	line = "	" + toIdentifier + " = &" + typeName + "{}"
+	line = indent + "	" + toIdentifier + " = &" + typeName + "{}"
 	c.Lines = append(c.Lines, line)
 
 	subFromFields := fromFieldStruct.Fields
@@ -133,13 +133,13 @@ func (c *TypeConverter) genConverterForStruct(
 		return err
 	}
 
-	line = "} else {"
+	line = indent + "} else {"
 	c.Lines = append(c.Lines, line)
 
-	line = "	" + toIdentifier + " = nil"
+	line = indent + "	" + toIdentifier + " = nil"
 	c.Lines = append(c.Lines, line)
 
-	line = "}"
+	line = indent + "}"
 	c.Lines = append(c.Lines, line)
 
 	return nil
@@ -208,13 +208,13 @@ func (c *TypeConverter) genConverterForList(
 			fromFieldType.ValueSpec,
 			"value",
 			keyPrefix+strings.Title(toField.Name)+"[index]",
-			indent,
+			"	"+indent,
 		)
 		if err != nil {
 			return err
 		}
 	} else {
-		line = toIdentifier + "[index] = " + typeName + "(value)"
+		line = "	" + toIdentifier + "[index] = " + typeName + "(value)"
 		c.Lines = append(c.Lines, line)
 	}
 
@@ -274,13 +274,13 @@ func (c *TypeConverter) genConverterForMap(
 			fromFieldType.ValueSpec,
 			"value",
 			keyPrefix+strings.Title(toField.Name)+"[key]",
-			indent,
+			"	"+indent,
 		)
 		if err != nil {
 			return err
 		}
 	} else {
-		line = toIdentifier + "[key] = " + typeName + "(value)"
+		line = "	" + toIdentifier + "[key] = " + typeName + "(value)"
 		c.Lines = append(c.Lines, line)
 	}
 

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -249,6 +249,37 @@ func (c *TypeConverter) genStructConverter(
 			line = "}"
 			c.Lines = append(c.Lines, line)
 
+		case *compile.ListSpec:
+			typeName, err := c.getGoTypeName(toFieldType.ValueSpec)
+			if err != nil {
+				return err
+			}
+
+			_, isStruct := toFieldType.ValueSpec.(*compile.StructSpec)
+			if isStruct {
+				line := prefix + " = make([]*" +
+					typeName + ", len(" + postfix + "))"
+				c.Lines = append(c.Lines, line)
+			} else {
+				line := prefix + " = make([]" +
+					typeName + ", len(" + postfix + "))"
+				c.Lines = append(c.Lines, line)
+			}
+
+			line := "for index, value := range " + postfix + " {"
+			c.Lines = append(c.Lines, line)
+
+			if isStruct {
+				line = prefix + "[index] = " + "(*" + typeName + ")(value)"
+				c.Lines = append(c.Lines, line)
+			} else {
+				line = prefix + "[index] = " + typeName + "(value)"
+				c.Lines = append(c.Lines, line)
+			}
+
+			line = "}"
+			c.Lines = append(c.Lines, line)
+
 		default:
 			// fmt.Printf("Unknown type %s for field %s \n",
 			// 	toField.Type.TypeCode().String(), toField.Name,

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -221,6 +221,7 @@ func (c *TypeConverter) genStructConverter(
 			}
 
 			var line string
+			// TODO: typedef for struct is invalid here ...
 			if toField.Required {
 				line = toIdentifier + " = " + typeName + "(" + fromIdentifier + ")"
 			} else {
@@ -317,6 +318,7 @@ func (c *TypeConverter) genStructConverter(
 			c.Lines = append(c.Lines, line)
 
 			if isStruct {
+				// TODO: need to deep copy struct here.
 				line = toIdentifier + "[key] = (*" + typeName + ")(value)"
 				c.Lines = append(c.Lines, line)
 			} else {

--- a/codegen/type_converter_test.go
+++ b/codegen/type_converter_test.go
@@ -405,3 +405,52 @@ func TestStructTypeMisMatch(t *testing.T) {
 	assert.Equal(t, "could not convert struct fields, "+
 		"incompatible type for four :", err.Error())
 }
+
+func TestConvertTypeDef(t *testing.T) {
+	lines, err := convertTypes(
+		"Foo", "Bar",
+		`typedef string UUID
+
+		struct Foo {
+			1: optional UUID one
+			2: required UUID two
+		}
+
+		struct Bar {
+			1: optional UUID one
+			2: required UUID two
+		}`,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, trim(`
+		out.One = (*structs.UUID)(in.One)
+		out.Two = structs.UUID(in.Two)
+	`), lines)
+}
+
+func TestConvertEnum(t *testing.T) {
+	lines, err := convertTypes(
+		"Foo", "Bar",
+		`enum ItemState {
+			REQUIRED,
+			OPTIONAL
+		}
+
+		struct Foo {
+			1: optional ItemState one
+			2: required ItemState two
+		}
+
+		struct Bar {
+			1: optional ItemState one
+			2: required ItemState two
+		}`,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, trim(`
+		out.One = (*structs.ItemState)(in.One)
+		out.Two = structs.ItemState(in.Two)
+	`), lines)
+}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -147,6 +147,14 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -147,6 +147,14 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -167,6 +167,14 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -175,6 +175,10 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooI16 = (*int16)(in.Foo.FooI16)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
+		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
+		for key, value := range in.Foo.FooMap {
+			out.Foo.FooMap[key] = string(value)
+		}
 	} else {
 		out.Foo = nil
 	}
@@ -196,6 +200,14 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 	out.StringField = string(in.StringField)
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
+	out.MapIntWithRange = make(map[string]int32, len(in.MapIntWithRange))
+	for key, value := range in.MapIntWithRange {
+		out.MapIntWithRange[key] = int32(value)
+	}
+	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
+	for key, value := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key] = int32(value)
+	}
 
 	return out
 }

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -120,3 +120,14 @@ cat ./coverage/istanbul.json | jq '[
 echo "Checking code coverage for runtime folder"
 ./node_modules/.bin/istanbul check-coverage --statements 100 \
 	./coverage/istanbul-runtime.json
+
+cat ./coverage/istanbul.json | jq '[
+	. |
+	to_entries |
+	.[] |
+	select(.key | contains("codegen/type_converter"))
+] | from_entries' > ./coverage/istanbul-codegen.json
+
+echo "Checking code coverage for codegen folder"
+./node_modules/.bin/istanbul check-coverage --statements 100 \
+	./coverage/istanbul-codegen.json


### PR DESCRIPTION
This PR adds more features to TypeConverter class.

Map, List, typedef and enum have been added.
Set is NOT implemented yet.

This PR does not add any tests yet, that will come
shortly.

r: @uber/zanzibar-team