### PR TITLE
Add  JSON tags for middlewareSpec

### DIFF
--- a/backend/repository/config.go
+++ b/backend/repository/config.go
@@ -56,25 +56,19 @@ type ThriftServiceMap map[string]map[string]*ThriftService
 
 // EndpointConfig stores configuration for an endpoint.
 type EndpointConfig struct {
-	ID               string            `json:"endpointId"`
-	Type             ProtocolType      `json:"endpointType"`
-	HandleID         string            `json:"handleId"`
-	ThriftFile       string            `json:"thriftFile"`
-	ThriftFileSha    string            `json:"thriftFileSha,omitempty"`
-	ThriftMethodName string            `json:"thriftMethodName"`
-	WorkflowType     string            `json:"workflowType"`
-	ClientID         string            `json:"clientID"`
-	ClientMethod     string            `json:"clientMethod"`
-	TestFixtures     []string          `json:"testFixtures"`
-	Middlewares      []*EndptMidConfig `json:"middlewares"`
-	ReqHeaderMap     map[string]string `json:"reqHeaderMap"`
-	ResHeaderMap     map[string]string `json:"resHeaderMap"`
-}
-
-// EndptMidConfig represents configuration for a middleware.
-type EndptMidConfig struct {
-	Name    string
-	Options map[string]interface{}
+	ID               string                    `json:"endpointId"`
+	Type             ProtocolType              `json:"endpointType"`
+	HandleID         string                    `json:"handleId"`
+	ThriftFile       string                    `json:"thriftFile"`
+	ThriftFileSha    string                    `json:"thriftFileSha,omitempty"`
+	ThriftMethodName string                    `json:"thriftMethodName"`
+	WorkflowType     string                    `json:"workflowType"`
+	ClientID         string                    `json:"clientID"`
+	ClientMethod     string                    `json:"clientMethod"`
+	TestFixtures     []string                  `json:"testFixtures"`
+	Middlewares      []*codegen.MiddlewareSpec `json:"middlewares"`
+	ReqHeaderMap     map[string]string         `json:"reqHeaderMap"`
+	ResHeaderMap     map[string]string         `json:"resHeaderMap"`
 }
 
 // ClientConfig stores configuration for an client.

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -1030,7 +1030,11 @@
 						"endpointId": "baz",
 						"endpointType": "http",
 						"handleId": "compare",
-						"middlewares": [],
+						"middlewares": [
+							{
+								"name": "example_reader"
+							}
+						],
 						"reqHeaderMap": {},
 						"resHeaderMap": {},
 						"testFixtures": [],

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -294,11 +294,11 @@ func newClientSpec(
 // level. The same mid
 type MiddlewareSpec struct {
 	// The middleware package name.
-	Name string
+	Name string `json:"name"`
 	// Go import path for the middleware.
-	Path string
+	Path string `json:"path,omitempty"`
 	// Middleware specific configuration options.
-	Options map[string]interface{}
+	Options map[string]interface{} `json:"options,omitempty"`
 }
 
 // NewMiddlewareSpec creates a middleware spec from a go file.


### PR DESCRIPTION
- Remove duplicated definition for middleware spec configuration `EndptMidConfig`. Use `MiddlewareSpec` as source of truth. 

- Add JSON tags for serialization.

- Add tests for updating middleware config.

r: @uber/zanzibar-team 