### PR TITLE
Expose dependencies tree on BenchGateway for testing

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1102,7 +1102,7 @@ func getConfig() *zanzibar.StaticConfig {
 func createGateway() (*zanzibar.Gateway, error) {
 	config := getConfig()
 	
-	gateway, err := service.CreateGateway(config, nil)
+	gateway, _, err := service.CreateGateway(config, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,7 +1158,7 @@ func mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "main.tmpl", size: 1971, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "main.tmpl", size: 1974, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1274,10 +1274,17 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
+// DependenciesTree contains all deps for this service.
+type DependenciesTree struct {
+	{{range $idx, $className := $instance.DependencyOrder -}}
+	{{$className | title}} *{{$className | title}}DependenciesNodes
+	{{end -}}
+}
+
 {{range $idx, $className := $instance.DependencyOrder -}}
 {{$moduleInstances := (index $instance.RecursiveDependencies $className) -}}
 // {{$className}}Dependencies contains {{$className}} dependencies
-type {{$className}}Dependencies struct {
+type {{$className | title}}DependenciesNodes struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
 	{{end -}}
@@ -1286,13 +1293,18 @@ type {{$className}}Dependencies struct {
 
 // InitializeDependencies fully initializes all dependencies in the dep tree
 // for the {{$instance.InstanceName}} {{$instance.ClassName}}
-func InitializeDependencies(gateway *zanzibar.Gateway) *Dependencies {
+func InitializeDependencies(
+	gateway *zanzibar.Gateway,
+) (*DependenciesTree, *Dependencies) {
 	{{- if not $instance.HasDependencies}}
-	return {{$instance.PackageInfo.ExportName}}(gateway)
+	return nil, {{$instance.PackageInfo.ExportName}}(gateway)
 	{{- else}}
+	tree := &DependenciesTree{}
+
 	{{- range $idx, $className := $instance.DependencyOrder}}
 	{{- $moduleInstances := (index $instance.RecursiveDependencies $className)}}
-	initialized{{$className | pascal}}Dependencies := &{{$className}}Dependencies{}
+	initialized{{$className | pascal}}Dependencies := &{{$className | title}}DependenciesNodes{}
+	tree.{{$className | title}} = initialized{{$className | pascal}}Dependencies
 
 	{{- range $idx, $dependency := $moduleInstances}}
 	{{- if $dependency.HasDependencies}}
@@ -1311,7 +1323,7 @@ func InitializeDependencies(gateway *zanzibar.Gateway) *Dependencies {
 	{{- end}}
 	{{end}}
 
-	return &Dependencies{
+	return tree, &Dependencies{
 		{{- range $className, $moduleInstances := $instance.ResolvedDependencies}}
 		{{$className | pascal}}: &{{$className | pascal}}Dependencies{
 			{{- range $idy, $subDependency := $moduleInstances}}
@@ -1334,7 +1346,7 @@ func module_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_initializer.tmpl", size: 2942, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_initializer.tmpl", size: 3337, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1355,24 +1367,27 @@ import (
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 )
 
+// DependenciesTree re-exported for convenience.
+type DependenciesTree module.DependenciesTree
+
 // CreateGateway creates a new instances of the {{$instance.InstanceName}}
 // service with the specified config
 func CreateGateway(
 	config *zanzibar.StaticConfig,
 	opts *zanzibar.Options,
-) (*zanzibar.Gateway, error) {
+) (*zanzibar.Gateway, interface{}, error) {
 	gateway, err := zanzibar.CreateGateway(config, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	dependencies := module.InitializeDependencies(gateway)
+	tree, dependencies := module.InitializeDependencies(gateway)
 	registerErr := registerEndpoints(gateway, dependencies)
 	if registerErr != nil {
-		return nil, registerErr
+		return nil, nil, registerErr
 	}
 
-	return gateway, nil
+	return gateway, (*DependenciesTree)(tree), nil
 }
 
 func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {
@@ -1396,7 +1411,7 @@ func serviceTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service.tmpl", size: 1118, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service.tmpl", size: 1270, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1283,7 +1283,7 @@ type DependenciesTree struct {
 
 {{range $idx, $className := $instance.DependencyOrder -}}
 {{$moduleInstances := (index $instance.RecursiveDependencies $className) -}}
-// {{$className}}Dependencies contains {{$className}} dependencies
+// {{$className | title}}DependenciesNodes contains {{$className}} dependencies
 type {{$className | title}}DependenciesNodes struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
@@ -1346,7 +1346,7 @@ func module_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_initializer.tmpl", size: 3337, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_initializer.tmpl", size: 3350, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -41,7 +41,7 @@ func getConfig() *zanzibar.StaticConfig {
 func createGateway() (*zanzibar.Gateway, error) {
 	config := getConfig()
 	
-	gateway, err := service.CreateGateway(config, nil)
+	gateway, _, err := service.CreateGateway(config, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -15,10 +15,17 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
+// DependenciesTree contains all deps for this service.
+type DependenciesTree struct {
+	{{range $idx, $className := $instance.DependencyOrder -}}
+	{{$className | title}} *{{$className | title}}DependenciesNodes
+	{{end -}}
+}
+
 {{range $idx, $className := $instance.DependencyOrder -}}
 {{$moduleInstances := (index $instance.RecursiveDependencies $className) -}}
-// {{$className}}Dependencies contains {{$className}} dependencies
-type {{$className}}Dependencies struct {
+// {{$className}}DependenciesNodes contains {{$className}} dependencies
+type {{$className | title}}DependenciesNodes struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}
 	{{end -}}
@@ -27,13 +34,18 @@ type {{$className}}Dependencies struct {
 
 // InitializeDependencies fully initializes all dependencies in the dep tree
 // for the {{$instance.InstanceName}} {{$instance.ClassName}}
-func InitializeDependencies(gateway *zanzibar.Gateway) *Dependencies {
+func InitializeDependencies(
+	gateway *zanzibar.Gateway,
+) (*DependenciesTree, *Dependencies) {
 	{{- if not $instance.HasDependencies}}
-	return {{$instance.PackageInfo.ExportName}}(gateway)
+	return nil, {{$instance.PackageInfo.ExportName}}(gateway)
 	{{- else}}
+	tree := &DependenciesTree{}
+
 	{{- range $idx, $className := $instance.DependencyOrder}}
 	{{- $moduleInstances := (index $instance.RecursiveDependencies $className)}}
-	initialized{{$className | pascal}}Dependencies := &{{$className}}Dependencies{}
+	initialized{{$className | pascal}}Dependencies := &{{$className | title}}DependenciesNodes{}
+	tree.{{$className | title}} = initialized{{$className | pascal}}Dependencies
 
 	{{- range $idx, $dependency := $moduleInstances}}
 	{{- if $dependency.HasDependencies}}
@@ -52,7 +64,7 @@ func InitializeDependencies(gateway *zanzibar.Gateway) *Dependencies {
 	{{- end}}
 	{{end}}
 
-	return &Dependencies{
+	return tree, &Dependencies{
 		{{- range $className, $moduleInstances := $instance.ResolvedDependencies}}
 		{{$className | pascal}}: &{{$className | pascal}}Dependencies{
 			{{- range $idy, $subDependency := $moduleInstances}}

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -24,7 +24,7 @@ type DependenciesTree struct {
 
 {{range $idx, $className := $instance.DependencyOrder -}}
 {{$moduleInstances := (index $instance.RecursiveDependencies $className) -}}
-// {{$className}}DependenciesNodes contains {{$className}} dependencies
+// {{$className | title}}DependenciesNodes contains {{$className}} dependencies
 type {{$className | title}}DependenciesNodes struct {
 	{{ range $idx, $dependency := $moduleInstances -}}
 	{{$dependency.PackageInfo.QualifiedInstanceName}} {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportType}}

--- a/codegen/templates/service.tmpl
+++ b/codegen/templates/service.tmpl
@@ -14,24 +14,27 @@ import (
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 )
 
+// DependenciesTree re-exported for convenience.
+type DependenciesTree module.DependenciesTree
+
 // CreateGateway creates a new instances of the {{$instance.InstanceName}}
 // service with the specified config
 func CreateGateway(
 	config *zanzibar.StaticConfig,
 	opts *zanzibar.Options,
-) (*zanzibar.Gateway, error) {
+) (*zanzibar.Gateway, interface{}, error) {
 	gateway, err := zanzibar.CreateGateway(config, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	dependencies := module.InitializeDependencies(gateway)
+	tree, dependencies := module.InitializeDependencies(gateway)
 	registerErr := registerEndpoints(gateway, dependencies)
 	if registerErr != nil {
-		return nil, registerErr
+		return nil, nil, registerErr
 	}
 
-	return gateway, nil
+	return gateway, (*DependenciesTree)(tree), nil
 }
 
 func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -61,7 +61,7 @@ func getConfig() *zanzibar.StaticConfig {
 func createGateway() (*zanzibar.Gateway, error) {
 	config := getConfig()
 
-	gateway, err := service.CreateGateway(config, nil)
+	gateway, _, err := service.CreateGateway(config, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -47,7 +47,7 @@ type DependenciesTree struct {
 	Endpoint *EndpointDependenciesNodes
 }
 
-// clientDependencies contains client dependencies
+// ClientDependenciesNodes contains client dependencies
 type ClientDependenciesNodes struct {
 	Bar       barClientGenerated.Client
 	Baz       bazClientGenerated.Client
@@ -55,7 +55,7 @@ type ClientDependenciesNodes struct {
 	GoogleNow googlenowClientGenerated.Client
 }
 
-// endpointDependencies contains endpoint dependencies
+// EndpointDependenciesNodes contains endpoint dependencies
 type EndpointDependenciesNodes struct {
 	Bar         barEndpointGenerated.Endpoint
 	Baz         bazEndpointGenerated.Endpoint

--- a/examples/example-gateway/build/services/example-gateway/service.go
+++ b/examples/example-gateway/build/services/example-gateway/service.go
@@ -29,24 +29,27 @@ import (
 	module "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
 )
 
+// DependenciesTree re-exported for convenience.
+type DependenciesTree module.DependenciesTree
+
 // CreateGateway creates a new instances of the example-gateway
 // service with the specified config
 func CreateGateway(
 	config *zanzibar.StaticConfig,
 	opts *zanzibar.Options,
-) (*zanzibar.Gateway, error) {
+) (*zanzibar.Gateway, interface{}, error) {
 	gateway, err := zanzibar.CreateGateway(config, opts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	dependencies := module.InitializeDependencies(gateway)
+	tree, dependencies := module.InitializeDependencies(gateway)
 	registerErr := registerEndpoints(gateway, dependencies)
 	if registerErr != nil {
-		return nil, registerErr
+		return nil, nil, registerErr
 	}
 
-	return gateway, nil
+	return gateway, (*DependenciesTree)(tree), nil
 }
 
 func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -25,8 +25,6 @@ import (
 	"net/http"
 	"testing"
 
-	barClient "github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-
 	"github.com/stretchr/testify/assert"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
 	zanzibar "github.com/uber/zanzibar/runtime"
@@ -114,7 +112,8 @@ func TestMakingClientCalLWithHeaders(t *testing.T) {
 		},
 	)
 
-	barClient := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	barClient := deps.Client.Bar
 	client := barClient.HTTPClient()
 
 	req := zanzibar.NewClientHTTPRequest("bar", "bar-path", client)
@@ -168,7 +167,8 @@ func TestMakingClientCalLWithRespHeaders(t *testing.T) {
 		},
 	)
 
-	bClient := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bClient := deps.Client.Bar
 
 	body, headers, err := bClient.Normal(
 		context.Background(), nil, &clientsBarBar.Bar_Normal_Args{},
@@ -200,7 +200,8 @@ func TestMakingClientCallWithThriftException(t *testing.T) {
 		},
 	)
 
-	bClient := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bClient := deps.Client.Bar
 
 	body, _, err := bClient.Normal(
 		context.Background(), nil, &clientsBarBar.Bar_Normal_Args{},
@@ -233,7 +234,8 @@ func TestMakingClientCallWithBadStatusCode(t *testing.T) {
 		},
 	)
 
-	bClient := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bClient := deps.Client.Bar
 
 	body, _, err := bClient.Normal(
 		context.Background(), nil, &clientsBarBar.Bar_Normal_Args{},
@@ -264,7 +266,8 @@ func TestMakingCallWithThriftException(t *testing.T) {
 	)
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
-	bClient := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bClient := deps.Client.Bar
 
 	_, err = bClient.ArgNotStruct(
 		context.Background(), nil,

--- a/test/clients/bar/bar_test.go
+++ b/test/clients/bar/bar_test.go
@@ -27,8 +27,6 @@ import (
 	"net/http"
 	"testing"
 
-	barClient "github.com/uber/zanzibar/examples/example-gateway/build/clients/bar"
-
 	barGen "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
@@ -82,7 +80,8 @@ func TestEchoI8(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoI8(
 		context.Background(), nil, &barGen.Echo_EchoI8_Args{Arg: arg},
@@ -127,7 +126,8 @@ func TestEchoI16(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoI16(
 		context.Background(), nil, &barGen.Echo_EchoI16_Args{Arg: arg},
@@ -172,7 +172,8 @@ func TestEchoI32(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoI32(
 		context.Background(), nil, &barGen.Echo_EchoI32_Args{Arg: arg},
@@ -217,7 +218,8 @@ func TestEchoI64(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoI64(
 		context.Background(), nil, &barGen.Echo_EchoI64_Args{Arg: arg},
@@ -262,7 +264,8 @@ func TestEchoDouble(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoDouble(
 		context.Background(), nil, &barGen.Echo_EchoDouble_Args{Arg: arg},
@@ -307,7 +310,8 @@ func TestEchoBool(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoBool(
 		context.Background(), nil, &barGen.Echo_EchoBool_Args{Arg: arg},
@@ -352,7 +356,8 @@ func TestEchoString(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoString(
 		context.Background(), nil, &barGen.Echo_EchoString_Args{Arg: arg},
@@ -397,7 +402,8 @@ func TestEchoBinary(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoBinary(
 		context.Background(), nil, &barGen.Echo_EchoBinary_Args{Arg: arg},
@@ -443,7 +449,8 @@ func TestEchoEnum(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoEnum(
 		context.Background(), nil, &barGen.Echo_EchoEnum_Args{Arg: arg},
@@ -488,7 +495,8 @@ func TestEchoTypedef(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoTypedef(
 		context.Background(), nil, &barGen.Echo_EchoTypedef_Args{Arg: arg},
@@ -536,7 +544,8 @@ func TestEchoStringSet(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStringSet(
 		context.Background(), nil, &barGen.Echo_EchoStringSet_Args{Arg: arg},
@@ -593,7 +602,8 @@ func TestEchoStructSet(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStructSet(
 		context.Background(), nil, &barGen.Echo_EchoStructSet_Args{Arg: arg},
@@ -638,7 +648,8 @@ func TestEchoStringList(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStringList(
 		context.Background(), nil, &barGen.Echo_EchoStringList_Args{Arg: arg},
@@ -695,7 +706,8 @@ func TestEchoStructList(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStructList(
 		context.Background(), nil, &barGen.Echo_EchoStructList_Args{Arg: arg},
@@ -752,7 +764,8 @@ func TestEchoStringMap(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStringMap(
 		context.Background(), nil, &barGen.Echo_EchoStringMap_Args{Arg: arg},
@@ -814,7 +827,8 @@ func TestEchoStructMap(t *testing.T) {
 			assert.NoError(t, err)
 		},
 	)
-	bar := barClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bar := deps.Client.Bar
 
 	result, _, err := bar.EchoStructMap(
 		context.Background(), nil, &barGen.Echo_EchoStructMap_Args{Arg: arg},

--- a/test/clients/baz/baz_test.go
+++ b/test/clients/baz/baz_test.go
@@ -71,7 +71,8 @@ func TestEchoI8(t *testing.T) {
 		"echoI8",
 		bazClient.NewSecondServiceEchoI8Handler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoI8(
 		context.Background(), nil, &bazGen.SecondService_EchoI8_Args{Arg: arg},
@@ -108,7 +109,8 @@ func TestEchoI16(t *testing.T) {
 		"echoI16",
 		bazClient.NewSecondServiceEchoI16Handler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoI16(
 		context.Background(), nil, &bazGen.SecondService_EchoI16_Args{Arg: arg},
@@ -145,7 +147,8 @@ func TestEchoI32(t *testing.T) {
 		"echoI32",
 		bazClient.NewSecondServiceEchoI32Handler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoI32(
 		context.Background(), nil, &bazGen.SecondService_EchoI32_Args{Arg: arg},
@@ -182,7 +185,8 @@ func TestEchoI64(t *testing.T) {
 		"echoI64",
 		bazClient.NewSecondServiceEchoI64Handler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoI64(
 		context.Background(), nil, &bazGen.SecondService_EchoI64_Args{Arg: arg},
@@ -219,7 +223,8 @@ func TestEchoDouble(t *testing.T) {
 		"echoDouble",
 		bazClient.NewSecondServiceEchoDoubleHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoDouble(
 		context.Background(), nil, &bazGen.SecondService_EchoDouble_Args{Arg: arg},
@@ -256,7 +261,8 @@ func TestEchoBool(t *testing.T) {
 		"echoBool",
 		bazClient.NewSecondServiceEchoBoolHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoBool(
 		context.Background(), nil, &bazGen.SecondService_EchoBool_Args{Arg: arg},
@@ -293,7 +299,8 @@ func TestEchoString(t *testing.T) {
 		"echoString",
 		bazClient.NewSecondServiceEchoStringHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoString(
 		context.Background(), nil, &bazGen.SecondService_EchoString_Args{Arg: arg},
@@ -330,7 +337,8 @@ func TestEchoBinary(t *testing.T) {
 		"echoBinary",
 		bazClient.NewSecondServiceEchoBinaryHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoBinary(
 		context.Background(), nil, &bazGen.SecondService_EchoBinary_Args{Arg: arg},
@@ -368,7 +376,8 @@ func TestEchoEnum(t *testing.T) {
 		"echoEnum",
 		bazClient.NewSecondServiceEchoEnumHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoEnum(
 		context.Background(), nil, &bazGen.SecondService_EchoEnum_Args{Arg: arg},
@@ -405,7 +414,8 @@ func TestEchoTypedef(t *testing.T) {
 		"echoTypedef",
 		bazClient.NewSecondServiceEchoTypedefHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoTypedef(
 		context.Background(), nil, &bazGen.SecondService_EchoTypedef_Args{Arg: arg},
@@ -445,7 +455,8 @@ func TestEchoStringSet(t *testing.T) {
 		"echoStringSet",
 		bazClient.NewSecondServiceEchoStringSetHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStringSet(
 		context.Background(), nil, &bazGen.SecondService_EchoStringSet_Args{Arg: arg},
@@ -485,7 +496,8 @@ func TestEchoStructSet(t *testing.T) {
 		"echoStructSet",
 		bazClient.NewSecondServiceEchoStructSetHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStructSet(
 		context.Background(), nil, &bazGen.SecondService_EchoStructSet_Args{Arg: arg},
@@ -522,7 +534,8 @@ func TestEchoStringList(t *testing.T) {
 		"echoStringList",
 		bazClient.NewSecondServiceEchoStringListHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStringList(
 		context.Background(), nil, &bazGen.SecondService_EchoStringList_Args{Arg: arg},
@@ -563,7 +576,8 @@ func TestEchoStructList(t *testing.T) {
 		"echoStructList",
 		bazClient.NewSecondServiceEchoStructListHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStructList(
 		context.Background(), nil, &bazGen.SecondService_EchoStructList_Args{Arg: arg},
@@ -604,7 +618,8 @@ func TestEchoStringMap(t *testing.T) {
 		"echoStringMap",
 		bazClient.NewSecondServiceEchoStringMapHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStringMap(
 		context.Background(), nil, &bazGen.SecondService_EchoStringMap_Args{Arg: arg},
@@ -653,7 +668,8 @@ func TestEchoStructMap(t *testing.T) {
 		"echoStructMap",
 		bazClient.NewSecondServiceEchoStructMapHandler(fake),
 	)
-	baz := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	baz := deps.Client.Baz
 
 	result, _, err := baz.EchoStructMap(
 		context.Background(), nil, &bazGen.SecondService_EchoStructMap_Args{Arg: arg},

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -193,7 +193,8 @@ func TestCompareInvalidArgs(t *testing.T) {
 	)
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
-	bazClient := bazClient.NewClient(bgateway.ActualGateway)
+	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
+	bazClient := deps.Client.Baz
 
 	res, _, err := bazClient.Compare(
 		context.Background(),

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -41,6 +41,7 @@ import (
 // BenchGateway for testing
 type BenchGateway struct {
 	ActualGateway *zanzibar.Gateway
+	Dependencies  interface{}
 
 	backendsHTTP     map[string]*testBackend.TestHTTPBackend
 	backendsTChannel map[string]*testBackend.TestTChannelBackend
@@ -65,7 +66,7 @@ func getZanzibarDirName() string {
 type CreateGatewayFn func(
 	config *zanzibar.StaticConfig,
 	opts *zanzibar.Options,
-) (*zanzibar.Gateway, error)
+) (*zanzibar.Gateway, interface{}, error)
 
 // CreateGateway bootstrap gateway for testing
 func CreateGateway(
@@ -129,13 +130,14 @@ func CreateGateway(
 		filepath.Join(getZanzibarDirName(), "config", "production.json"),
 	}, seedConfig)
 
-	gateway, err := createGateway(config, &zanzibar.Options{
+	gateway, dependencies, err := createGateway(config, &zanzibar.Options{
 		LogWriter: zapcore.AddSync(benchGateway.logBytes),
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	benchGateway.Dependencies = dependencies
 	benchGateway.ActualGateway = gateway
 
 	benchGateway.tchannelClient = zanzibar.NewTChannelClient(


### PR DESCRIPTION
By exposing the dependency tree on the BenchGateway class,
developers can write tests with all the components and
test backends pre-configured and then grab a task/client
"module instance" and use it for integration tests.

r: @uber/zanzibar-team