### PR TITLE
Make middleware configuration optional

### DIFF
--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -761,9 +761,14 @@ func parseEndpointJsons(
 }
 
 func parseMiddlewareConfig(
-	config string,
+	middlewareConfig string,
 	configDirName string,
-) ([]*MiddlewareSpec, error) {
+) (map[string]*MiddlewareSpec, error) {
+	specMap := map[string]*MiddlewareSpec{}
+	if middlewareConfig == "" {
+		return specMap, nil
+	}
+	config := filepath.Join(configDirName, middlewareConfig)
 	bytes, err := ioutil.ReadFile(config)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -792,8 +797,7 @@ func parseMiddlewareConfig(
 		)
 	}
 
-	specs := make([]*MiddlewareSpec, len(midList))
-	for idx, mid := range midList {
+	for _, mid := range midList {
 		mid, ok := mid.(map[string]interface{})
 		if !ok {
 			return nil, errors.Wrapf(
@@ -811,7 +815,7 @@ func parseMiddlewareConfig(
 			)
 		}
 
-		specs[idx], err = NewMiddlewareSpec(
+		specMap[name], err = NewMiddlewareSpec(
 			name,
 			importPath,
 			schema,
@@ -824,7 +828,7 @@ func parseMiddlewareConfig(
 			)
 		}
 	}
-	return specs, nil
+	return specMap, nil
 }
 
 // GatewaySpec collects information for the entire gateway

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -864,11 +864,6 @@ func NewGatewaySpec(
 		return nil, errors.Wrap(err, "cannot create template")
 	}
 
-	middleConfig := filepath.Join(
-		configDirName,
-		middlewareConfig,
-	)
-
 	clientJsons, err := filepath.Glob(filepath.Join(
 		configDirName,
 		clientConfig,
@@ -907,13 +902,10 @@ func NewGatewaySpec(
 		gatewayName:       gatewayName,
 	}
 
-	middlewares, err := parseMiddlewareConfig(middleConfig, configDirName)
+	spec.MiddlewareModules, err = parseMiddlewareConfig(middlewareConfig, configDirName)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "Cannot load middlewares:")
-	}
-	for _, mspec := range middlewares {
-		spec.MiddlewareModules[mspec.Name] = mspec
 	}
 
 	clientSpecs := make([]*ClientSpec, len(clientJsons))

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -74,19 +74,10 @@ func NewPackageHelper(
 		)
 	}
 
-	middlewareSpecs := map[string]*MiddlewareSpec{}
-	middleConfig := filepath.Join(
-		configDirName,
-		middlewareConfig,
-	)
-	middlewares, err := parseMiddlewareConfig(middleConfig, configDirName)
+	middlewareSpecs, err := parseMiddlewareConfig(middlewareConfig, configDirName)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err, "Cannot load middlewares:")
-	}
-
-	for _, mspec := range middlewares {
-		middlewareSpecs[mspec.Name] = mspec
 	}
 
 	p := &PackageHelper{


### PR DESCRIPTION
If middleware config file name is set as '""', this PR treats it as no middleware is used instead of throwing a configuration-not-found error.

This saves the effort of creating empty middleware config in order to pass the error check.

r: @uber/zanzibar-team 