### PR TITLE
Read/Write Thrift file meta in a repository

### DIFF
--- a/backend/repository/thrift_update.go
+++ b/backend/repository/thrift_update.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package repository
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	metaJSONFilePath = "idls.json"
+)
+
+// ThriftConfig returns the meta of thrifts for a runtime repository.
+func (r *Repository) ThriftConfig(idlRoot string) (map[string]*ThriftMeta, error) {
+	r.RLock()
+	defer r.RUnlock()
+	config := make(map[string]*ThriftMeta)
+	err := readJSONFile(r.absPath(metaJSONFilePath), &config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal idls.json file")
+	}
+	return config, nil
+}
+
+// WriteThriftFileAndConfig writes the update the file contents and meta config.
+func (r *Repository) WriteThriftFileAndConfig(thriftMeta map[string]*ThriftMeta) error {
+	cfg, err := r.LatestGatewayConfig()
+	if err != nil {
+		return errors.Wrap(err, "invalid configuration before updating thrifts")
+	}
+	thriftRootDir := cfg.ThriftRootDir
+	curMeta, err := r.ThriftConfig(thriftRootDir)
+	if err != nil {
+		return err
+	}
+	// Merge updated thriftMeta into curMeta
+	for path, meta := range thriftMeta {
+		curMeta[path] = meta
+	}
+	r.Lock()
+	defer r.Unlock()
+	for _, meta := range thriftMeta {
+		if err := r.writeThriftFile(thriftRootDir, meta); err != nil {
+			return err
+		}
+		meta.Content = ""
+	}
+	return r.writeThriftConfig(curMeta)
+}
+
+// writeThriftFile update the content of a thrift file.
+func (r *Repository) writeThriftFile(idlRoot string, meta *ThriftMeta) error {
+	if meta == nil || meta.Path == "" || meta.Content == "" {
+		return errors.Errorf("meta is invalid: %+v", meta)
+	}
+	path := r.absPath(filepath.Join(idlRoot, meta.Path))
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return errors.Wrapf(err, "faile to creat dir %s", dir)
+	}
+	if err := ioutil.WriteFile(path, []byte(meta.Content), os.ModePerm); err != nil {
+		return errors.Wrap(err, "failed to write thrift file")
+	}
+	return nil
+}
+
+// writeThriftConfig writes the meta of trifts into a runtime repository.
+func (r *Repository) writeThriftConfig(meta map[string]*ThriftMeta) error {
+	b, err := json.MarshalIndent(meta, "", "\t")
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal thrift meta")
+	}
+	path := r.absPath(metaJSONFilePath)
+	err = ioutil.WriteFile(path, b, os.ModePerm)
+	if err != nil {
+		return errors.Wrap(err, "failed to write thrift idls.json")
+	}
+	return nil
+}
+
+// ThriftFileVersion returns the version of a thrft file.
+func (r *Repository) ThriftFileVersion(thriftFile string) (string, error) {
+	path := r.absPath(metaJSONFilePath)
+	r.RLock()
+	defer r.RUnlock()
+	meta := make(map[string]*ThriftMeta)
+	err := readJSONFile(path, &meta)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal the content of thrift meta file")
+	}
+	thriftMeta, ok := meta[thriftFile]
+	if !ok {
+		return "", errors.Errorf("can't find thrift file <%s> in thrift meta file", thriftFile)
+	}
+	return thriftMeta.Version, nil
+}

