### PR TITLE
Generate clients as interfaces instead of structs

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -503,7 +503,7 @@ func readPackageInfo(
 		),
 		ExportName:            "New" + qualifiedClassName,
 		QualifiedInstanceName: qualifiedInstanceName,
-		ExportType:            qualifiedInstanceName + qualifiedClassName,
+		ExportType:            qualifiedClassName,
 		GeneratedPackagePath: filepath.Join(
 			packageRoot,
 			relativeGeneratedPath,

--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -175,7 +175,7 @@ func TestExampleService(t *testing.T) {
 		JSONFileName:  "client-config.json",
 		PackageInfo: &PackageInfo{
 			ExportName:            "NewClient",
-			ExportType:            "ExampleClient",
+			ExportType:            "Client",
 			GeneratedPackageAlias: "exampleClientGenerated",
 			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/clients/example",
 			IsExportGenerated:     true,
@@ -201,7 +201,7 @@ func TestExampleService(t *testing.T) {
 		JSONFileName: "endpoint-config.json",
 		PackageInfo: &PackageInfo{
 			ExportName:            "NewEndpoint",
-			ExportType:            "HealthEndpoint",
+			ExportType:            "Endpoint",
 			GeneratedPackageAlias: "healthEndpointGenerated",
 			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/endpoints/health",
 			IsExportGenerated:     true,

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -830,7 +830,13 @@ type Client interface {
 {{- end -}}
 }
 
-// NewClient returns a new http client.
+// {{$clientName}} is the http client.
+type {{$clientName}} struct {
+	clientID string
+	httpClient   *zanzibar.HTTPClient
+}
+
+// {{$exportName}} returns a new http client.
 func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := gateway.Config.MustGetInt("clients.{{$clientID}}.port")
@@ -841,14 +847,6 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
-
-// {{$clientName}} is the http client.
-type {{$clientName}} struct {
-	clientID string
-	httpClient   *zanzibar.HTTPClient
-}
-
-{{/*  ========================= Method =========================  */ -}}
 
 // HTTPClient returns the underlying HTTP client, should only be
 // used for internal testing.
@@ -1031,7 +1029,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 6352, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 6284, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1309,10 +1309,30 @@ import (
 
 {{$clientID := .ClientID -}}
 {{$exposedMethods := .ExposedMethods -}}
-{{- $clientName := .ExportType }}
+{{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
+
+// Client defines {{$clientID}} client interface.
+type Client interface {
+{{range $svc := .Services -}}
+{{range .Methods}}
+{{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
+{{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
+{{- if $methodName -}}
+	{{$methodName}}(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		{{if ne .RequestType "" -}}
+		args {{.RequestType}},
+		{{end -}}
+	) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error)
+{{- end -}}
+{{- end -}}
+{{- end -}}
+}
+
 // NewClient returns a new TChannel client for service {{$clientID}}.
-func {{$exportName}}(gateway *zanzibar.Gateway) *{{$clientName}} {
+func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	{{- /* this is the service discovery service name */}}
 	serviceName := gateway.Config.MustGetString("clients.{{$clientID}}.serviceName")
 	sc := gateway.Channel.GetSubChannel(serviceName, tchannel.Isolated)
@@ -1413,7 +1433,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3378, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 3933, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -79,6 +79,7 @@ type Dependencies struct {
 // {{$classType | pascal}}Dependencies contains {{$classType}} dependencies
 type {{$classType | pascal}}Dependencies struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
+	{{- /* TODO: the dependency type should cover all types instead of just interface type */ -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
 	{{end -}}
 }
@@ -95,7 +96,7 @@ func dependency_structTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dependency_struct.tmpl", size: 1032, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "dependency_struct.tmpl", size: 1127, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/dependency_struct.tmpl
+++ b/codegen/templates/dependency_struct.tmpl
@@ -20,6 +20,7 @@ type Dependencies struct {
 // {{$classType | pascal}}Dependencies contains {{$classType}} dependencies
 type {{$classType | pascal}}Dependencies struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
+	{{- /* TODO: the dependency type should cover all types instead of just interface type */ -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
 	{{end -}}
 }

--- a/codegen/templates/dependency_struct.tmpl
+++ b/codegen/templates/dependency_struct.tmpl
@@ -20,7 +20,7 @@ type Dependencies struct {
 // {{$classType | pascal}}Dependencies contains {{$classType}} dependencies
 type {{$classType | pascal}}Dependencies struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
-	{{$dependency.PackageInfo.QualifiedInstanceName}} *{{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
+	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
 	{{end -}}
 }
 {{end -}}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -17,29 +17,54 @@ import (
 
 {{- $clientID := .ClientID -}}
 {{$exposedMethods := .ExposedMethods -}}
-{{- $clientName := .ExportType }}
+{{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
-// {{$clientName}} is the http client.
-type {{$clientName}} struct {
-	ClientID string
-	HTTPClient   *zanzibar.HTTPClient
+
+// Client defines {{$clientID}} client interface.
+type Client interface {
+	HTTPClient() *zanzibar.HTTPClient
+{{- range $svc := .Services -}}
+{{range .Methods}}
+{{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
+{{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
+{{- if $methodName -}}
+	{{$methodName}}(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		{{if ne .RequestType "" -}}
+		args {{.RequestType}},
+		{{end -}}
+	) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error)
+{{- end -}}
+{{- end -}}
+{{- end -}}
 }
 
 // NewClient returns a new http client.
-func {{$exportName}}(
-	gateway *zanzibar.Gateway,
-) *{{$clientName}} {
+func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := gateway.Config.MustGetInt("clients.{{$clientID}}.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{
-		ClientID: "{{$clientID}}",
-		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
+		clientID: "{{$clientID}}",
+		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
+// {{$clientName}} is the http client.
+type {{$clientName}} struct {
+	clientID string
+	httpClient   *zanzibar.HTTPClient
+}
+
 {{/*  ========================= Method =========================  */ -}}
+
+// HTTPClient returns the underlying HTTP client, should only be
+// used for internal testing.
+func (c *{{$clientName}}) HTTPClient() *zanzibar.HTTPClient {
+	return c.httpClient
+}
 
 {{range $svc := .Services}}
 {{range .Methods}}
@@ -59,7 +84,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	var defaultRes  {{.ResponseType}}
 	{{end -}}
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "{{.Name}}", c.HTTPClient,
+		c.clientID, "{{.Name}}", c.httpClient,
 	)
 
 	{{- if .ReqHeaders }}
@@ -71,7 +96,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	{{- end}}
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL
+	fullURL := c.httpClient.BaseURL
 	{{- range $k, $segment := .PathSegments -}}
 	{{- if eq $segment.Type "static" -}}+"/{{$segment.Text}}"
 	{{- else -}}+"/"+string(r{{$segment.BodyIdentifier | title}})

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -40,7 +40,13 @@ type Client interface {
 {{- end -}}
 }
 
-// NewClient returns a new http client.
+// {{$clientName}} is the http client.
+type {{$clientName}} struct {
+	clientID string
+	httpClient   *zanzibar.HTTPClient
+}
+
+// {{$exportName}} returns a new http client.
 func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := gateway.Config.MustGetInt("clients.{{$clientID}}.port")
@@ -51,14 +57,6 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
-
-// {{$clientName}} is the http client.
-type {{$clientName}} struct {
-	clientID string
-	httpClient   *zanzibar.HTTPClient
-}
-
-{{/*  ========================= Method =========================  */ -}}
 
 // HTTPClient returns the underlying HTTP client, should only be
 // used for internal testing.

--- a/codegen/templates/init_clients.tmpl
+++ b/codegen/templates/init_clients.tmpl
@@ -13,7 +13,7 @@ import (
 // This should only hold clients generate from specs
 type Clients struct {
 	{{range $idx, $clientInfo := .ClientInfo -}}
-	{{$clientInfo.FieldName}} {{if $clientInfo.IsPointerType}}*{{end}}{{$clientInfo.PackageAlias}}.{{$clientInfo.ExportType}}
+	{{$clientInfo.FieldName}} {{$clientInfo.PackageAlias}}.{{$clientInfo.ExportType}}
 	{{end}}
 }
 

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -19,10 +19,30 @@ import (
 
 {{$clientID := .ClientID -}}
 {{$exposedMethods := .ExposedMethods -}}
-{{- $clientName := .ExportType }}
+{{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
+
+// Client defines {{$clientID}} client interface.
+type Client interface {
+{{range $svc := .Services -}}
+{{range .Methods}}
+{{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
+{{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
+{{- if $methodName -}}
+	{{$methodName}}(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		{{if ne .RequestType "" -}}
+		args {{.RequestType}},
+		{{end -}}
+	) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error)
+{{- end -}}
+{{- end -}}
+{{- end -}}
+}
+
 // NewClient returns a new TChannel client for service {{$clientID}}.
-func {{$exportName}}(gateway *zanzibar.Gateway) *{{$clientName}} {
+func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	{{- /* this is the service discovery service name */}}
 	serviceName := gateway.Config.MustGetString("clients.{{$clientID}}.serviceName")
 	sc := gateway.Channel.GetSubChannel(serviceName, tchannel.Isolated)

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -85,6 +85,12 @@ type Client interface {
 	) (string, map[string]string, error)
 }
 
+// barClient is the http client.
+type barClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
 // NewClient returns a new http client.
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
@@ -95,12 +101,6 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		clientID:   "bar",
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
-}
-
-// barClient is the http client.
-type barClient struct {
-	clientID   string
-	httpClient *zanzibar.HTTPClient
 }
 
 // HTTPClient returns the underlying HTTP client, should only be

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -45,6 +45,21 @@ type Client interface {
 		reqHeaders map[string]string,
 		args *clientsBarBar.Bar_ArgWithHeaders_Args,
 	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithManyQueryParams(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithQueryHeader(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithQueryHeader_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithQueryParams(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithQueryParams_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
 	MissingArg(
 		ctx context.Context,
 		reqHeaders map[string]string,
@@ -203,18 +218,18 @@ func (c *barClient) ArgWithHeaders(
 }
 
 // ArgWithManyQueryParams calls "/bar/argWithManyQueryParams" endpoint.
-func (c *BarClient) ArgWithManyQueryParams(
+func (c *barClient) ArgWithManyQueryParams(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithManyQueryParams", c.HTTPClient,
+		c.clientID, "argWithManyQueryParams", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithManyQueryParams"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithManyQueryParams"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -250,18 +265,18 @@ func (c *BarClient) ArgWithManyQueryParams(
 }
 
 // ArgWithQueryHeader calls "/bar/argWithQueryHeader" endpoint.
-func (c *BarClient) ArgWithQueryHeader(
+func (c *barClient) ArgWithQueryHeader(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithQueryHeader", c.HTTPClient,
+		c.clientID, "argWithQueryHeader", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithQueryHeader"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryHeader"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -297,18 +312,18 @@ func (c *BarClient) ArgWithQueryHeader(
 }
 
 // ArgWithQueryParams calls "/bar/argWithQueryParams" endpoint.
-func (c *BarClient) ArgWithQueryParams(
+func (c *barClient) ArgWithQueryParams(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithQueryParams", c.HTTPClient,
+		c.clientID, "argWithQueryParams", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithQueryParams"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryParams"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -32,38 +32,80 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-// BarClient is the http client.
-type BarClient struct {
-	ClientID   string
-	HTTPClient *zanzibar.HTTPClient
+// Client defines bar client interface.
+type Client interface {
+	HTTPClient() *zanzibar.HTTPClient
+	ArgNotStruct(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgNotStruct_Args,
+	) (map[string]string, error)
+	ArgWithHeaders(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithHeaders_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	MissingArg(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	NoRequest(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	Normal(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_Normal_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	TooManyArgs(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_TooManyArgs_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	Echo(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Echo_Echo_Args,
+	) (string, map[string]string, error)
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	gateway *zanzibar.Gateway,
-) *BarClient {
+func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
 	port := gateway.Config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
-	return &BarClient{
-		ClientID:   "bar",
-		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
+	return &barClient{
+		clientID:   "bar",
+		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
+// barClient is the http client.
+type barClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
+// HTTPClient returns the underlying HTTP client, should only be
+// used for internal testing.
+func (c *barClient) HTTPClient() *zanzibar.HTTPClient {
+	return c.httpClient
+}
+
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
-func (c *BarClient) ArgNotStruct(
+func (c *barClient) ArgNotStruct(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argNotStruct", c.HTTPClient,
+		c.clientID, "argNotStruct", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/arg-not-struct-path"
+	fullURL := c.httpClient.BaseURL + "/arg-not-struct-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -113,19 +155,19 @@ func (c *BarClient) ArgNotStruct(
 }
 
 // ArgWithHeaders calls "/bar/argWithHeaders" endpoint.
-func (c *BarClient) ArgWithHeaders(
+func (c *barClient) ArgWithHeaders(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithHeaders", c.HTTPClient,
+		c.clientID, "argWithHeaders", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithHeaders"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithHeaders"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -302,17 +344,17 @@ func (c *BarClient) ArgWithQueryParams(
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
-func (c *BarClient) MissingArg(
+func (c *barClient) MissingArg(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "missingArg", c.HTTPClient,
+		c.clientID, "missingArg", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/missing-arg-path"
+	fullURL := c.httpClient.BaseURL + "/missing-arg-path"
 
 	err := req.WriteJSON("GET", fullURL, headers, nil)
 	if err != nil {
@@ -363,17 +405,17 @@ func (c *BarClient) MissingArg(
 }
 
 // NoRequest calls "/no-request-path" endpoint.
-func (c *BarClient) NoRequest(
+func (c *barClient) NoRequest(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "noRequest", c.HTTPClient,
+		c.clientID, "noRequest", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/no-request-path"
+	fullURL := c.httpClient.BaseURL + "/no-request-path"
 
 	err := req.WriteJSON("GET", fullURL, headers, nil)
 	if err != nil {
@@ -424,18 +466,18 @@ func (c *BarClient) NoRequest(
 }
 
 // Normal calls "/bar-path" endpoint.
-func (c *BarClient) Normal(
+func (c *barClient) Normal(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "normal", c.HTTPClient,
+		c.clientID, "normal", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar-path"
+	fullURL := c.httpClient.BaseURL + "/bar-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -486,18 +528,18 @@ func (c *BarClient) Normal(
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
-func (c *BarClient) TooManyArgs(
+func (c *barClient) TooManyArgs(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "tooManyArgs", c.HTTPClient,
+		c.clientID, "tooManyArgs", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/too-many-args-path"
+	fullURL := c.httpClient.BaseURL + "/too-many-args-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -548,19 +590,19 @@ func (c *BarClient) TooManyArgs(
 }
 
 // Echo calls "/echo" endpoint.
-func (c *BarClient) Echo(
+func (c *barClient) Echo(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Echo_Echo_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "echo", c.HTTPClient,
+		c.clientID, "echo", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/echo"
+	fullURL := c.httpClient.BaseURL + "/echo"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -85,6 +85,12 @@ type Client interface {
 	) (string, map[string]string, error)
 }
 
+// barClient is the http client.
+type barClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
 // NewClient returns a new http client.
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
@@ -95,12 +101,6 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		clientID:   "bar",
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
-}
-
-// barClient is the http client.
-type barClient struct {
-	clientID   string
-	httpClient *zanzibar.HTTPClient
 }
 
 // HTTPClient returns the underlying HTTP client, should only be

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -45,6 +45,21 @@ type Client interface {
 		reqHeaders map[string]string,
 		args *clientsBarBar.Bar_ArgWithHeaders_Args,
 	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithManyQueryParams(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithQueryHeader(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithQueryHeader_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	ArgWithQueryParams(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithQueryParams_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
 	MissingArg(
 		ctx context.Context,
 		reqHeaders map[string]string,
@@ -203,18 +218,18 @@ func (c *barClient) ArgWithHeaders(
 }
 
 // ArgWithManyQueryParams calls "/bar/argWithManyQueryParams" endpoint.
-func (c *BarClient) ArgWithManyQueryParams(
+func (c *barClient) ArgWithManyQueryParams(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithManyQueryParams", c.HTTPClient,
+		c.clientID, "argWithManyQueryParams", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithManyQueryParams"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithManyQueryParams"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -250,18 +265,18 @@ func (c *BarClient) ArgWithManyQueryParams(
 }
 
 // ArgWithQueryHeader calls "/bar/argWithQueryHeader" endpoint.
-func (c *BarClient) ArgWithQueryHeader(
+func (c *barClient) ArgWithQueryHeader(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithQueryHeader", c.HTTPClient,
+		c.clientID, "argWithQueryHeader", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithQueryHeader"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryHeader"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -297,18 +312,18 @@ func (c *BarClient) ArgWithQueryHeader(
 }
 
 // ArgWithQueryParams calls "/bar/argWithQueryParams" endpoint.
-func (c *BarClient) ArgWithQueryParams(
+func (c *barClient) ArgWithQueryParams(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithQueryParams", c.HTTPClient,
+		c.clientID, "argWithQueryParams", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithQueryParams"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryParams"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -32,38 +32,80 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-// BarClient is the http client.
-type BarClient struct {
-	ClientID   string
-	HTTPClient *zanzibar.HTTPClient
+// Client defines bar client interface.
+type Client interface {
+	HTTPClient() *zanzibar.HTTPClient
+	ArgNotStruct(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgNotStruct_Args,
+	) (map[string]string, error)
+	ArgWithHeaders(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_ArgWithHeaders_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	MissingArg(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	NoRequest(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	Normal(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_Normal_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	TooManyArgs(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Bar_TooManyArgs_Args,
+	) (*clientsBarBar.BarResponse, map[string]string, error)
+	Echo(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBarBar.Echo_Echo_Args,
+	) (string, map[string]string, error)
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	gateway *zanzibar.Gateway,
-) *BarClient {
+func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
 	port := gateway.Config.MustGetInt("clients.bar.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
-	return &BarClient{
-		ClientID:   "bar",
-		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
+	return &barClient{
+		clientID:   "bar",
+		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
+// barClient is the http client.
+type barClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
+// HTTPClient returns the underlying HTTP client, should only be
+// used for internal testing.
+func (c *barClient) HTTPClient() *zanzibar.HTTPClient {
+	return c.httpClient
+}
+
 // ArgNotStruct calls "/arg-not-struct-path" endpoint.
-func (c *BarClient) ArgNotStruct(
+func (c *barClient) ArgNotStruct(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argNotStruct", c.HTTPClient,
+		c.clientID, "argNotStruct", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/arg-not-struct-path"
+	fullURL := c.httpClient.BaseURL + "/arg-not-struct-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -113,19 +155,19 @@ func (c *BarClient) ArgNotStruct(
 }
 
 // ArgWithHeaders calls "/bar/argWithHeaders" endpoint.
-func (c *BarClient) ArgWithHeaders(
+func (c *barClient) ArgWithHeaders(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "argWithHeaders", c.HTTPClient,
+		c.clientID, "argWithHeaders", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar" + "/argWithHeaders"
+	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithHeaders"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -302,17 +344,17 @@ func (c *BarClient) ArgWithQueryParams(
 }
 
 // MissingArg calls "/missing-arg-path" endpoint.
-func (c *BarClient) MissingArg(
+func (c *barClient) MissingArg(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "missingArg", c.HTTPClient,
+		c.clientID, "missingArg", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/missing-arg-path"
+	fullURL := c.httpClient.BaseURL + "/missing-arg-path"
 
 	err := req.WriteJSON("GET", fullURL, headers, nil)
 	if err != nil {
@@ -363,17 +405,17 @@ func (c *BarClient) MissingArg(
 }
 
 // NoRequest calls "/no-request-path" endpoint.
-func (c *BarClient) NoRequest(
+func (c *barClient) NoRequest(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "noRequest", c.HTTPClient,
+		c.clientID, "noRequest", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/no-request-path"
+	fullURL := c.httpClient.BaseURL + "/no-request-path"
 
 	err := req.WriteJSON("GET", fullURL, headers, nil)
 	if err != nil {
@@ -424,18 +466,18 @@ func (c *BarClient) NoRequest(
 }
 
 // Normal calls "/bar-path" endpoint.
-func (c *BarClient) Normal(
+func (c *barClient) Normal(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "normal", c.HTTPClient,
+		c.clientID, "normal", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/bar-path"
+	fullURL := c.httpClient.BaseURL + "/bar-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -486,18 +528,18 @@ func (c *BarClient) Normal(
 }
 
 // TooManyArgs calls "/too-many-args-path" endpoint.
-func (c *BarClient) TooManyArgs(
+func (c *barClient) TooManyArgs(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "tooManyArgs", c.HTTPClient,
+		c.clientID, "tooManyArgs", c.httpClient,
 	)
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/too-many-args-path"
+	fullURL := c.httpClient.BaseURL + "/too-many-args-path"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -548,19 +590,19 @@ func (c *BarClient) TooManyArgs(
 }
 
 // Echo calls "/echo" endpoint.
-func (c *BarClient) Echo(
+func (c *barClient) Echo(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsBarBar.Echo_Echo_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "echo", c.HTTPClient,
+		c.clientID, "echo", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/echo"
+	fullURL := c.httpClient.BaseURL + "/echo"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -37,8 +37,35 @@ import (
 	clientsBazBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/baz"
 )
 
+// Client defines baz client interface.
+type Client interface {
+	Echo(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBazBaz.SecondService_Echo_Args,
+	) (string, map[string]string, error)
+	Call(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBazBaz.SimpleService_Call_Args,
+	) (map[string]string, error)
+	Compare(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsBazBaz.SimpleService_Compare_Args,
+	) (*clientsBazBase.BazResponse, map[string]string, error)
+	Ping(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (*clientsBazBase.BazResponse, map[string]string, error)
+	DeliberateDiffNoop(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (map[string]string, error)
+}
+
 // NewClient returns a new TChannel client for service baz.
-func NewClient(gateway *zanzibar.Gateway) *BazClient {
+func NewClient(gateway *zanzibar.Gateway) Client {
 	serviceName := gateway.Config.MustGetString("clients.baz.serviceName")
 	sc := gateway.Channel.GetSubChannel(serviceName, tchannel.Isolated)
 
@@ -61,18 +88,18 @@ func NewClient(gateway *zanzibar.Gateway) *BazClient {
 		},
 	)
 
-	return &BazClient{
+	return &bazClient{
 		client: client,
 	}
 }
 
-// BazClient is the TChannel client for downstream service.
-type BazClient struct {
+// bazClient is the TChannel client for downstream service.
+type bazClient struct {
 	client zanzibar.TChannelClient
 }
 
 // Echo is a client RPC call for method "SecondService::Echo"
-func (c *BazClient) Echo(
+func (c *bazClient) Echo(
 	ctx context.Context,
 	reqHeaders map[string]string,
 	args *clientsBazBaz.SecondService_Echo_Args,
@@ -87,7 +114,7 @@ func (c *BazClient) Echo(
 	if err == nil && !success {
 		switch {
 		default:
-			err = errors.New("BazClient received no result or unknown exception for Echo")
+			err = errors.New("bazClient received no result or unknown exception for Echo")
 		}
 	}
 	if err != nil {
@@ -99,7 +126,7 @@ func (c *BazClient) Echo(
 }
 
 // Call is a client RPC call for method "SimpleService::Call"
-func (c *BazClient) Call(
+func (c *bazClient) Call(
 	ctx context.Context,
 	reqHeaders map[string]string,
 	args *clientsBazBaz.SimpleService_Call_Args,
@@ -115,7 +142,7 @@ func (c *BazClient) Call(
 		case result.AuthErr != nil:
 			err = result.AuthErr
 		default:
-			err = errors.New("BazClient received no result or unknown exception for Call")
+			err = errors.New("bazClient received no result or unknown exception for Call")
 		}
 	}
 	if err != nil {
@@ -126,7 +153,7 @@ func (c *BazClient) Call(
 }
 
 // Compare is a client RPC call for method "SimpleService::Compare"
-func (c *BazClient) Compare(
+func (c *bazClient) Compare(
 	ctx context.Context,
 	reqHeaders map[string]string,
 	args *clientsBazBaz.SimpleService_Compare_Args,
@@ -145,7 +172,7 @@ func (c *BazClient) Compare(
 		case result.OtherAuthErr != nil:
 			err = result.OtherAuthErr
 		default:
-			err = errors.New("BazClient received no result or unknown exception for Compare")
+			err = errors.New("bazClient received no result or unknown exception for Compare")
 		}
 	}
 	if err != nil {
@@ -157,7 +184,7 @@ func (c *BazClient) Compare(
 }
 
 // Ping is a client RPC call for method "SimpleService::Ping"
-func (c *BazClient) Ping(
+func (c *bazClient) Ping(
 	ctx context.Context,
 	reqHeaders map[string]string,
 ) (*clientsBazBase.BazResponse, map[string]string, error) {
@@ -172,7 +199,7 @@ func (c *BazClient) Ping(
 	if err == nil && !success {
 		switch {
 		default:
-			err = errors.New("BazClient received no result or unknown exception for Ping")
+			err = errors.New("bazClient received no result or unknown exception for Ping")
 		}
 	}
 	if err != nil {
@@ -184,7 +211,7 @@ func (c *BazClient) Ping(
 }
 
 // DeliberateDiffNoop is a client RPC call for method "SimpleService::SillyNoop"
-func (c *BazClient) DeliberateDiffNoop(
+func (c *bazClient) DeliberateDiffNoop(
 	ctx context.Context,
 	reqHeaders map[string]string,
 ) (map[string]string, error) {
@@ -202,7 +229,7 @@ func (c *BazClient) DeliberateDiffNoop(
 		case result.ServerErr != nil:
 			err = result.ServerErr
 		default:
-			err = errors.New("BazClient received no result or unknown exception for SillyNoop")
+			err = errors.New("bazClient received no result or unknown exception for SillyNoop")
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/clients.go
+++ b/examples/example-gateway/build/clients/clients.go
@@ -37,11 +37,11 @@ import (
 // Clients datastructure that holds all the generated clients
 // This should only hold clients generate from specs
 type Clients struct {
-	Bar       *barClientGenerated.BarClient
-	Baz       *bazClientGenerated.BazClient
-	Contacts  *contactsClientGenerated.ContactsClient
-	GoogleNow *googlenowClientGenerated.GoogleNowClient
-	Quux      *quuxClientStatic.Quux
+	Bar       barClientGenerated.Client
+	Baz       bazClientGenerated.Client
+	Contacts  contactsClientGenerated.Client
+	GoogleNow googlenowClientGenerated.Client
+	Quux      quuxClientStatic.Client
 }
 
 // CreateClients will make all clients

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -42,6 +42,12 @@ type Client interface {
 	) (*clientsContactsContacts.SaveContactsResponse, map[string]string, error)
 }
 
+// contactsClient is the http client.
+type contactsClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
 // NewClient returns a new http client.
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.contacts.ip")
@@ -52,12 +58,6 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		clientID:   "contacts",
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
-}
-
-// contactsClient is the http client.
-type contactsClient struct {
-	clientID   string
-	httpClient *zanzibar.HTTPClient
 }
 
 // HTTPClient returns the underlying HTTP client, should only be

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -46,6 +46,12 @@ type Client interface {
 	) (map[string]string, error)
 }
 
+// googleNowClient is the http client.
+type googleNowClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
 // NewClient returns a new http client.
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.google-now.ip")
@@ -56,12 +62,6 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		clientID:   "google-now",
 		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
-}
-
-// googleNowClient is the http client.
-type googleNowClient struct {
-	clientID   string
-	httpClient *zanzibar.HTTPClient
 }
 
 // HTTPClient returns the underlying HTTP client, should only be

--- a/examples/example-gateway/build/clients/googlenow/googlenow.go
+++ b/examples/example-gateway/build/clients/googlenow/googlenow.go
@@ -32,39 +32,57 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-// GoogleNowClient is the http client.
-type GoogleNowClient struct {
-	ClientID   string
-	HTTPClient *zanzibar.HTTPClient
+// Client defines google-now client interface.
+type Client interface {
+	HTTPClient() *zanzibar.HTTPClient
+	AddCredentials(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *clientsGooglenowGooglenow.GoogleNowService_AddCredentials_Args,
+	) (map[string]string, error)
+	CheckCredentials(
+		ctx context.Context,
+		reqHeaders map[string]string,
+	) (map[string]string, error)
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	gateway *zanzibar.Gateway,
-) *GoogleNowClient {
+func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.google-now.ip")
 	port := gateway.Config.MustGetInt("clients.google-now.port")
 
 	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
-	return &GoogleNowClient{
-		ClientID:   "google-now",
-		HTTPClient: zanzibar.NewHTTPClient(gateway, baseURL),
+	return &googleNowClient{
+		clientID:   "google-now",
+		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
 	}
 }
 
+// googleNowClient is the http client.
+type googleNowClient struct {
+	clientID   string
+	httpClient *zanzibar.HTTPClient
+}
+
+// HTTPClient returns the underlying HTTP client, should only be
+// used for internal testing.
+func (c *googleNowClient) HTTPClient() *zanzibar.HTTPClient {
+	return c.httpClient
+}
+
 // AddCredentials calls "/add-credentials" endpoint.
-func (c *GoogleNowClient) AddCredentials(
+func (c *googleNowClient) AddCredentials(
 	ctx context.Context,
 	headers map[string]string,
 	r *clientsGooglenowGooglenow.GoogleNowService_AddCredentials_Args,
 ) (map[string]string, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "addCredentials", c.HTTPClient,
+		c.clientID, "addCredentials", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/add-credentials"
+	fullURL := c.httpClient.BaseURL + "/add-credentials"
 
 	err := req.WriteJSON("POST", fullURL, headers, r)
 	if err != nil {
@@ -99,17 +117,17 @@ func (c *GoogleNowClient) AddCredentials(
 }
 
 // CheckCredentials calls "/check-credentials" endpoint.
-func (c *GoogleNowClient) CheckCredentials(
+func (c *googleNowClient) CheckCredentials(
 	ctx context.Context,
 	headers map[string]string,
 ) (map[string]string, error) {
 	req := zanzibar.NewClientHTTPRequest(
-		c.ClientID, "checkCredentials", c.HTTPClient,
+		c.clientID, "checkCredentials", c.httpClient,
 	)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
-	fullURL := c.HTTPClient.BaseURL + "/check-credentials"
+	fullURL := c.httpClient.BaseURL + "/check-credentials"
 
 	err := req.WriteJSON("POST", fullURL, headers, nil)
 	if err != nil {

--- a/examples/example-gateway/build/clients/quux/dependencies.go
+++ b/examples/example-gateway/build/clients/quux/dependencies.go
@@ -34,5 +34,5 @@ type Dependencies struct {
 
 // ClientDependencies contains client dependencies
 type ClientDependencies struct {
-	Bar *barClientGenerated.BarClient
+	Bar barClientGenerated.Client
 }

--- a/examples/example-gateway/clients/quux/client-config.json
+++ b/examples/example-gateway/clients/quux/client-config.json
@@ -4,7 +4,7 @@
 	"config": {
 		"serviceName": "quux",
 		"customImportPath": "github.com/uber/zanzibar/examples/example-gateway/clients/quux",
-		"customClientType": "*Quux",
+		"customClientType": "Client",
 		"customPackageName": "quux"
 	},
 	"dependencies": {

--- a/examples/example-gateway/clients/quux/quux.go
+++ b/examples/example-gateway/clients/quux/quux.go
@@ -25,10 +25,12 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-// Quux is a custom client that does nothing yet
-type Quux struct{}
+// Client is a custom client that does nothing yet
+type Client interface{}
+
+type quux struct{}
 
 // NewClient creates a new Quux client
-func NewClient(g *zanzibar.Gateway, dependencies quuxClient.ClientDependencies) *Quux {
-	return &Quux{}
+func NewClient(g *zanzibar.Gateway, dependencies quuxClient.ClientDependencies) Client {
+	return &quux{}
 }

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -116,7 +116,7 @@ func TestMakingClientCalLWithHeaders(t *testing.T) {
 	)
 
 	clients := bgateway.ActualGateway.Clients.(*clients.Clients)
-	client := clients.Bar.HTTPClient
+	client := clients.Bar.HTTPClient()
 
 	req := zanzibar.NewClientHTTPRequest("bar", "bar-path", client)
 


### PR DESCRIPTION
This PR generates the http/tchannel clients as client interfaces instead of structs in order to easily mock clients for testing.