### PR TITLE
Export isStructType function

### DIFF
--- a/codegen/method.go
+++ b/codegen/method.go
@@ -260,7 +260,7 @@ func (ms *MethodSpec) setRequestType(curThriftFile string, funcSpec *compile.Fun
 	if isRequestBoxed(funcSpec) {
 		ms.RequestBoxed = true
 		ms.RequestType, err = packageHelper.TypeFullName(funcSpec.ArgsSpec[0].Type)
-		if err == nil && isStructType(funcSpec.ArgsSpec[0].Type) {
+		if err == nil && IsStructType(funcSpec.ArgsSpec[0].Type) {
 			ms.RequestType = "*" + ms.RequestType
 		}
 	} else {
@@ -284,7 +284,7 @@ func (ms *MethodSpec) setResponseType(curThriftFile string, respSpec *compile.Re
 		return nil
 	}
 	typeName, err := packageHelper.TypeFullName(respSpec.ReturnType)
-	if isStructType(respSpec.ReturnType) {
+	if IsStructType(respSpec.ReturnType) {
 		typeName = "*" + typeName
 	}
 	if err != nil {

--- a/codegen/thrift.go
+++ b/codegen/thrift.go
@@ -90,7 +90,7 @@ func goReferenceType(p PackageNameResolver, spec compile.TypeSpec) (string, erro
 		return "", err
 	}
 
-	if isStructType(spec) {
+	if IsStructType(spec) {
 		t = "*" + t
 	}
 
@@ -112,8 +112,8 @@ func goCustomType(p PackageNameResolver, spec compile.TypeSpec) (string, error) 
 	return pkg + "." + pascalCase(spec.ThriftName()), nil
 }
 
-// isStructType returns true if the given thrift type is struct, false otherwise.
-func isStructType(spec compile.TypeSpec) bool {
+// IsStructType returns true if the given thrift type is struct, false otherwise.
+func IsStructType(spec compile.TypeSpec) bool {
 	spec = compile.RootTypeSpec(spec)
 	_, isStruct := spec.(*compile.StructSpec)
 	return isStruct


### PR DESCRIPTION
This PR makes `isStructType` public as it is useful outside zanzibar for code interacting with module system.

@uber/zanzibar-team 