### PR TITLE
Adding service environment config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,27 +21,39 @@
 package config
 
 import (
-	"github.com/pkg/errors"
-	zanzibar "github.com/uber/zanzibar/runtime"
+	"os"
+
+	"github.com/uber/zanzibar/runtime"
 )
 
-// NewRuntimeConfigOrDie returns a static config struct that is pre-set with
-// the service configuration defaults
+// EnvConfig map from environment variable to config key and data type
+type EnvConfig map[string]struct {
+	Key      string `json:"key"`
+	DataType string `json:"dataType"`
+}
+
+// NewRuntimeConfigOrDie returns a static config struct
+// that is pre-set with the service configuration defaults
+// and overridden by service.env.config
 func NewRuntimeConfigOrDie(
 	files []string,
 	seedConfig map[string]interface{},
 ) *zanzibar.StaticConfig {
 	defaultConfig, err := defaultConfig()
 	if err != nil {
-		panic(errors.Wrap)
-	}
-	serviceConfig := make([]*zanzibar.ConfigOption, len(files)+1)
-	serviceConfig[0] = defaultConfig
-	for i, configFilePath := range files {
-		serviceConfig[i+1] = zanzibar.ConfigFilePath(configFilePath)
+		panic("error getting default config")
 	}
 
-	return zanzibar.NewStaticConfigOrDie(serviceConfig, seedConfig)
+	var serviceConfig []*zanzibar.ConfigOption
+	serviceConfig = append(serviceConfig, defaultConfig)
+	for _, configFilePath := range files {
+		serviceConfig = append(serviceConfig, zanzibar.ConfigFilePath(configFilePath))
+	}
+
+	staticConfig := zanzibar.NewStaticConfigOrDie(serviceConfig, seedConfig)
+	getEnvConfig(staticConfig)
+
+	return staticConfig
 }
 
 func defaultConfig() (*zanzibar.ConfigOption, error) {
@@ -49,6 +61,15 @@ func defaultConfig() (*zanzibar.ConfigOption, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return zanzibar.ConfigFileContents(bytes), nil
+}
+
+func getEnvConfig(cfg *zanzibar.StaticConfig) {
+	var envConfig EnvConfig
+	cfg.MustGetStruct("service.env.config", &envConfig)
+	for envVar, configKey := range envConfig {
+		if value, ok := os.LookupEnv(envVar); ok {
+			cfg.SetConfigValue(configKey.Key, []byte(value), configKey.DataType)
+		}
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -44,14 +44,14 @@ func NewRuntimeConfigOrDie(
 		panic("error getting default config")
 	}
 
-	var serviceConfig []*zanzibar.ConfigOption
+	serviceConfig := make([]*zanzibar.ConfigOption, 0, len(files)+1)
 	serviceConfig = append(serviceConfig, defaultConfig)
 	for _, configFilePath := range files {
 		serviceConfig = append(serviceConfig, zanzibar.ConfigFilePath(configFilePath))
 	}
 
 	staticConfig := zanzibar.NewStaticConfigOrDie(serviceConfig, seedConfig)
-	getEnvConfig(staticConfig)
+	setEnvConfig(staticConfig)
 
 	return staticConfig
 }
@@ -64,12 +64,12 @@ func defaultConfig() (*zanzibar.ConfigOption, error) {
 	return zanzibar.ConfigFileContents(bytes), nil
 }
 
-func getEnvConfig(cfg *zanzibar.StaticConfig) {
+func setEnvConfig(cfg *zanzibar.StaticConfig) {
 	var envConfig EnvConfig
 	cfg.MustGetStruct("service.env.config", &envConfig)
 	for envVar, configKey := range envConfig {
 		if value, ok := os.LookupEnv(envVar); ok {
-			cfg.SetConfigValue(configKey.Key, []byte(value), configKey.DataType)
+			cfg.SetConfigValueOrDie(configKey.Key, []byte(value), configKey.DataType)
 		}
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/config"
+)
+
+const (
+	uberPortHTTPEnv     = "UBER_PORT_HTTP"
+	uberPortTChannelEnv = "UBER_PORT_TCHANNEL"
+	httpPortKey         = "http.port"
+	tchannelPortKey     = "tchannel.port"
+)
+
+func TestNewRuntimeConfigOrDie(t *testing.T) {
+	httpPortValue := os.Getenv(uberPortHTTPEnv)
+	defer os.Setenv(uberPortHTTPEnv, httpPortValue)
+
+	tchannelPortValue := os.Getenv(uberPortTChannelEnv)
+	defer os.Setenv(uberPortTChannelEnv, tchannelPortValue)
+
+	os.Setenv(uberPortHTTPEnv, "1111")
+	os.Setenv(uberPortTChannelEnv, "2222")
+	cfg := config.NewRuntimeConfigOrDie([]string{"test.json"}, nil)
+
+	assert.Equal(t, "my-gateway", cfg.MustGetString("serviceName")) // existing config
+	assert.Equal(t, int64(1111), cfg.MustGetInt(httpPortKey))       // replaced config
+	assert.Equal(t, int64(2222), cfg.MustGetInt(tchannelPortKey))   // new config
+}

--- a/config/production.json
+++ b/config/production.json
@@ -1,6 +1,7 @@
 {
+	"service.env.config": {},
+
 	"serviceName": "my-gateway",
-	"port": 4000,
 	"env": "production",
 	"useDatacenter": false,
 
@@ -18,6 +19,8 @@
 	"metrics.runtime.enableMemMetrics": true,
 	"metrics.runtime.enableGCMetrics": true,
 	"metrics.runtime.collectInterval": 1000,
+
+	"http.port": 4000,
 
 	"tchannel.serviceName": "my-gateway",
 	"tchannel.processName": "my-gateway"

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -65,8 +65,9 @@ func (fi bindataFileInfo) Sys() interface{} {
 }
 
 var _productionJson = []byte(`{
+	"service.env.config": {},
+
 	"serviceName": "my-gateway",
-	"port": 4000,
 	"env": "production",
 	"useDatacenter": false,
 
@@ -85,6 +86,8 @@ var _productionJson = []byte(`{
 	"metrics.runtime.enableGCMetrics": true,
 	"metrics.runtime.collectInterval": 1000,
 
+	"http.port": 4000,
+
 	"tchannel.serviceName": "my-gateway",
 	"tchannel.processName": "my-gateway"
 }
@@ -100,7 +103,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 590, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 624, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,15 @@
+{
+	"serviceName": "my-gateway",
+	"http.port": 1000,
+
+	"service.env.config": {
+		"UBER_PORT_HTTP": {
+			"key": "http.port",
+			"dataType": "number"
+		},
+		"UBER_PORT_TCHANNEL": {
+			"key": "tchannel.port",
+			"dataType": "number"
+		}
+	}
+}

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -20,6 +20,7 @@
 	"logger.output": "disk",
 	"metrics.m3.service": "example-gateway",
 	"metrics.tally.service": "example-gateway",
+	"service.env.config": {},
 	"serviceName": "example-gateway",
 	"tchannel.port": 7784,
 	"tchannel.processName": "example-gateway",

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -275,9 +275,9 @@ func (gateway *Gateway) setupConfig(config *StaticConfig) {
 			panic("expected datacenterFile: " + dcFile + " to exist")
 		}
 
-		config.SetOrDie("datacenter", string(bytes))
+		config.SetSeedOrDie("datacenter", string(bytes))
 	} else {
-		config.SetOrDie("datacenter", "unknown")
+		config.SetSeedOrDie("datacenter", "unknown")
 	}
 }
 

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -265,10 +265,10 @@ func (conf *StaticConfig) MustGetStruct(key string, ptr interface{}) {
 	panic(errors.Errorf("Key (%s) not available", key))
 }
 
-// SetConfigValue sets the static config value.
+// SetConfigValueOrDie sets the static config value.
 // dataType can be a boolean, number or string.
-// SetConfigValue will panic if the config is frozen.
-func (conf *StaticConfig) SetConfigValue(key string, bytes []byte, dataType string) {
+// SetConfigValueOrDie will panic if the config is frozen.
+func (conf *StaticConfig) SetConfigValueOrDie(key string, bytes []byte, dataType string) {
 	if conf.frozen {
 		panic(errors.Errorf("Cannot set(%s) because frozen", key))
 	}
@@ -291,11 +291,11 @@ func (conf *StaticConfig) SetConfigValue(key string, bytes []byte, dataType stri
 	}
 }
 
-// SetOrDie a value in the config, useful for tests.
+// SetSeedOrDie a value in the config, useful for tests.
 // Keys you set must not exist in the JSON files.
 // Set() will panic if the key exists or if frozen.
 // Strongly recommended not to be used for production code.
-func (conf *StaticConfig) SetOrDie(key string, value interface{}) {
+func (conf *StaticConfig) SetSeedOrDie(key string, value interface{}) {
 	if conf.frozen {
 		panic(errors.Errorf("Cannot set(%s) because frozen", key))
 	}

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -21,12 +21,10 @@
 package zanzibar
 
 import (
-	"io/ioutil"
-	"reflect"
-
 	"encoding/json"
-
+	"io/ioutil"
 	"os"
+	"reflect"
 
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
@@ -267,8 +265,34 @@ func (conf *StaticConfig) MustGetStruct(key string, ptr interface{}) {
 	panic(errors.Errorf("Key (%s) not available", key))
 }
 
+// SetConfigValue sets the static config value.
+// dataType can be a boolean, number or string.
+// SetConfigValue will panic if the config is frozen.
+func (conf *StaticConfig) SetConfigValue(key string, bytes []byte, dataType string) {
+	if conf.frozen {
+		panic(errors.Errorf("Cannot set(%s) because frozen", key))
+	}
+
+	var dt jsonparser.ValueType
+	switch dataType {
+	case "boolean":
+		dt = jsonparser.Boolean
+	case "number":
+		dt = jsonparser.Number
+	case "string":
+		dt = jsonparser.String
+	default:
+		panic("unknown config data type")
+	}
+
+	conf.configValues[key] = StaticConfigValue{
+		dataType: dt,
+		bytes:    bytes,
+	}
+}
+
 // SetOrDie a value in the config, useful for tests.
-// Keys you set must not exist in the JSON files
+// Keys you set must not exist in the JSON files.
 // Set() will panic if the key exists or if frozen.
 // Strongly recommended not to be used for production code.
 func (conf *StaticConfig) SetOrDie(key string, value interface{}) {

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/zanzibar/config"
+)
+
+const (
+	uberPortHTTPEnv     = "UBER_PORT_HTTP"
+	uberPortTChannelEnv = "UBER_PORT_TCHANNEL"
+	httpPortKey         = "http.port"
+	tchannelPortKey     = "tchannel.port"
+)
+
+func TestNewRuntimeConfigOrDie(t *testing.T) {
+	httpPortValue := os.Getenv(uberPortHTTPEnv)
+	defer os.Setenv(uberPortHTTPEnv, httpPortValue)
+
+	tchannelPortValue := os.Getenv(uberPortTChannelEnv)
+	defer os.Setenv(uberPortTChannelEnv, tchannelPortValue)
+
+	os.Setenv(uberPortHTTPEnv, "1111")
+	os.Setenv(uberPortTChannelEnv, "2222")
+	cfg := config.NewRuntimeConfigOrDie([]string{"test.json"}, nil)
+
+	assert.Equal(t, "my-gateway", cfg.MustGetString("serviceName")) // existing config
+	assert.Equal(t, int64(1111), cfg.MustGetInt(httpPortKey))       // replaced config
+	assert.Equal(t, int64(2222), cfg.MustGetInt(tchannelPortKey))   // new config
+}

--- a/test/config/test.json
+++ b/test/config/test.json
@@ -1,0 +1,15 @@
+{
+	"serviceName": "my-gateway",
+	"http.port": 1000,
+
+	"service.env.config": {
+		"UBER_PORT_HTTP": {
+			"key": "http.port",
+			"dataType": "number"
+		},
+		"UBER_PORT_TCHANNEL": {
+			"key": "tchannel.port",
+			"dataType": "number"
+		}
+	}
+}


### PR DESCRIPTION
User can add `service.env.config` to override existing config values with environment values. For example:

```
	"service.env.config": {
		"UBER_PORT_HTTP": {
			"key": "http.port",
			"dataType": "number"
		},
		"UBER_PORT_TCHANNEL": {
			"key": "tchannel.port",
			"dataType": "number"
		}
	}
```