### PR TITLE
Remove example-gateway details from test/lib/bench_gateway

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -2,6 +2,7 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
+	"useDatacenter": false,
 
 	"logger.output": "stdout",
 

--- a/examples/example-gateway/build/services/example-gateway/zanzibar-defaults.json
+++ b/examples/example-gateway/build/services/example-gateway/zanzibar-defaults.json
@@ -2,6 +2,7 @@
 	"serviceName": "my-gateway",
 	"port": 4000,
 	"env": "production",
+	"useDatacenter": false,
 
 	"logger.output": "stdout",
 

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -34,10 +34,18 @@ import (
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 )
 
+var defaultTestOptions *testGateway.Options = &testGateway.Options{
+	KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+	KnownTChannelBackends: []string{"baz"},
+}
+var defaultTestConfig map[string]interface{} = map[string]interface{}{
+	"clients.baz.serviceName": "baz",
+}
+
 func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -61,8 +69,8 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 
 func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -86,9 +94,12 @@ func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 }
 
 func TestMakingClientCalLWithHeaders(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"bar"},
-	}, clients.CreateClients, endpoints.Register)
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -131,9 +142,12 @@ func TestMakingClientCalLWithHeaders(t *testing.T) {
 }
 
 func TestMakingClientCalLWithRespHeaders(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"bar"},
-	}, clients.CreateClients, endpoints.Register)
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -168,9 +182,12 @@ func TestMakingClientCalLWithRespHeaders(t *testing.T) {
 }
 
 func TestMakingClientCallWithThriftException(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"bar"},
-	}, clients.CreateClients, endpoints.Register)
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -199,9 +216,12 @@ func TestMakingClientCallWithThriftException(t *testing.T) {
 }
 
 func TestMakingClientCallWithBadStatusCode(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"bar"},
