### PR TITLE
Ensure we close pending tchannel requests.

### DIFF
--- a/benchmarks/benchserver/main.go
+++ b/benchmarks/benchserver/main.go
@@ -90,7 +90,7 @@ func serverTChannel(logger *zap.Logger) *testBackend.TestTChannelBackend {
 	simpleServiceCallHandler := baz.NewSimpleServiceCallHandler(handleSimpleServiceCall)
 
 	// must register handler first before bootstrap
-	tchannelBackend.Register("SimpleService", "Call", simpleServiceCallHandler)
+	tchannelBackend.Register("SimpleService", "call", simpleServiceCallHandler)
 
 	err = tchannelBackend.Bootstrap()
 	if err != nil {

--- a/benchmarks/compare_to.sh
+++ b/benchmarks/compare_to.sh
@@ -79,7 +79,7 @@ done
 rm -f benchmark.txt
 touch benchmark.txt
 
-if [ "$BENCHMARK_FILE" -eq "bench" ]; then
+if [ "$BENCHMARK_FILE" == "bench" ]; then
     run $CURRENT_SHA
     go_bench $CURRENT_SHA
     run $OTHER_SHA

--- a/benchmarks/compare_to.sh
+++ b/benchmarks/compare_to.sh
@@ -63,6 +63,8 @@ function benchmark_runner() {
 }
 
 function go_bench() {
+    local sha=$1
+
     rm -f "bench_$sha.txt"
     touch "bench_$sha.txt"
     for i in `seq 5`; do

--- a/benchmarks/compare_to.sh
+++ b/benchmarks/compare_to.sh
@@ -89,7 +89,7 @@ if [ "$BENCHMARK_FILE" == "bench" ]; then
 
     go get -u golang.org/x/tools/cmd/benchcmp
     echo "Comparing old $CURRENT_SHA to new $OTHER_SHA"
-    benchmp -best "bench_$CURRENT_SHA.txt" "bench_$OTHER_SHA.txt"
+    benchcmp -best "bench_$CURRENT_SHA.txt" "bench_$OTHER_SHA.txt"
 
 else
     run $CURRENT_SHA

--- a/benchmarks/compare_to.sh
+++ b/benchmarks/compare_to.sh
@@ -3,18 +3,19 @@ set -e
 
 if [ "$1" == "" ]; then
     echo "Must pass in another git sha"
-    echo "e.g: ./benchmarks/compare_to.sh master contacts_1KB.lua"
+    echo "e.g: ./benchmarks/compare_to.sh master benchmarks/contacts_1KB.lua"
     exit 1
 fi
 
 if [ "$2" == "" ]; then
     echo "Must pass in a target lua script to benchmark against"
-    echo "e.g: ./benchmarks/compare_to.sh master contacts_1KB.lua"
+    echo "e.g: ./benchmarks/compare_to.sh master benchmarks/contacts_1KB.lua"
     exit 1
 fi
 
 OTHER_SHA=$1
 CURRENT_SHA=`git rev-parse --abbrev-ref HEAD`
+BENCHMARK_FILE=$2
 
 function banner() {
     echo ""
@@ -29,16 +30,45 @@ function banner() {
 
 function run() {
     local sha=$1
-    local lua_script=$2
 
     banner "switching branch to $sha"
     git checkout $sha
 
+    rm -f stdout.txt
+    rm -f stderr.txt
+
     banner "compiling $sha"
-    make bins
+    make bins 1>stdout.txt 2>stderr.txt | true
+    local exit_code="${PIPESTATUS[0]}"
+    if [ "$exit_code" -ne "0" ]; then
+        cat stdout.txt
+        cat stderr.txt 1>&2
+        exit $exit_code
+    fi
+}
+
+function benchmark_runner() {
+    local sha=$1
+    local lua_script=$2
 
     banner "benchmarking $sha"
-    $PWD/benchmarks/runner/runner -loadtest -script=$lua_script
+    banner "benchmark output $sha" | tee -a benchmark.txt 1>/dev/null
+    $PWD/benchmarks/runner/runner -loadtest -script=$lua_script \
+        | tee -a benchmark.txt 1>/dev/null
+    local exit_code2="${PIPESTATUS[0]}"
+    if [ "$exit_code2" -ne "0" ]; then
+        cat benchmark.txt
+        exit $exit_code2
+    fi
+}
+
+function go_bench() {
+    rm -f "bench_$sha.txt"
+    touch "bench_$sha.txt"
+    for i in `seq 5`; do
+        banner "running bench program $sha iter $i"
+        make bench | tee -a "bench_$sha.txt"
+    done
 }
 
 # Go to root dir
@@ -46,7 +76,30 @@ while [ "$(basename $PWD)" != "zanzibar" ]; do
     cd ..
 done
 
-run $CURRENT_SHA $2
-run $OTHER_SHA $2
+rm -f benchmark.txt
+touch benchmark.txt
+
+if [ "$BENCHMARK_FILE" -eq "bench" ]; then
+    run $CURRENT_SHA
+    go_bench $CURRENT_SHA
+    run $OTHER_SHA
+    go_bench $OTHER_SHA
+
+    go get -u golang.org/x/tools/cmd/benchcmp
+    echo "Comparing old $CURRENT_SHA to new $OTHER_SHA"
+    benchmp -best "bench_$CURRENT_SHA.txt" "bench_$OTHER_SHA.txt"
+
+else
+    run $CURRENT_SHA
+    benchmark_runner $CURRENT_SHA $BENCHMARK_FILE
+    run $OTHER_SHA
+    benchmark_runner $OTHER_SHA $BENCHMARK_FILE
+
+    cat benchmark.txt
+    rm -f benchmark.txt
+fi
+
 
 git checkout $CURRENT_SHA
+rm -f stdout.txt
+rm -f stderr.txt

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -88,6 +88,11 @@ func (c *tchannelClient) writeArgs(call *tchannel.OutboundCall, headers map[stri
 func (c *tchannelClient) readResponse(response *tchannel.OutboundCallResponse, resp RWTStruct) (bool, map[string]string, error) {
 	reader, err := response.Arg2Reader()
 	if err != nil {
+		// Do not wrap system errors.
+		if _, ok := err.(tchannel.SystemError); ok {
+			return false, nil, err
+		}
+
 		return false, nil, errors.Wrapf(err, "could not create arg2reader for outbound call response: %s", c.serviceName)
 	}
 
@@ -155,6 +160,11 @@ func (c *tchannelClient) Call(ctx context.Context, thriftService, methodName str
 		return err
 	})
 	if err != nil {
+		// Do not wrap system errors.
+		if _, ok := err.(tchannel.SystemError); ok {
+			return false, nil, err
+		}
+
 		return false, nil, errors.Wrapf(err, "could not make outbound call: %s", c.serviceName)
 	}
 

--- a/runtime/tchannel_helpers.go
+++ b/runtime/tchannel_helpers.go
@@ -71,20 +71,6 @@ func PutBuffer(buf *bytes.Buffer) {
 	bufPool.Put(buf)
 }
 
-// WriteStruct writes the given Thriftrw struct to a writer.
-func WriteStruct(writer io.Writer, s RWTStruct) error {
-	wireValue, err := s.ToWire()
-	if err != nil {
-		return err
-	}
-
-	if err := protocol.Binary.Encode(wireValue, writer); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ReadStruct reads the given Thriftrw struct.
 func ReadStruct(reader io.Reader, s RWTStruct) error {
 	readerAt, ok := reader.(io.ReaderAt)

--- a/runtime/tchannel_logger_test.go
+++ b/runtime/tchannel_logger_test.go
@@ -85,8 +85,8 @@ func TestTChannelLoggerWithFields(t *testing.T) {
 		assert.Nil(t, logger.Fields(), "Fields() always return nil")
 
 		fields := []tchannel.LogField{
-			{"a", "foo"},
-			{"b", 42},
+			{Key: "a", Value: "foo"},
+			{Key: "b", Value: 42},
 		}
 		expectedFields := []zapcore.Field{}
 		for _, f := range fields {

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -201,10 +201,7 @@ func (s *TChannelRouter) handle(ctx context.Context, handler handler, service st
 		return errors.Wrapf(err, "could not close arg3reader is empty for inbound call: %s::%s", service, method)
 	}
 
-	respBuf := GetBuffer()
-	defer PutBuffer(respBuf)
-
-	err = WriteStruct(respBuf, resp)
+	structWireValue, err := resp.ToWire()
 	if err != nil {
 		// If we could not write the body then we should do something else
 		// instead.
@@ -239,7 +236,7 @@ func (s *TChannelRouter) handle(ctx context.Context, handler handler, service st
 		return errors.Wrapf(err, "could not create arg3writer for inbound call response: %s::%s", service, method)
 	}
 
-	_, err = twriter.Write(respBuf.Bytes())
+	err = protocol.Binary.Encode(structWireValue, twriter)
 	if err != nil {
 		_ = twriter.Close()
 

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -190,11 +190,12 @@ func (writer *DoubleCloseWriter) Close() error {
 
 func (s *TChannelRouter) handle(ctx context.Context, handler handler, service string, method string, call *tchannel.InboundCall) error {
 	treader, err := call.Arg2Reader()
-	reader := DoubleCloseReader{ReadCloser: treader}
-	defer reader.HardClose()
 	if err != nil {
 		return errors.Wrapf(err, "could not create arg2reader for inbound call: %s::%s", service, method)
 	}
+	reader := DoubleCloseReader{ReadCloser: treader}
+	defer reader.HardClose()
+
 	headers, err := ReadHeaders(reader)
 	if err != nil {
 		return errors.Wrapf(err, "could not reade headers for inbound call: %s::%s", service, method)
@@ -208,11 +209,11 @@ func (s *TChannelRouter) handle(ctx context.Context, handler handler, service st
 	}
 
 	treader, err = call.Arg3Reader()
-	reader = DoubleCloseReader{ReadCloser: treader}
-	defer reader.HardClose()
 	if err != nil {
 		return errors.Wrapf(err, "could not create arg3reader for inbound call: %s::%s", service, method)
 	}
+	reader = DoubleCloseReader{ReadCloser: treader}
+	defer reader.HardClose()
 
 	buf := GetBuffer()
 	defer PutBuffer(buf)
@@ -273,11 +274,11 @@ func (s *TChannelRouter) handle(ctx context.Context, handler handler, service st
 	}
 
 	twriter, err := call.Response().Arg2Writer()
-	writer := DoubleCloseWriter{WriteFlusher: twriter}
-	defer writer.HardClose()
 	if err != nil {
 		return errors.Wrapf(err, "could not create arg2writer for inbound call response: %s::%s", service, method)
 	}
+	writer := DoubleCloseWriter{WriteFlusher: twriter}
+	defer writer.HardClose()
 
 	if err := WriteHeaders(writer, respHeaders); err != nil {
 		return errors.Wrapf(err, "could not write headers for inbound call response: %s::%s", service, method)
@@ -287,11 +288,11 @@ func (s *TChannelRouter) handle(ctx context.Context, handler handler, service st
 	}
 
 	twriter, err = call.Response().Arg3Writer()
-	writer = DoubleCloseWriter{WriteFlusher: twriter}
-	defer writer.HardClose()
 	if err != nil {
 		return errors.Wrapf(err, "could not create arg3writer for inbound call response: %s::%s", service, method)
 	}
+	writer = DoubleCloseWriter{WriteFlusher: twriter}
+	defer writer.HardClose()
 
 	_, err = writer.Write(respBuf.Bytes())
 	if err != nil {

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -128,8 +128,6 @@ func TestCompare(t *testing.T) {
 		}, nil, nil
 	}
 
-	// bazClient.NewSimpleServiceCompareHandler
-
 	gateway.TChannelBackends()["baz"].Register(
 		"SimpleService",
 		"compare",

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -192,7 +192,7 @@ func TestCompareInvalidArgs(t *testing.T) {
 
 	gateway.TChannelBackends()["baz"].Register(
 		"SimpleService",
-		"Compare",
+		"compare",
 		bazClient.NewSimpleServiceCompareHandler(fakeCompare),
 	)
 

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -27,13 +27,14 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 
 	"github.com/uber/zanzibar/examples/example-gateway/build/clients"
-	bazServer "github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
 	"github.com/uber/zanzibar/examples/example-gateway/build/endpoints"
-	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/base"
+	clientsBazBase "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/base"
 	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/baz"
 )
 
@@ -41,12 +42,12 @@ var testCompareCounter int
 
 func compare(
 	ctx context.Context, reqHeaders map[string]string, args *baz.SimpleService_Compare_Args,
-) (*base.BazResponse, map[string]string, error) {
+) (*clientsBazBase.BazResponse, map[string]string, error) {
 	testCompareCounter++
 	r1 := args.Arg1
 	r2 := args.Arg2
 	if r1.B1 && r1.S2 == "hello" && r1.I3 == 42 && r2.B1 && r2.S2 == "hola" && r2.I3 == 42 {
-		return &base.BazResponse{
+		return &clientsBazBase.BazResponse{
 			Message: "different",
 		}, nil, nil
 	}
@@ -74,7 +75,7 @@ func BenchmarkCompare(b *testing.B) {
 	gateway.TChannelBackends()["baz"].Register(
 		"SimpleService",
 		"compare",
-		bazServer.NewSimpleServiceCompareHandler(compare),
+		bazClient.NewSimpleServiceCompareHandler(compare),
 	)
 
 	b.ResetTimer()
@@ -104,4 +105,56 @@ func BenchmarkCompare(b *testing.B) {
 
 	b.StopTimer()
 	gateway.Close()
+}
+
+func TestCompare(t *testing.T) {
+	gateway, err := testGateway.CreateGateway(t, testConfig, testOptions)
+	if !assert.NoError(t, err, "got bootstrap err") {
+		return
+	}
+	defer gateway.Close()
+
+	callCounter := 0
+
+	fakeCompare := func(
+		ctx context.Context,
+		reqHeaders map[string]string,
+		args *baz.SimpleService_Compare_Args,
+	) (*clientsBazBase.BazResponse, map[string]string, error) {
+		callCounter++
+
+		return &clientsBazBase.BazResponse{
+			Message: "a message",
+		}, nil, nil
+	}
+
+	// bazClient.NewSimpleServiceCompareHandler
+
+	gateway.TChannelBackends()["baz"].Register(
+		"SimpleService",
+		"compare",
+		bazClient.NewSimpleServiceCompareHandler(fakeCompare),
+	)
+
+	res, err := gateway.MakeRequest(
+		"POST", "/baz/compare", nil,
+		bytes.NewBuffer([]byte(`{
+			"arg1":{ "b1":true,"s2":"a","i3":1 },
+			"arg2":{ "b1":true,"s2":"a","i3":1 }
+		}`)),
+	)
+
+	if !assert.NoError(t, err, "got request error") {
+		return
+	}
+
+	assert.Equal(t, 1, callCounter)
+	assert.Equal(t, 200, res.StatusCode)
+
+	bytes, err := ioutil.ReadAll(res.Body)
+	if !assert.NoError(t, err, "got read error") {
+		return
+	}
+
+	assert.Equal(t, `{"message":"a message"}`, string(bytes))
 }

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -196,4 +196,25 @@ func TestPingWithInvalidResponse(t *testing.T) {
 	}
 
 	assert.Equal(t, `{"error":"Unexpected server error"}`, string(bytes))
+
+	allLogs := gateway.AllLogs()
+
+	assert.Equal(t, 7, len(allLogs))
+	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
+	assert.Equal(t, 1, len(allLogs["Outbound connection is active."]))
+	assert.Equal(t, 1, len(allLogs["Failed after non-retriable error."]))
+	assert.Equal(t, 1, len(allLogs["Could not make client request"]))
+	assert.Equal(t, 1, len(allLogs["Workflow for endpoint returned error"]))
+	assert.Equal(t, 1, len(allLogs["Sending error for endpoint request"]))
+	assert.Equal(t, 1, len(allLogs["Finished an incoming server HTTP request"]))
+
+	logLines := gateway.Logs("warn", "Could not make client request")
+	assert.Equal(t, 1, len(logLines))
+
+	logObj := logLines[0]
+	assert.Equal(
+		t,
+		"tchannel error ErrCodeUnexpected: Server Error",
+		logObj["error"].(string),
+	)
 }

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -199,7 +199,8 @@ func TestPingWithInvalidResponse(t *testing.T) {
 
 	allLogs := gateway.AllLogs()
 
-	assert.Equal(t, 7, len(allLogs))
+	assert.Equal(t, 8, len(allLogs))
+	assert.Equal(t, 1, len(allLogs["Finished a downstream TChannel request"]))
 	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
 	assert.Equal(t, 1, len(allLogs["Outbound connection is active."]))
 	assert.Equal(t, 1, len(allLogs["Failed after non-retriable error."]))


### PR DESCRIPTION
  - For the server, make sure we close reader/writer.
  - For the client, make sure we close reader/writer.
  - For client/server, do thrift validation into a buffer
        and do not write an invalid partial RPC request down the wire

r: @uber/zanzibar-team