### PR TITLE
Use fork of thriftrw for now.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9c89b932f9af1747c2e0fa0757019541e3260c81e87ca7ca2a8747cbe77e436e
-updated: 2017-06-26T16:24:37.132113705-07:00
+hash: 815cb7302675a73cd0223fda54ae7456e4c2bc9afc0cb828f348fdbd1c899526
+updated: 2017-08-03T15:29:27.397456819-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -22,7 +22,7 @@ imports:
 - name: github.com/go-yaml/yaml
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 - name: github.com/jessevdk/go-flags
-  version: 5695738f733662da3e9afc2283bba6f3c879002d
+  version: 4cc2832a6e6d1d3b815e2b9d544b2a4dfb3ce8fa
 - name: github.com/julienschmidt/httprouter
   version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 - name: github.com/kardianos/osext
@@ -50,10 +50,9 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
+  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
   subpackages:
   - assert
-  - mock
   - require
 - name: github.com/uber-go/atomic
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
@@ -77,6 +76,8 @@ imports:
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: go.uber.org/thriftrw
   version: bbc73fe4e851cac67043d021242eb03920c2f1dd
+  repo: git@github.com:Raynos/thriftrw-go
+  vcs: git
   subpackages:
   - ast
   - compile
@@ -112,7 +113,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 5f8847ae0d0e90b6a9dc8148e7ad616874625171
+  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
   subpackages:
   - context
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -76,7 +76,7 @@ imports:
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - name: go.uber.org/thriftrw
   version: bbc73fe4e851cac67043d021242eb03920c2f1dd
-  repo: git@github.com:Raynos/thriftrw-go
+  repo: git@github.com:raynos/thriftrw-go
   vcs: git
   subpackages:
   - ast

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 815cb7302675a73cd0223fda54ae7456e4c2bc9afc0cb828f348fdbd1c899526
-updated: 2017-08-03T15:29:27.397456819-07:00
+hash: 5bd8f923639f0f7014bbf186ae4a4cf0028e87ec2f2fd01f00fca2406fd35682
+updated: 2017-08-03T16:20:53.117457421-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -50,7 +50,7 @@ imports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 4d4bfba8f1d1027c4fdbe371823030df51419987
+  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,6 +2,10 @@ package: github.com/uber/zanzibar
 import:
 - package: github.com/go-validator/validator
   version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448
+- package: github.com/davecgh/go-spew
+  version: 346938d642f2ec3594ed81d874461961cd0faa76
+- package: golang.org/x/net
+  version: master
 - package: github.com/go-yaml/yaml
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 - package: github.com/mailru/easyjson
@@ -32,13 +36,13 @@ import:
   version: c2c54e542fb797ad986b31721e1baedf214ca413
 - package: go.uber.org/thriftrw
   version: bbc73fe4e851cac67043d021242eb03920c2f1dd
+  repo:    git@github.com:Raynos/thriftrw-go
+  vcs:     git
 - package: github.com/uber/tchannel-go
   version: v1.3.0
 - package: github.com/opentracing/opentracing-go
   version: 6edb48674bd9467b8e91fda004f2bd7202d60ce4
 # tchannel needs master for golang.org/x/net
-- package: golang.org/x/net
-  version: master
 - package: github.com/buger/jsonparser
   version: 5b691c8ebc4af5191baa426561d62f1b5115d6e5
 -testImport:

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,8 +45,5 @@ import:
 # tchannel needs master for golang.org/x/net
 - package: github.com/buger/jsonparser
   version: 5b691c8ebc4af5191baa426561d62f1b5115d6e5
--testImport:
- - package: github.com/stretchr/testify
- -  version: f6abca593680b2315d2075e0f5e2a9751e3f431a
- -  subpackages:
- -  - assert
+- package: github.com/stretchr/testify
+  version: f6abca593680b2315d2075e0f5e2a9751e3f431a

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,7 +36,7 @@ import:
   version: c2c54e542fb797ad986b31721e1baedf214ca413
 - package: go.uber.org/thriftrw
   version: bbc73fe4e851cac67043d021242eb03920c2f1dd
-  repo:    git@github.com:Raynos/thriftrw-go
+  repo:    git@github.com:raynos/thriftrw-go
   vcs:     git
 - package: github.com/uber/tchannel-go
   version: v1.3.0


### PR DESCRIPTION
Upstream wants to delete branch, use a proper fork instead.

Will contribute patches back to upstream soon.

r: @uber/zanzibar-team