-	}, clients.CreateClients, endpoints.Register)
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -229,9 +249,12 @@ func TestMakingClientCallWithBadStatusCode(t *testing.T) {
 }
 
 func TestMakingCallWithThriftException(t *testing.T) {
-	gateway, err := benchGateway.CreateGateway(nil, &testGateway.Options{
-		KnownHTTPBackends: []string{"bar"},
-	}, clients.CreateClients, endpoints.Register)
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		clients.CreateClients,
+		endpoints.Register,
+	)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -58,8 +58,8 @@ func TestHandlers(t *testing.T) {
 	// request/responses without setting up a backend and register.
 	// Currently they require endpoints to instantiate.
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -145,8 +145,8 @@ func TestMiddlewareRequestAbort(t *testing.T) {
 	assert.Equal(t, 3, len(middlewares))
 
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -200,8 +200,8 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 	assert.Equal(t, 3, len(middlewares))
 
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -263,8 +263,8 @@ func TestMiddlewareSharedStates(t *testing.T) {
 	// request/responses without setting up a backend and register.
 	// Currently they require endpoints to instantiate.
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -35,8 +35,8 @@ import (
 
 func TestTrailingSlashRoutes(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -106,8 +106,8 @@ func TestTrailingSlashRoutes(t *testing.T) {
 
 func TestRouterNotFound(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -135,8 +135,8 @@ func TestRouterNotFound(t *testing.T) {
 
 func TestRouterInvalidMethod(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -39,12 +39,13 @@ import (
 
 func TestInvalidReadAndUnmarshalBody(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
+		defaultTestConfig,
 		&testGateway.Options{
 			LogWhitelist: map[string]bool{
 				"Could not ReadAll() body": true,
 			},
-			KnownHTTPBackends: []string{"bar"},
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,
 		endpoints.Register,

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -37,8 +37,8 @@ import (
 
 func TestInvalidStatusCode(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -97,8 +97,8 @@ func TestInvalidStatusCode(t *testing.T) {
 
 func TestCallingWriteJSONWithNil(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -158,8 +158,8 @@ func (f failingJsonObj) MarshalJSON() ([]byte, error) {
 
 func TestCallWriteJSONWithBadJSON(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -232,8 +232,8 @@ type MyBody struct {
 
 func TestResponsePeekBody(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -294,8 +294,8 @@ func TestResponsePeekBody(t *testing.T) {
 
 func TestResponseSetHeaders(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)
@@ -344,8 +344,8 @@ func TestResponseSetHeaders(t *testing.T) {
 
 func TestResponsePeekBodyError(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		defaultTestConfig,
+		defaultTestOptions,
 		clients.CreateClients,
 		endpoints.Register,
 	)

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -71,14 +71,14 @@ type StaticConfig struct {
 func NewStaticConfigOrDie(
 	files []string, seedConfig map[string]interface{},
 ) *StaticConfig {
-	if seedConfig == nil {
-		seedConfig = map[string]interface{}{}
-	}
-
 	config := &StaticConfig{
 		files:        files,
-		seedConfig:   seedConfig,
+		seedConfig:   map[string]interface{}{},
 		configValues: map[string]StaticConfigValue{},
+	}
+
+	for key, value := range seedConfig {
+		config.seedConfig[key] = value
 	}
 
 	config.initializeConfigValues()

--- a/runtime/static_config_test.go
+++ b/runtime/static_config_test.go
@@ -559,3 +559,27 @@ func TestPanicReadingWrongTypeFromDisk(t *testing.T) {
 
 	closer.Close()
 }
+
+func TestStaticConfigHasOwnState(t *testing.T) {
+	dict := map[string]interface{}{
+		"a.b.c": "v",
+		"bool":  true,
+		"int":   int64(1),
+		"float": float64(1.0),
+	}
+
+	config1 := zanzibar.NewStaticConfigOrDie(
+		[]string{},
+		dict,
+	)
+	config2 := zanzibar.NewStaticConfigOrDie(
+		[]string{},
+		dict,
+	)
+
+	config1.SetOrDie("a-key", "a-value")
+
+	assert.Panics(t, func() {
+		config2.MustGetString("a-key")
+	})
+}

--- a/test/endpoints/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_call_test.go
@@ -51,9 +51,10 @@ func call(
 func BenchmarkCall(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
 		map[string]interface{}{
-			"clients.baz.serviceName": "Qux",
+			"clients.baz.serviceName": "baz",
 		},
 		&testGateway.Options{
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -57,9 +57,10 @@ func compare(
 func BenchmarkCompare(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
 		map[string]interface{}{
-			"clients.baz.serviceName": "Qux",
+			"clients.baz.serviceName": "baz",
 		},
 		&testGateway.Options{
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -49,9 +49,10 @@ func ping(ctx context.Context, reqHeaders map[string]string) (*base.BazResponse,
 func BenchmarkPing(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
 		map[string]interface{}{
-			"clients.baz.serviceName": "Qux",
+			"clients.baz.serviceName": "baz",
 		},
 		&testGateway.Options{
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,

--- a/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
@@ -44,9 +44,10 @@ func sillyNoop(ctx context.Context, reqHeaders map[string]string) (map[string]st
 func BenchmarkSillyNoop(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
 		map[string]interface{}{
-			"clients.baz.serviceName": "Qux",
+			"clients.baz.serviceName": "baz",
 		},
 		&testGateway.Options{
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,

--- a/test/endpoints/contacts/save-contacts_test.go
+++ b/test/endpoints/contacts/save-contacts_test.go
@@ -40,9 +40,12 @@ var benchBytes = []byte("{\"userUUID\":\"foo\",\"contacts\":[{\"fragments\":[{\"
 
 func BenchmarkSaveContacts(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
+		map[string]interface{}{
+			"clients.baz.serviceName": "baz",
+		},
 		&testGateway.Options{
-			KnownHTTPBackends: []string{"contacts"},
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,
 		endpoints.Register,

--- a/test/endpoints/google_now/google_now_test.go
+++ b/test/endpoints/google_now/google_now_test.go
@@ -50,9 +50,12 @@ var headers map[string]string = map[string]string{
 
 func BenchmarkGoogleNowAddCredentials(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
+		map[string]interface{}{
+			"clients.baz.serviceName": "baz",
+		},
 		&testGateway.Options{
-			KnownHTTPBackends: []string{"google-now"},
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+			KnownTChannelBackends: []string{"baz"},
 		},
 		clients.CreateClients,
 		endpoints.Register,

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -69,8 +69,13 @@ func TestHealthCall(t *testing.T) {
 
 func BenchmarkHealthCall(b *testing.B) {
 	gateway, err := benchGateway.CreateGateway(
-		nil,
-		nil,
+		map[string]interface{}{
+			"clients.baz.serviceName": "baz",
+		},
+		&testGateway.Options{
+			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+			KnownTChannelBackends: []string{"baz"},
+		},
 		clients.CreateClients,
 		endpoints.Register,
 	)

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -128,16 +128,6 @@ func CreateGateway(
 
 	config := zanzibar.NewStaticConfigOrDie([]string{
 		filepath.Join(getZanzibarDirName(), "config", "production.json"),
-		filepath.Join(
-			getDirName(),
-			"..",
-			"..",
-			"..",
-			"examples",
-			"example-gateway",
-			"config",
-			"production.json",
-		),
 	}, seedConfig)
 
 	gateway, err := zanzibar.CreateGateway(config, &zanzibar.Options{

--- a/test/lib/test_backend/test_tchannel_backend.go
+++ b/test/lib/test_backend/test_tchannel_backend.go
@@ -70,6 +70,8 @@ func BuildTChannelBackends(
 		result[clientName] = backend
 		cfg["clients."+clientName+".ip"] = "127.0.0.1"
 		cfg["clients."+clientName+".port"] = int64(backend.RealPort)
+		cfg["clients."+clientName+".timeout"] = int64(10000)
+		cfg["clients."+clientName+".timeoutPerAttempt"] = int64(10000)
 	}
 
 	return result, nil


### PR DESCRIPTION
Currently the test/lib/bench_gateway.BenchGateway class
only works with the example-gateway because it's hardcoded
to load the example-gateway config.

This PR removes that and updates our tests to properly configure
the BenchGateway so that it works.

I've updated the tchannel TestBackend to set default timeout
configurations to reduce boilerplate.

Also fixed a bug in StaticConfig in passing where it had
mutable shared state if the seedConfig is re-used.

r: @uber/zanzibar-team