### PR TITLE
Fix tchannel client method visibility 

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1337,7 +1337,7 @@ type {{$clientName}} struct {
 {{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
 {{$methodName := index $exposedMethods $serviceMethod -}}
 {{if $methodName -}}
-	// {{$methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
+	// {{title $methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
 	func (c *{{$clientName}}) {{title $methodName}}(
 		ctx context.Context,
 		reqHeaders map[string]string,
@@ -1394,7 +1394,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3260, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3266, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1338,7 +1338,7 @@ type {{$clientName}} struct {
 {{$methodName := index $exposedMethods $serviceMethod -}}
 {{if $methodName -}}
 	// {{$methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
-	func (c *{{$clientName}}) {{$methodName}}(
+	func (c *{{$clientName}}) {{title $methodName}}(
 		ctx context.Context,
 		reqHeaders map[string]string,
 		{{if ne .RequestType "" -}}
@@ -1394,7 +1394,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3254, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3260, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -63,7 +63,7 @@ type {{$clientName}} struct {
 {{$methodName := index $exposedMethods $serviceMethod -}}
 {{if $methodName -}}
 	// {{$methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
-	func (c *{{$clientName}}) {{$methodName}}(
+	func (c *{{$clientName}}) {{title $methodName}}(
 		ctx context.Context,
 		reqHeaders map[string]string,
 		{{if ne .RequestType "" -}}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -62,7 +62,7 @@ type {{$clientName}} struct {
 {{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
 {{$methodName := index $exposedMethods $serviceMethod -}}
 {{if $methodName -}}
-	// {{$methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
+	// {{title $methodName}} is a client RPC call for method "{{$svc.Name}}::{{.Name}}"
 	func (c *{{$clientName}}) {{title $methodName}}(
 		ctx context.Context,
 		reqHeaders map[string]string,


### PR DESCRIPTION
tchannel client methods are name as `methodName` and thus package level visible. They should be `MethodName` so the endpoint code can call them