--- a/backend/repository/thrift_update_test.go
+++ b/backend/repository/thrift_update_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package repository
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	testlib "github.com/uber/zanzibar/test/lib"
+)
+
+func TestThriftConfig(t *testing.T) {
+	tempDir, err := copyExample(t)
+	if !assert.NoError(t, err, "Failed to copy example.") {
+		return
+	}
+	r := &Repository{
+		localDir: tempDir,
+	}
+	meta, err := r.ThriftConfig(r.LocalDir())
+	if !assert.NoError(t, err, "Failed to read thrift configs.") {
+		return
+	}
+	b, err := json.MarshalIndent(meta, "", "\t")
+	b = append(b, []byte("\n")...)
+	if !assert.NoError(t, err, "Failed to marshal meta to bytes.") {
+		return
+	}
+	testlib.CompareGoldenFile(t, "../../examples/example-gateway/idls.json", b)
+}
+
+func TestThriftVersion(t *testing.T) {
+
+	tempDir, err := copyExample(t)
+	if !assert.NoError(t, err, "Failed to copy example.") {
+		return
+	}
+	r := &Repository{
+		localDir: tempDir,
+	}
+	v, err := r.ThriftFileVersion("endpoints/bar/bar.thrift")
+	if !assert.NoError(t, err, "Failed to read thrift version.") {
+		return
+	}
+	assert.Equal(t, "v1", v)
+
+	_, err = r.ThriftFileVersion("no-such-file.thrift")
+	assert.Error(t, err, "should failed to fetch a non exist file.")
+}
+
+func TestWriteThriftFileAndConfig(t *testing.T) {
+	path := "a/new/file/name.thrift"
+	version := "new version"
+	newMeta := map[string]*ThriftMeta{
+		path: &ThriftMeta{
+			Path:    path,
+			Version: version,
+			Content: "filecontent",
+		},
+	}
+
+	tempDir, err := copyExample(t)
+	if !assert.NoError(t, err, "Failed to copy example.") {
+		return
+	}
+	r := &Repository{
+		localDir: tempDir,
+	}
+
+	err = r.WriteThriftFileAndConfig(newMeta)
+	if !assert.NoError(t, err, "Failed to write new thrift configuration.") {
+		return
+	}
+
+	v, err := r.ThriftFileVersion(path)
+	if !assert.NoError(t, err, "Failed to read thrift version.") {
+		return
+	}
+	assert.Equal(t, version, v)
+}

--- a/examples/example-gateway/idls.json
+++ b/examples/example-gateway/idls.json
@@ -1,0 +1,50 @@
+{
+	"clients/bar/bar.thrift": {
+		"path": "clients/bar/bar.thrift",
+		"version": "v1"
+	},
+	"clients/baz/base.thrift": {
+		"path": "clients/baz/base.thrift",
+		"version": "v1"
+	},
+	"clients/baz/baz.thrift": {
+		"path": "clients/baz/baz.thrift",
+		"version": "v1"
+	},
+	"clients/contacts/contacts.thrift": {
+		"path": "clients/contacts/contacts.thrift",
+		"version": "v1"
+	},
+	"clients/foo/foo.thrift": {
+		"path": "clients/foo/foo.thrift",
+		"version": "v1"
+	},
+	"clients/googlenow/googlenow.thrift": {
+		"path": "clients/googlenow/googlenow.thrift",
+		"version": "v1"
+	},
+	"endpoints/bar/bar.thrift": {
+		"path": "endpoints/bar/bar.thrift",
+		"version": "v1"
+	},
+	"endpoints/baz/baz.thrift": {
+		"path": "endpoints/baz/baz.thrift",
+		"version": "v1"
+	},
+	"endpoints/contacts/contacts.thrift": {
+		"path": "endpoints/contacts/contacts.thrift",
+		"version": "v1"
+	},
+	"endpoints/foo/foo.thrift": {
+		"path": "endpoints/foo/foo.thrift",
+		"version": "v1"
+	},
+	"endpoints/googlenow/googlenow.thrift": {
+		"path": "endpoints/googlenow/googlenow.thrift",
+		"version": "v1"
+	},
+	"endpoints/tchannel/baz/baz.thrift": {
+		"path": "endpoints/tchannel/baz/baz.thrift",
+		"version": "v1"
+	}
+}


### PR DESCRIPTION
This PR adds "idls.json" file to store the meta data of thrift files in a repository.

In next PR, I will add a thrift registration repository to update the thrift files and the meta data in "idls.json".