### PR TITLE
Improve workspace support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,9 @@ before_install:
   - sudo dpkg -i wrk_4.0.1-2_amd64.deb
   - rm wrk_4.0.1-2_amd64.deb
 install:
-  - make install
+  - make jenkins-install
 script:
-  - make generate
-  - make check-generate
-  - make lint
-  - make test-only
-  - make cover
+  - make jenkins-test
   - make fast-bench
   - make bins
   - make test-benchmark-runner

--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,6 @@ jenkins-install:
 	@rm -rf ./workspace/
 	@mkdir -p ./workspace/src/github.com/uber/
 	@ln -s $(PWD) workspace/src/github.com/uber/zanzibar
-	export GOPATH=$(PWD)/workspace
-	export PATH=$(PWD)/workspace/bin:$(PATH)
 	cd workspace/src/github.com/uber/zanzibar && \
 		GOPATH=$(PWD)/workspace \
 		PATH=$(PWD)/workspace/bin:$(PATH) \
@@ -256,8 +254,7 @@ jenkins-install:
 
 .PHONY: jenkins-test
 jenkins-test:
-	export GOPATH=$(PWD)/workspace
-	export PATH=$(PWD)/workspace/bin:$(PATH)
+	PWD=$(pwd)
 	cd workspace/src/github.com/uber/zanzibar && \
 		GOPATH=$(PWD)/workspace \
 		PATH=$(PWD)/workspace/bin:$(PATH) \
@@ -270,10 +267,6 @@ jenkins-test:
 		GOPATH=$(PWD)/workspace \
 		PATH=$(PWD)/workspace/bin:$(PATH) \
 		make test-only
