### PR TITLE
Refactor endpoint config to use clientID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - make jenkins-install
 script:
   - make jenkins-test
+  - make cover
   - make fast-bench
   - make bins
   - make test-benchmark-runner

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ check-generate:
 .PHONY: test-all
 test-all: 
 	$(MAKE) jenkins
+	$(MAKE) cover
 	$(MAKE) fast-bench 
 	$(MAKE) bins 
 	$(MAKE) install-wrk

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -40,8 +40,6 @@ func getDirName() string {
 }
 
 var mandatoryClientFields = []string{
-	"clientType",
-	"clientId",
 	"thriftFile",
 	"thriftFileSha",
 }
@@ -136,10 +134,6 @@ func NewClientSpec(
 		)
 	}
 
-	// Restore the properties in the old config structure
-	clientConfig.Config["clientId"] = clientConfig.Name
-	clientConfig.Config["clientType"] = clientConfig.Type
-
 	switch clientConfig.Type {
 	case "http":
 		return NewHTTPClientSpec(instance, clientConfig, h)
@@ -214,7 +208,7 @@ func NewCustomClientSpec(
 		ExportName:         instance.PackageInfo.ExportName,
 		ExportType:         instance.PackageInfo.ExportType,
 		ClientType:         clientConfig.Type,
-		ClientID:           clientConfig.Config["clientId"].(string),
+		ClientID:           clientConfig.Name,
 		ClientName:         instance.PackageInfo.QualifiedInstanceName,
 		CustomImportPath:   clientConfig.Config["customImportPath"].(string),
 		CustomClientType:   clientConfig.Config["customClientType"].(string),
@@ -289,7 +283,7 @@ func newClientSpec(
 		ExportName:         instance.PackageInfo.ExportName,
 		ExportType:         instance.PackageInfo.ExportType,
 		ThriftFile:         thriftFile,
-		ClientID:           config["clientId"].(string),
+		ClientID:           instance.InstanceName,
 		ClientName:         instance.PackageInfo.QualifiedInstanceName,
 		ThriftServiceName:  thriftServiceName,
 	}, nil

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -389,7 +389,7 @@ type EndpointSpec struct {
 	// If "custom" then where to import custom code from
 	WorkflowImportPath string
 	// if "httpClient", which client to call.
-	ClientName string
+	ClientID string
 	// if "httpClient", which client method to call.
 	ClientMethod string
 	// The client for this endpoint if httpClient or tchannelClient
@@ -463,18 +463,18 @@ func NewEndpointSpec(
 	}
 
 	var workflowImportPath string
-	var clientName string
+	var clientID string
 	var clientMethod string
 
 	workflowType := endpointConfigObj["workflowType"].(string)
 	if workflowType == "httpClient" || workflowType == "tchannelClient" {
-		iclientName, ok := endpointConfigObj["clientName"]
+		iclientID, ok := endpointConfigObj["clientID"]
 		if !ok {
 			return nil, errors.Errorf(
 				"endpoint config (%s) must have clientName field", jsonFile,
 			)
 		}
-		clientName = iclientName.(string)
+		clientID = iclientID.(string)
 
 		iclientMethod, ok := endpointConfigObj["clientMethod"]
 		if !ok {
@@ -543,7 +543,7 @@ func NewEndpointSpec(
 		ThriftMethodName:   parts[1],
 		WorkflowType:       workflowType,
 		WorkflowImportPath: workflowImportPath,
-		ClientName:         clientName,
+		ClientID:           clientID,
 		ClientMethod:       clientMethod,
 	}
 
@@ -708,7 +708,7 @@ func (e *EndpointSpec) SetDownstream(
 
 	var clientSpec *ClientSpec
 	for _, v := range clientModules {
-		if v.ClientName == e.ClientName {
+		if v.ClientID == e.ClientID {
 			clientSpec = v
 			break
 		}
@@ -718,7 +718,7 @@ func (e *EndpointSpec) SetDownstream(
 		return errors.Errorf(
 			"When parsing endpoint json (%s), "+
 				"could not find client (%s) in gateway",
-			e.JSONFile, e.ClientName,
+			e.JSONFile, e.ClientID,
 		)
 	}
 

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -471,7 +471,7 @@ func NewEndpointSpec(
 		iclientID, ok := endpointConfigObj["clientID"]
 		if !ok {
 			return nil, errors.Errorf(
-				"endpoint config (%s) must have clientName field", jsonFile,
+				"endpoint config (%s) must have clientID field", jsonFile,
 			)
 		}
 		clientID = iclientID.(string)

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -703,9 +703,10 @@ func (g *EndpointGenerator) generateEndpointFile(
 			strings.Title(method.Name) + "Endpoint"
 	}
 
-	clientID := ""
+	clientID := e.ClientID
+	clientName := ""
 	if e.ClientSpec != nil {
-		clientID = e.ClientSpec.ClientID
+		clientName = e.ClientSpec.ClientName
 	}
 
 	// TODO: http client needs to support multiple thrift services
@@ -719,7 +720,7 @@ func (g *EndpointGenerator) generateEndpointFile(
 		ResHeaderMap:       e.ResHeaderMap,
 		ResHeaderMapKeys:   e.ResHeaderMapKeys,
 		ClientID:           clientID,
-		ClientName:         e.ClientName,
+		ClientName:         clientName,
 		ClientMethodName:   e.ClientMethod,
 		WorkflowName:       workflowName,
 	}
@@ -872,7 +873,7 @@ func (g *EndpointGenerator) generateEndpointTestFile(
 
 	tempName := "endpoint_test.tmpl"
 	if e.WorkflowType == "tchannelClient" {
-		meta.ClientName = e.ClientName
+		meta.ClientName = e.ClientSpec.ClientName
 
 		meta.IncludedPackages = append(
 			method.Downstream.IncludedPackages,

--- a/examples/example-gateway/endpoints/bar/arg_not_struct.json
+++ b/examples/example-gateway/endpoints/bar/arg_not_struct.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::argNotStruct",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "argNotStruct",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/bar/arg_with_headers.json
+++ b/examples/example-gateway/endpoints/bar/arg_with_headers.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::argWithHeaders",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "argWithHeaders",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/bar/missing_arg.json
+++ b/examples/example-gateway/endpoints/bar/missing_arg.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::missingArg",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "missingArg",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/bar/no_request.json
+++ b/examples/example-gateway/endpoints/bar/no_request.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::noRequest",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "noRequest",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/bar/normal.json
+++ b/examples/example-gateway/endpoints/bar/normal.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::normal",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "normal",
 	"testFixtures": [],
 	"middlewares": [

--- a/examples/example-gateway/endpoints/bar/too_many_args.json
+++ b/examples/example-gateway/endpoints/bar/too_many_args.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "Bar::tooManyArgs",
 	"workflowType": "httpClient",
-	"clientName": "Bar",
+	"clientID": "bar",
 	"clientMethod": "tooManyArgs",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/baz/call.json
+++ b/examples/example-gateway/endpoints/baz/call.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "SimpleService::Call",
 	"workflowType": "tchannelClient",
-	"clientName": "Baz",
+	"clientID": "baz",
 	"clientMethod": "Call",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/baz/compare.json
+++ b/examples/example-gateway/endpoints/baz/compare.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "SimpleService::Compare",
 	"workflowType": "tchannelClient",
-	"clientName": "Baz",
+	"clientID": "baz",
 	"clientMethod": "Compare",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/baz/ping.json
+++ b/examples/example-gateway/endpoints/baz/ping.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "SimpleService::Ping",
 	"workflowType": "tchannelClient",
-	"clientName": "Baz",
+	"clientID": "baz",
 	"clientMethod": "Ping",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/baz/silly_noop.json
+++ b/examples/example-gateway/endpoints/baz/silly_noop.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "SimpleService::SillyNoop",
 	"workflowType": "tchannelClient",
-	"clientName": "Baz",
+	"clientID": "baz",
 	"clientMethod": "DeliberateDiffNoop",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/googlenow/add_credentials.json
+++ b/examples/example-gateway/endpoints/googlenow/add_credentials.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "GoogleNow::addCredentials",
 	"workflowType": "httpClient",
-	"clientName": "GoogleNow",
+	"clientID": "google-now",
 	"clientMethod": "addCredentials",
 	"testFixtures": [],
 	"middlewares": [],

--- a/examples/example-gateway/endpoints/googlenow/check_credentials.json
+++ b/examples/example-gateway/endpoints/googlenow/check_credentials.json
@@ -6,7 +6,7 @@
 	"thriftFileSha": "{{placeholder}}",
 	"thriftMethodName": "GoogleNow::checkCredentials",
 	"workflowType": "httpClient",
-	"clientName": "GoogleNow",
+	"clientID": "google-now",
 	"clientMethod": "checkCredentials",
 	"testFixtures": [],
 	"middlewares": [],

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -40,14 +40,14 @@ type ClientHTTPRequest struct {
 	httpRequest *http.Request
 	res         *ClientHTTPResponse
 
-	ClientName string
+	ClientID   string
 	MethodName string
 	Logger     *zap.Logger
 }
 
 // NewClientHTTPRequest allocates a ClientHTTPRequest
 func NewClientHTTPRequest(
-	clientName string, methodName string,
+	clientID string, methodName string,
 	client *HTTPClient,
 ) *ClientHTTPRequest {
 	req := &ClientHTTPRequest{
@@ -57,26 +57,26 @@ func NewClientHTTPRequest(
 
 	req.res = NewClientHTTPResponse(req)
 
-	req.start(clientName, methodName)
+	req.start(clientID, methodName)
 	return req
 }
 
 // Start the request, do some metrics book keeping
 func (req *ClientHTTPRequest) start(
-	clientName string, methodName string,
+	clientID string, methodName string,
 ) {
 	if req.started {
 		/* coverage ignore next line */
 		req.Logger.Error(
 			"Cannot start ClientHTTPRequest twice",
 			zap.String("methodName", methodName),
-			zap.String("clientName", clientName),
+			zap.String("clientID", clientID),
 		)
 		/* coverage ignore next line */
 		return
 	}
 
-	req.ClientName = clientName
+	req.ClientID = clientID
 	req.MethodName = methodName
 
 	req.started = true
@@ -96,7 +96,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 				zap.String("error", err.Error()),
 			)
 			return errors.Wrapf(err,
-				"Could not serialize json for client: %s", req.ClientName,
+				"Could not serialize json for client: %s", req.ClientID,
 			)
 		}
 
@@ -113,7 +113,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 		)
 		return errors.Wrapf(httpErr,
 			"Could not make outbound request for client: %s",
-			req.ClientName,
+			req.ClientID,
 		)
 	}
 

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -79,7 +79,7 @@ func (res *ClientHTTPResponse) ReadAll() ([]byte, error) {
 		return nil, errors.Wrapf(
 			err,
 			"Could not read client(%s) response body",
-			res.req.ClientName,
+			res.req.ClientID,
 		)
 	}
 
@@ -98,7 +98,7 @@ func (res *ClientHTTPResponse) UnmarshalBody(
 		return errors.Wrapf(
 			err,
 			"Could not parse client(%s) json",
-			res.req.ClientName,
+			res.req.ClientID,
 		)
 	}
 

--- a/test/lib/test_backend/test_tchannel_backend.go
+++ b/test/lib/test_backend/test_tchannel_backend.go
@@ -48,12 +48,12 @@ func BuildTChannelBackends(
 	result := make(map[string]*TestTChannelBackend, n)
 
 	for i := 0; i < n; i++ {
-		clientName := knownTChannelBackends[i]
+		clientID := knownTChannelBackends[i]
 
-		val, ok := cfg["clients."+clientName+".serviceName"]
+		val, ok := cfg["clients."+clientID+".serviceName"]
 		var serviceName string
 		if !ok {
-			serviceName = clientName
+			serviceName = clientID
 		} else {
 			serviceName = val.(string)
 		}
@@ -68,11 +68,11 @@ func BuildTChannelBackends(
 			return nil, err
 		}
 
-		result[clientName] = backend
-		cfg["clients."+clientName+".ip"] = "127.0.0.1"
-		cfg["clients."+clientName+".port"] = int64(backend.RealPort)
-		cfg["clients."+clientName+".timeout"] = int64(10000)
-		cfg["clients."+clientName+".timeoutPerAttempt"] = int64(10000)
+		result[clientID] = backend
+		cfg["clients."+clientID+".ip"] = "127.0.0.1"
+		cfg["clients."+clientID+".port"] = int64(backend.RealPort)
+		cfg["clients."+clientID+".timeout"] = int64(10000)
+		cfg["clients."+clientID+".timeoutPerAttempt"] = int64(10000)
 	}
 
 	return result, nil


### PR DESCRIPTION
The `clientName` is no longer used in the client config.
I've updated the endpoint config to require `clientID`
which is the top level `"name"` of the client config.

This should remove `clientName` from all configs.

r: @uber/zanzibar-team