### PR TITLE
Generalize template helper

### DIFF
--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -844,11 +844,6 @@ func parseMiddlewareConfig(
 
 // GatewaySpec collects information for the entire gateway
 type GatewaySpec struct {
-	// package helper for gateway
-	PackageHelper *PackageHelper
-	// tempalte instance for gateway
-	Template *Template
-
 	ClientModules     map[string]*ClientSpec
 	EndpointModules   map[string]*EndpointSpec
 	MiddlewareModules map[string]*MiddlewareSpec
@@ -869,13 +864,8 @@ func NewGatewaySpec(
 	middlewareConfig string,
 	gatewayName string,
 ) (*GatewaySpec, error) {
-	tmpl, err := NewTemplate()
-	if err != nil {
-		return nil, errors.Wrap(err, "cannot create template")
-	}
-
 	endpointGroupJsons := []string{}
-	err = filepath.Walk(
+	err := filepath.Walk(
 		filepath.Join(configDirName, endpointConfig),
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
@@ -898,8 +888,6 @@ func NewGatewaySpec(
 	}
 
 	spec := &GatewaySpec{
-		PackageHelper:     packageHelper,
-		Template:          tmpl,
 		ClientModules:     map[string]*ClientSpec{},
 		EndpointModules:   map[string]*EndpointSpec{},
 		MiddlewareModules: map[string]*MiddlewareSpec{},

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -111,7 +111,7 @@ func NewDefaultModuleSystem(
 	h *PackageHelper,
 ) (*ModuleSystem, error) {
 	system := NewModuleSystem()
-	tmpl, err := NewTemplate()
+	tmpl, err := NewDefaultTemplate()
 
 	if err != nil {
 		return nil, err

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -97,14 +97,13 @@ type Template struct {
 	template *tmpl.Template
 }
 
-// NewTemplate creates a bundle of templates.
-func NewTemplate() (*Template, error) {
-	return NewTemplateFromAssetProvider(&defaultAssetCollection{})
+// NewDefaultTemplate creates a bundle of templates.
+func NewDefaultTemplate() (*Template, error) {
+	return NewTemplate(&defaultAssetCollection{})
 }
 
-// NewTemplateFromAssetProvider returns a template helper for the
-// provided asset collection
-func NewTemplateFromAssetProvider(
+// NewTemplate returns a template helper for the provided asset collection
+func NewTemplate(
 	assetProvider AssetProvider,
 ) (*Template, error) {
 	t := tmpl.New("main").Funcs(funcMap)

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -51,7 +51,7 @@ func (*defaultAssetCollection) Asset(assetName string) ([]byte, error) {
 	return templates.Asset(assetName)
 }
 
-var funcMap = tmpl.FuncMap{
+var defaultFuncMap = tmpl.FuncMap{
 	"lower":         strings.ToLower,
 	"title":         strings.Title,
 	"fullTypeName":  fullTypeName,
@@ -99,14 +99,18 @@ type Template struct {
 
 // NewDefaultTemplate creates a bundle of templates.
 func NewDefaultTemplate() (*Template, error) {
-	return NewTemplate(&defaultAssetCollection{})
+	return NewTemplate(
+		&defaultAssetCollection{},
+		defaultFuncMap,
+	)
 }
 
 // NewTemplate returns a template helper for the provided asset collection
 func NewTemplate(
 	assetProvider AssetProvider,
+	functionMap tmpl.FuncMap,
 ) (*Template, error) {
-	t := tmpl.New("main").Funcs(funcMap)
+	t := tmpl.New("main").Funcs(functionMap)
 	for _, file := range assetProvider.AssetNames() {
 		fileContent, err := assetProvider.Asset(file)
 		if err != nil {


### PR DESCRIPTION
I've generalized the template helper over a generic asset collection so that we can use this inside other codebases with different collections of templates.