### PR TITLE
Support module class to map to multiple directories

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -119,22 +119,6 @@ func (system *ModuleSystem) validateClassDir(class *ModuleClass, dir string) err
 		)
 	}
 
-	// Validate the module class directories are unique
-	for registeredName, registered := range system.classes {
-		if class.ClassType != registered.ClassType {
-			continue
-		}
-		for _, claimedDir := range registered.Directories {
-			if dir == claimedDir {
-				return errors.Errorf(
-					"Module class %q conflicts with directory %q from class %q",
-					class.Name,
-					dir,
-					registeredName,
-				)
-			}
-		}
-	}
 	return nil
 }
 

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -118,9 +118,9 @@ func NewDefaultModuleSystem(
 
 	// Register client module class and type generators
 	if err := system.RegisterClass(ModuleClass{
-		Name:      "client",
-		Directory: "clients",
-		ClassType: MultiModule,
+		Name:        "client",
+		Directories: []string{"clients"},
+		ClassType:   MultiModule,
 	}); err != nil {
 		return nil, errors.Wrapf(err, "Error registering client class")
 	}
@@ -157,10 +157,10 @@ func NewDefaultModuleSystem(
 
 	// Register endpoint module class and type generators
 	if err := system.RegisterClass(ModuleClass{
-		Name:      "endpoint",
-		Directory: "endpoints",
-		ClassType: MultiModule,
-		DependsOn: []string{"client"},
+		Name:        "endpoint",
+		Directories: []string{"endpoints"},
+		ClassType:   MultiModule,
+		DependsOn:   []string{"client"},
 	}); err != nil {
 		return nil, errors.Wrapf(err, "Error registering endpoint class")
 	}
@@ -186,10 +186,10 @@ func NewDefaultModuleSystem(
 	}
 
 	if err := system.RegisterClass(ModuleClass{
-		Name:      "service",
-		Directory: "services",
-		ClassType: MultiModule,
-		DependsOn: []string{"endpoint"},
+		Name:        "service",
+		Directories: []string{"services"},
+		ClassType:   MultiModule,
+		DependsOn:   []string{"endpoint"},
 	}); err != nil {
 		return nil, errors.Wrapf(
 			err,

--- a/codegen/test-service/another/bar/endpoint-config.json
+++ b/codegen/test-service/another/bar/endpoint-config.json
@@ -1,0 +1,12 @@
+{
+	"name": "bar",
+	"type": "http",
+	"config": {
+		"rateLimit": 100
+	},
+	"dependencies": {
+		"client": [
+			"example"
+		]
+	}
+}

--- a/codegen/test-service/endpoints/health/embedded-client/client-config.json
+++ b/codegen/test-service/endpoints/health/embedded-client/client-config.json
@@ -1,0 +1,9 @@
+{
+	"name": "embedded",
+	"type": "http",
+	"config": {
+		"headers": {
+				"x-service-name": "example"
+		}
+	}
+}

--- a/codegen/test-service/more-endpoints/foo/endpoint-config.json
+++ b/codegen/test-service/more-endpoints/foo/endpoint-config.json
@@ -1,0 +1,12 @@
+{
+	"name": "foo",
+	"type": "http",
+	"config": {
+		"rateLimit": 100
+	},
+	"dependencies": {
+		"client": [
+			"example"
+		]
+	}
+}


### PR DESCRIPTION
Currently the module system has 1:1 mapping from module class to the top level hosting directory, e.g., all endpoints configs reside in `example-gateway/endpoints`. This can be cumbersome for applications that, for whatever reason, prefer to have multiple top level directories for the same module class. 

This PR adds API to register additional config directories for a known module class.
@uber/zanzibar-team 