### PR TITLE
Fix acronyms mapping in the Type Converter

### DIFF
--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -191,7 +191,7 @@ func (c *TypeConverter) genConverterForList(
 			valueStruct,
 			fromFieldType.ValueSpec,
 			"value",
-			keyPrefix+strings.Title(toField.Name)+"[index]",
+			keyPrefix+pascalCase(toField.Name)+"[index]",
 			"	"+indent,
 		)
 		if err != nil {
@@ -256,7 +256,7 @@ func (c *TypeConverter) genConverterForMap(
 			valueStruct,
 			fromFieldType.ValueSpec,
 			"value",
-			keyPrefix+strings.Title(toField.Name)+"[key]",
+			keyPrefix+pascalCase(toField.Name)+"[key]",
 			"	"+indent,
 		)
 		if err != nil {
@@ -294,8 +294,8 @@ func (c *TypeConverter) genStructConverter(
 			)
 		}
 
-		toIdentifier := indent + "out." + keyPrefix + strings.Title(toField.Name)
-		fromIdentifier := "in." + keyPrefix + strings.Title(fromField.Name)
+		toIdentifier := indent + "out." + keyPrefix + pascalCase(toField.Name)
+		fromIdentifier := "in." + keyPrefix + pascalCase(fromField.Name)
 
 		// Override thrift type names to avoid naming collisions between endpoint
 		// and client types.
@@ -341,7 +341,7 @@ func (c *TypeConverter) genStructConverter(
 				toFieldType,
 				fromField.Type,
 				fromIdentifier,
-				keyPrefix+strings.Title(toField.Name),
+				keyPrefix+pascalCase(toField.Name),
 				indent,
 			)
 			if err != nil {

--- a/codegen/type_converter_test.go
+++ b/codegen/type_converter_test.go
@@ -990,14 +990,14 @@ func TestConvertStructWithAcoronymTypes(t *testing.T) {
 	assert.Equal(t, trim(`
 		if in.Three != nil {
 			out.Three = &structs.NestedBar{}
-			out.Three.uuid = string(in.Three.uuid)
+			out.Three.UUID = string(in.Three.UUID)
 			out.Three.Two = (*string)(in.Three.Two)
 		} else {
 			out.Three = nil
 		}
 		if in.Four != nil {
 			out.Four = &structs.NestedBar{}
-			out.Four.uuid = string(in.Four.uuid)
+			out.Four.UUID = string(in.Four.UUID)
 			out.Four.Two = (*string)(in.Four.Two)
 		} else {
 			out.Four = nil


### PR DESCRIPTION
Currently the type converter does not use the pascalCasing method that will capitalize common acronyms. This is needed for mapping fields in a manner that is consistent with the thrift compiler.