### PR TITLE
Thread generated module specs through dependencies

### DIFF
--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -39,7 +39,7 @@ type TestHTTPClientGenerator struct{}
 
 func (*TestHTTPClientGenerator) Generate(
 	instance *ModuleInstance,
-) (map[string][]byte, error) {
+) (*BuildResult, error) {
 	return nil, nil
 }
 
@@ -47,7 +47,7 @@ type TestTChannelClientGenerator struct{}
 
 func (*TestTChannelClientGenerator) Generate(
 	instance *ModuleInstance,
-) (map[string][]byte, error) {
+) (*BuildResult, error) {
 	return nil, nil
 }
 
@@ -55,7 +55,7 @@ type TestHTTPEndpointGenerator struct{}
 
 func (*TestHTTPEndpointGenerator) Generate(
 	instance *ModuleInstance,
-) (map[string][]byte, error) {
+) (*BuildResult, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Some module generators will generate specs. This change supports returning a generated spec from a generator, which mutates a private field on the ModuleInstance for sharing the spec through ResolvedModules. The intended use case is to share the client specs with the endpoint generators so that proxy endpoints can generate code from the client spec.