-	cd workspace/src/github.com/uber/zanzibar && \
-		GOPATH=$(PWD)/workspace \
-		PATH=$(PWD)/workspace/bin:$(PATH) \
-		make cover
 
 .PHONY: jenkins
 jenkins:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PKG_FILES = benchmarks codegen examples runtime test
 
 COVER_PKGS = $(shell glide novendor | grep -v "test/..." | \
 	grep -v "main/..." | grep -v "benchmarks/..." | \
-	awk -vORS=, '{ print $1 }' | sed 's/,$$/\n/')
+	grep -v "workspace/..." | awk -vORS=, '{ print $1 }' | sed 's/,$$/\n/')
 
 GO_FILES := $(shell \
 	find . '(' -path '*/.*' -o -path './vendor' ')' -prune \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ eclint-fix:
 
 .PHONY: lint
 lint: check-licence eclint-check
-	@rm -f ./workspace
+	@rm -rf ./workspace
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ eclint-fix:
 
 .PHONY: lint
 lint: check-licence eclint-check
-	@rm -rf ./workspace
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ eclint-fix:
 
 .PHONY: lint
 lint: check-licence eclint-check
+	@rm -f ./workspace
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@gofmt -d -s $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,12 @@ EXAMPLE_SERVICES = $(sort $(dir $(wildcard $(EXAMPLE_SERVICES_DIR)*/)))
 check-licence:
 	@echo "Checking uber-licence..."
 	@ls ./node_modules/.bin/uber-licence >/dev/null 2>&1 || npm i uber-licence
-	@./node_modules/.bin/uber-licence --dry --file '*.go' --dir '!vendor' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
+	@./node_modules/.bin/uber-licence --dry --file '*.go' --dir '!workspace' --dir '!vendor' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
 
 .PHONY: fix-licence
 fix-licence:
 	@ls ./node_modules/.bin/uber-licence >/dev/null 2>&1 || npm i uber-licence
-	./node_modules/.bin/uber-licence --file '*.go' --dir '!vendor' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
+	./node_modules/.bin/uber-licence --file '*.go' --dir '!vendor' --dir '!workspace' --dir '!examples' --dir '!.tmp_gen' --dir '!template_bundle'
 
 .PHONY: install
 install:
@@ -95,15 +95,11 @@ check-generate:
 	rm -rf ./examples/example-gateway/build
 	make generate
 	git status --porcelain > git-status.log
-	@[ ! -s git-status.log ] || ( cat git-status.log ; git diff ; [ ! -s git-status.log ] );
+	@[ ! -s git-status.log ] || ( cat git-status.log ; git --no-pager diff ; [ ! -s git-status.log ] );
 
 .PHONY: test-all
 test-all: 
-	$(MAKE) generate 
-	$(MAKE) check-generate 
-	$(MAKE) lint 
-	$(MAKE) test-only 
-	$(MAKE) cover 
+	$(MAKE) jenkins
 	$(MAKE) fast-bench 
 	$(MAKE) bins 
 	$(MAKE) install-wrk
@@ -225,7 +221,6 @@ view-gocov:
 		open coverage/index.html; \
 	fi
 
-
 .PHONY: view-cover
 view-cover:
 	go tool cover -html=./coverage/cover.out
@@ -245,3 +240,39 @@ tag-build:
 	git add VERSION
 	cat VERSION | xargs -I{} git commit -m "build: {}"
 	cat VERSION | xargs -I{} git tag -m "build: {}" "build-{}"
+
+.PHONY: jenkins-install
+jenkins-install:
+	PWD=$(pwd)
+	@rm -rf ./vendor/
+	@rm -rf ./workspace/
+	@mkdir -p ./workspace/src/github.com/uber/
+	@ln -s $(PWD) workspace/src/github.com/uber/zanzibar
+	cd workspace/src/github.com/uber/zanzibar && \
+		GOPATH=$(PWD)/workspace \
+		PATH=$(PWD)/workspace/bin:$(PATH) \
+		make install
+
+.PHONY: jenkins-test
+jenkins-test:
+	cd workspace/src/github.com/uber/zanzibar && \
+		GOPATH=$(PWD)/workspace \
+		PATH=$(PWD)/workspace/bin:$(PATH) \
+		make check-generate
+	cd workspace/src/github.com/uber/zanzibar && \
+		GOPATH=$(PWD)/workspace \
+		PATH=$(PWD)/workspace/bin:$(PATH) \
+		make lint
+	cd workspace/src/github.com/uber/zanzibar && \
+		GOPATH=$(PWD)/workspace \
+		PATH=$(PWD)/workspace/bin:$(PATH) \
+		make test-only
+	cd workspace/src/github.com/uber/zanzibar && \
+		GOPATH=$(PWD)/workspace \
+		PATH=$(PWD)/workspace/bin:$(PATH) \
+		make cover
+
+.PHONY: jenkins
+jenkins:
+	$(MAKE) jenkins-install
+	$(MAKE) jenkins-test

--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,8 @@ jenkins-install:
 	@rm -rf ./workspace/
 	@mkdir -p ./workspace/src/github.com/uber/
 	@ln -s $(PWD) workspace/src/github.com/uber/zanzibar
+	export GOPATH=$(PWD)/workspace
+	export PATH=$(PWD)/workspace/bin:$(PATH)
 	cd workspace/src/github.com/uber/zanzibar && \
 		GOPATH=$(PWD)/workspace \
 		PATH=$(PWD)/workspace/bin:$(PATH) \
@@ -254,6 +256,8 @@ jenkins-install:
 
 .PHONY: jenkins-test
 jenkins-test:
+	export GOPATH=$(PWD)/workspace
+	export PATH=$(PWD)/workspace/bin:$(PATH)
 	cd workspace/src/github.com/uber/zanzibar && \
 		GOPATH=$(PWD)/workspace \
 		PATH=$(PWD)/workspace/bin:$(PATH) \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PKGS = $(shell glide novendor)
+PKGS = $(shell glide novendor | grep -v "workspace/...")
 PKG_FILES = benchmarks codegen examples runtime test
 
 COVER_PKGS = $(shell glide novendor | grep -v "test/..." | \
@@ -6,8 +6,7 @@ COVER_PKGS = $(shell glide novendor | grep -v "test/..." | \
 	grep -v "workspace/..." | awk -vORS=, '{ print $1 }' | sed 's/,$$/\n/')
 
 GO_FILES := $(shell \
-	find . '(' -path '*/.*' -o -path './vendor' ')' -prune \
-	-o -name '*.go' -print | cut -b3-)
+	find . '(' -path '*/.*' -o -path './vendor' -o -path './workspace' ')' -prune -o -name '*.go' -print | cut -b3-)
 
 FILTER_LINT := grep -v -e "vendor/" -e "third_party/" -e "gen-code/" -e "codegen/templates/" -e "codegen/template_bundle/"
 

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -380,6 +380,8 @@ type EndpointSpec struct {
 	ClientName string
 	// if "httpClient", which client method to call.
 	ClientMethod string
+	// The client for this endpoint if httpClient or tchannelClient
+	ClientSpec *ClientSpec
 }
 
 func ensureFields(config map[string]interface{}, mandatoryFields []string, jsonFile string) error {
@@ -707,6 +709,8 @@ func (e *EndpointSpec) SetDownstream(
 			e.JSONFile, e.ClientName,
 		)
 	}
+
+	e.ClientSpec = clientSpec
 
 	return e.ModuleSpec.SetDownstream(
 		e.ThriftServiceName, e.ThriftMethodName,

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -853,10 +853,14 @@ func (g *EndpointGenerator) generateEndpointTestFile(
 	tempName := "endpoint_test.tmpl"
 	if e.WorkflowType == "tchannelClient" {
 		meta.ClientName = e.ClientName
-		meta.IncludedPackages = append(method.Downstream.IncludedPackages, GoPackageImport{
-			AliasName:   method.Downstream.PackageName,
-			PackageName: method.Downstream.GoPackage,
-		})
+
+		meta.IncludedPackages = append(
+			method.Downstream.IncludedPackages,
+			GoPackageImport{
+				AliasName:   method.Downstream.PackageName,
+				PackageName: e.ClientSpec.GoPackageName,
+			},
+		)
 		tempName = "endpoint_test_tchannel_client.tmpl"
 	}
 

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -165,28 +165,6 @@ func (p PackageHelper) CodeGenTargetPath() string {
 	return p.targetGenDir
 }
 
-// PackageGenPath returns the Go package path for generated code from a thrift file.
-func (p PackageHelper) PackageGenPath(thrift string) (string, error) {
-	if !strings.HasSuffix(thrift, ".thrift") {
-		return "", errors.Errorf("file %s is not .thrift", thrift)
-	}
-
-	idx := strings.Index(thrift, p.thriftRootDir)
-	if idx == -1 {
-		return "", errors.Errorf(
-			"file %s is not in thrift dir (%s)",
-			thrift, p.thriftRootDir,
-		)
-	}
-
-	nsIndex := strings.Index(p.targetGenDir, p.gatewayNamespace)
-	return path.Join(
-		p.gatewayNamespace,
-		p.targetGenDir[nsIndex+len(p.gatewayNamespace):],
-		filepath.Dir(thrift[idx+len(p.thriftRootDir):]),
-	), nil
-}
-
 // TypePackageName returns the package name that defines the type.
 func (p PackageHelper) TypePackageName(thrift string) (string, error) {
 	if !strings.HasSuffix(thrift, ".thrift") {

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -35,8 +35,6 @@ type PackageHelper struct {
 	packageRoot string
 	// The root directory containing thrift files.
 	thriftRootDir string
-	// Namespace under thrift folder
-	gatewayNamespace string
 	// The go package name of where all the generated structs are
 	genCodePackage string
 	// The directory to put the generated service code.
@@ -59,7 +57,6 @@ func NewPackageHelper(
 	thriftRootDir string,
 	genCodePackage string,
 	targetGenDir string,
-	gatewayNamespace string,
 	copyrightHeader string,
 ) (*PackageHelper, error) {
 	genDir, err := filepath.Abs(targetGenDir)
@@ -83,15 +80,6 @@ func NewPackageHelper(
 
 	goGatewayNamespace := filepath.Join(packageRoot, relativeGenDir)
 
-	genDirIndex := strings.Index(genDir, gatewayNamespace)
-	if genDirIndex == -1 {
-		return nil, errors.Errorf(
-			"gatewayNamespace (%s) must be inside targetGenDir (%s)",
-			gatewayNamespace,
-			genDir,
-		)
-	}
-
 	middlewareSpecs := map[string]*MiddlewareSpec{}
 	middleConfig := filepath.Join(
 		configDirName,
@@ -111,7 +99,6 @@ func NewPackageHelper(
 		packageRoot:        packageRoot,
 		thriftRootDir:      path.Clean(thriftRootDir),
 		genCodePackage:     genCodePackage,
-		gatewayNamespace:   gatewayNamespace,
 		goGatewayNamespace: goGatewayNamespace,
 		targetGenDir:       genDir,
 		copyrightHeader:    copyrightHeader,

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -69,7 +69,6 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		filepath.Join(absGatewayPath, "idl"),
 		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
 		tmpDir,
-		"github.com/uber/zanzibar",
 		testCopyrightHeader,
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -98,18 +98,6 @@ func TestTypePackageName(t *testing.T) {
 	assert.Error(t, err, "should return error for not a thrift file")
 }
 
-func TestPackageGenPath(t *testing.T) {
-	h := newPackageHelper(t)
-	p, err := h.PackageGenPath(fooThrift)
-	assert.Nil(t, err, "should not return error")
-	exp := "github.com/uber/zanzibar/.tmp_gen/clients/foo"
-	assert.Equal(t, exp, p, "wrong generated Go package path")
-	_, err = h.PackageGenPath("/Users/xxx/go/src/github.com/uber/zanzibar/examples/example-gateway/build/idl/github.com/uber/zanzibar/clients/foo/foo.go")
-	assert.Error(t, err, "should return error for not a thrift file")
-	_, err = h.PackageGenPath("/Users/xxx/go/src/github.com/uber/zanzibar/examples/example-gateway/build/zanzibar/clients/foo/foo.thrift")
-	assert.Error(t, err, "should return error for not in IDL dir")
-}
-
 func TestEndpointTestConfigPath(t *testing.T) {
 	h := newPackageHelper(t)
 	p := h.EndpointTestConfigPath("foo", "bar")

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -87,7 +87,6 @@ func main() {
 		filepath.Join(configDirName, config.MustGetString("thriftRootDir")),
 		config.MustGetString("genCodePackage"),
 		filepath.Join(configDirName, config.MustGetString("targetGenDir")),
-		config.MustGetString("gatewayNamespace"),
 		string(copyright),
 	)
 	checkError(

--- a/codegen/service_test.go
+++ b/codegen/service_test.go
@@ -45,7 +45,7 @@ func TestModuleSpec(t *testing.T) {
 }
 
 func convertThriftPathToRelative(m *codegen.ModuleSpec) {
-	index := strings.Index(m.ThriftFile, "zanzibar")
+	index := strings.LastIndex(m.ThriftFile, "zanzibar")
 	m.ThriftFile = m.ThriftFile[index:]
 
 	for _, service := range m.Services {

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -65,7 +65,6 @@ func TestGenerateBar(t *testing.T) {
 		filepath.Join(absGatewayPath, "idl"),
 		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
 		tmpDir,
-		"github.com/uber/zanzibar",
 		testCopyrightHeader,
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {

--- a/codegen/test_data/bar.json
+++ b/codegen/test_data/bar.json
@@ -1,7 +1,6 @@
 {
 	"ThriftFile": "zanzibar/examples/example-gateway/idl/endpoints/bar/bar.thrift",
 	"WantAnnot": true,
-	"GoPackage": "github.com/uber/zanzibar/.tmp_gen/endpoints/bar",
 	"PackageName": "bar",
 	"GoThriftTypesFilePath": "",
 	"IncludedPackages": [

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -2,7 +2,6 @@
 	"gatewayName": "example-gateway",
 	"packageRoot": "github.com/uber/zanzibar/examples/example-gateway",
 	"thriftRootDir": "./idl",
-	"gatewayNamespace": "github.com/uber/zanzibar",
 	"genCodePackage": "github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
 	"targetGenDir": "./build",
 

--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -12,12 +12,13 @@ start=`date +%s`
 
 if [ $# -eq 0 ]
 then
-	FILES=$(go list ./... | grep -v "vendor" | \
+	FILES=$(go list -e ./... | grep -v "vendor" | \
+		grep -v "workspace" | \
 		grep "test\|examples\|runtime\|codegen")
 elif [ $# -eq 1 ]
 then
-	FILES=$(go list ./... | grep -v "vendor" | \
-		grep "$1")
+	FILES=$(go list -e ./... | grep -v "vendor" | \
+		grep -v "workspace" | grep "$1")
 else
 	FILES=$@
 fi

--- a/scripts/easy_json/easy_json.go
+++ b/scripts/easy_json/easy_json.go
@@ -127,6 +127,7 @@ func main() {
 		return
 	}
 
+	// Do not paralleliz, not worth it.
 	for _, file := range files {
 		easyJSONFile := file[0:len(file)-3] + "_easyjson.go"
 		oldChecksum := getOldChecksum(easyJSONFile)

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -e
+
 PREFIX=examples/example-gateway
 
 bash ./codegen/runner/pre-steps.sh "$PREFIX/build" "$PREFIX"

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -75,6 +75,8 @@ type ChildProcessGateway struct {
 	errorLogs        map[string][]string
 	channel          *tchannel.Channel
 	serviceName      string
+	startTime        time.Time
+	endTime          time.Time
 
 	HTTPClient       *http.Client
 	TChannelClient   zanzibar.TChannelClient
@@ -117,6 +119,8 @@ func (gateway *ChildProcessGateway) setupMetrics(
 func CreateGateway(
 	t *testing.T, config map[string]interface{}, opts *Options,
 ) (TestGateway, error) {
+	startTime := time.Now()
+
 	if config == nil {
 		config = map[string]interface{}{}
 	}
@@ -158,6 +162,7 @@ func CreateGateway(
 		serviceName: serviceName,
 		test:        t,
 		opts:        opts,
+		startTime:   startTime,
 		HTTPClient: &http.Client{
 			Transport: &http.Transport{
 				DisableKeepAlives:   false,
@@ -294,4 +299,6 @@ func (gateway *ChildProcessGateway) Close() {
 			)
 		}
 	}
+
+	gateway.endTime = time.Now()
 }

--- a/test/lib/test_gateway/test_gateway_cover.go
+++ b/test/lib/test_gateway/test_gateway_cover.go
@@ -195,7 +195,8 @@ func createTestBinaryFile(
 		if folder == "./test/..." ||
 			folder == "./benchmarks/..." ||
 			folder == "./scripts/..." ||
-			folder == "" {
+			folder == "" ||
+			folder == "./workspace/..." {
 			continue
 		}
 


### PR DESCRIPTION
Improve support for "workspace" and multiple GOPATH

 - Fixed PackageHelper to not rely on "gatewayNamespace" and instead rely surely on packageRoot
 - Fixed code to not generate "package name" from thrift file which is incorrect, instead use module system
 - Fixed makefile to support "workspace"
 - Fixed makefile & code coverage tooling to be GOPATH agnostic.

r: @uber/zanzibar-team 