### PR TITLE
Adding metrics and logs to client http request/response

### DIFF
--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -3,10 +3,10 @@
 package {{$instance.PackageInfo.PackageName}}
 
 import (
-	"bytes"
 	"context"
-	"net/http"
+	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/uber/zanzibar/runtime"
@@ -50,11 +50,22 @@ type {{$clientName}} struct {
 func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := gateway.Config.MustGetInt("clients.{{$clientID}}.port")
+	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
+	timeout := time.Duration(gateway.Config.MustGetInt("clients.{{$clientID}}.timeout")) * time.Millisecond
 
-	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &{{$clientName}}{
 		clientID: "{{$clientID}}",
-		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
+		httpClient: zanzibar.NewHTTPClient(
+			gateway,
+			"{{$clientID}}",
+			[]string{
+				{{range $serviceMethod, $methodName := $exposedMethods -}}
+				"{{$methodName}}",
+				{{end}}
+			},
+			baseURL,
+			timeout,
+		),
 	}
 }
 
@@ -81,9 +92,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	{{if .ResponseType -}}
 	var defaultRes  {{.ResponseType}}
 	{{end -}}
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "{{.Name}}", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "{{$methodName}}", c.httpClient)
 
 	{{- if .ReqHeaders }}
 	// TODO(jakev): Ensure we validate mandatory headers

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -25,8 +25,10 @@ package barClient
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
@@ -189,11 +191,47 @@ type barClient struct {
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
 	port := gateway.Config.MustGetInt("clients.bar.port")
+	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
+	timeout := time.Duration(gateway.Config.MustGetInt("clients.bar.timeout")) * time.Millisecond
 
-	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &barClient{
-		clientID:   "bar",
-		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
+		clientID: "bar",
+		httpClient: zanzibar.NewHTTPClient(
+			gateway,
+			"bar",
+			[]string{
+				"ArgNotStruct",
+				"ArgWithHeaders",
+				"ArgWithManyQueryParams",
+				"ArgWithNestedQueryParams",
+				"ArgWithParams",
+				"ArgWithQueryHeader",
+				"ArgWithQueryParams",
+				"MissingArg",
+				"NoRequest",
+				"Normal",
+				"NormalRecur",
+				"TooManyArgs",
+				"EchoBinary",
+				"EchoBool",
+				"EchoDouble",
+				"EchoEnum",
+				"EchoI16",
+				"EchoI32",
+				"EchoI64",
+				"EchoI8",
+				"EchoString",
+				"EchoStringList",
+				"EchoStringMap",
+				"EchoStringSet",
+				"EchoStructList",
+				"EchoStructMap",
+				"EchoStructSet",
+				"EchoTypedef",
+			},
+			baseURL,
+			timeout,
+		),
 	}
 }
 
@@ -209,9 +247,7 @@ func (c *barClient) ArgNotStruct(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argNotStruct", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgNotStruct", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/arg-not-struct-path"
@@ -271,9 +307,7 @@ func (c *barClient) ArgWithHeaders(
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithHeaders", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithHeaders", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -320,9 +354,7 @@ func (c *barClient) ArgWithManyQueryParams(
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithManyQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithManyQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithManyQueryParams"
@@ -413,9 +445,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 	r *clientsBarBar.Bar_ArgWithNestedQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithNestedQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithNestedQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithNestedQueryParams"
@@ -499,9 +529,7 @@ func (c *barClient) ArgWithParams(
 	r *clientsBarBar.Bar_ArgWithParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/" + string(r.UUID) + "/segment" + "/" + string(r.Params.UserUUID)
@@ -550,9 +578,7 @@ func (c *barClient) ArgWithQueryHeader(
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithQueryHeader", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryHeader", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryHeader"
@@ -598,9 +624,7 @@ func (c *barClient) ArgWithQueryParams(
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryParams"
@@ -654,9 +678,7 @@ func (c *barClient) MissingArg(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "missingArg", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "MissingArg", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/missing-arg-path"
@@ -716,9 +738,7 @@ func (c *barClient) NoRequest(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "noRequest", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "NoRequest", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/no-request-path"
@@ -779,9 +799,7 @@ func (c *barClient) Normal(
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "normal", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "Normal", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar-path"
@@ -842,9 +860,7 @@ func (c *barClient) NormalRecur(
 	r *clientsBarBar.Bar_NormalRecur_Args,
 ) (*clientsBarBar.BarResponseRecur, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponseRecur
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "normalRecur", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "NormalRecur", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/recur"
@@ -904,9 +920,7 @@ func (c *barClient) TooManyArgs(
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "tooManyArgs", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "TooManyArgs", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/too-many-args-path"
@@ -967,9 +981,7 @@ func (c *barClient) EchoBinary(
 	r *clientsBarBar.Echo_EchoBinary_Args,
 ) ([]byte, map[string]string, error) {
 	var defaultRes []byte
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoBinary", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBinary", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1015,9 +1027,7 @@ func (c *barClient) EchoBool(
 	r *clientsBarBar.Echo_EchoBool_Args,
 ) (bool, map[string]string, error) {
 	var defaultRes bool
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoBool", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBool", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1063,9 +1073,7 @@ func (c *barClient) EchoDouble(
 	r *clientsBarBar.Echo_EchoDouble_Args,
 ) (float64, map[string]string, error) {
 	var defaultRes float64
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoDouble", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoDouble", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1111,9 +1119,7 @@ func (c *barClient) EchoEnum(
 	r *clientsBarBar.Echo_EchoEnum_Args,
 ) (clientsBarBar.Fruit, map[string]string, error) {
 	var defaultRes clientsBarBar.Fruit
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoEnum", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoEnum", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1159,9 +1165,7 @@ func (c *barClient) EchoI16(
 	r *clientsBarBar.Echo_EchoI16_Args,
 ) (int16, map[string]string, error) {
 	var defaultRes int16
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI16", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI16", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1207,9 +1211,7 @@ func (c *barClient) EchoI32(
 	r *clientsBarBar.Echo_EchoI32_Args,
 ) (int32, map[string]string, error) {
 	var defaultRes int32
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI32", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI32", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1255,9 +1257,7 @@ func (c *barClient) EchoI64(
 	r *clientsBarBar.Echo_EchoI64_Args,
 ) (int64, map[string]string, error) {
 	var defaultRes int64
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI64", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI64", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1303,9 +1303,7 @@ func (c *barClient) EchoI8(
 	r *clientsBarBar.Echo_EchoI8_Args,
 ) (int8, map[string]string, error) {
 	var defaultRes int8
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI8", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI8", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1351,9 +1349,7 @@ func (c *barClient) EchoString(
 	r *clientsBarBar.Echo_EchoString_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoString", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoString", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1399,9 +1395,7 @@ func (c *barClient) EchoStringList(
 	r *clientsBarBar.Echo_EchoStringList_Args,
 ) ([]string, map[string]string, error) {
 	var defaultRes []string
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringList", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringList", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1447,9 +1441,7 @@ func (c *barClient) EchoStringMap(
 	r *clientsBarBar.Echo_EchoStringMap_Args,
 ) (map[string]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes map[string]*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringMap", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringMap", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1495,9 +1487,7 @@ func (c *barClient) EchoStringSet(
 	r *clientsBarBar.Echo_EchoStringSet_Args,
 ) (map[string]struct{}, map[string]string, error) {
 	var defaultRes map[string]struct{}
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringSet", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringSet", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1543,9 +1533,7 @@ func (c *barClient) EchoStructList(
 	r *clientsBarBar.Echo_EchoStructList_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructList", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructList", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1597,9 +1585,7 @@ func (c *barClient) EchoStructMap(
 		Key   *clientsBarBar.BarResponse
 		Value string
 	}
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructMap", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructMap", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1648,9 +1634,7 @@ func (c *barClient) EchoStructSet(
 	r *clientsBarBar.Echo_EchoStructSet_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructSet", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructSet", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1696,9 +1680,7 @@ func (c *barClient) EchoTypedef(
 	r *clientsBarBar.Echo_EchoTypedef_Args,
 ) (clientsBarBar.UUID, map[string]string, error) {
 	var defaultRes clientsBarBar.UUID
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoTypedef", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoTypedef", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -25,8 +25,10 @@ package barClient
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
@@ -189,11 +191,47 @@ type barClient struct {
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.bar.ip")
 	port := gateway.Config.MustGetInt("clients.bar.port")
+	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
+	timeout := time.Duration(gateway.Config.MustGetInt("clients.bar.timeout")) * time.Millisecond
 
-	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &barClient{
-		clientID:   "bar",
-		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
+		clientID: "bar",
+		httpClient: zanzibar.NewHTTPClient(
+			gateway,
+			"bar",
+			[]string{
+				"ArgNotStruct",
+				"ArgWithHeaders",
+				"ArgWithManyQueryParams",
+				"ArgWithNestedQueryParams",
+				"ArgWithParams",
+				"ArgWithQueryHeader",
+				"ArgWithQueryParams",
+				"MissingArg",
+				"NoRequest",
+				"Normal",
+				"NormalRecur",
+				"TooManyArgs",
+				"EchoBinary",
+				"EchoBool",
+				"EchoDouble",
+				"EchoEnum",
+				"EchoI16",
+				"EchoI32",
+				"EchoI64",
+				"EchoI8",
+				"EchoString",
+				"EchoStringList",
+				"EchoStringMap",
+				"EchoStringSet",
+				"EchoStructList",
+				"EchoStructMap",
+				"EchoStructSet",
+				"EchoTypedef",
+			},
+			baseURL,
+			timeout,
+		),
 	}
 }
 
@@ -209,9 +247,7 @@ func (c *barClient) ArgNotStruct(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argNotStruct", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgNotStruct", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/arg-not-struct-path"
@@ -271,9 +307,7 @@ func (c *barClient) ArgWithHeaders(
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithHeaders", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithHeaders", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -320,9 +354,7 @@ func (c *barClient) ArgWithManyQueryParams(
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithManyQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithManyQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithManyQueryParams"
@@ -413,9 +445,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 	r *clientsBarBar.Bar_ArgWithNestedQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithNestedQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithNestedQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithNestedQueryParams"
@@ -499,9 +529,7 @@ func (c *barClient) ArgWithParams(
 	r *clientsBarBar.Bar_ArgWithParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/" + string(r.UUID) + "/segment" + "/" + string(r.Params.UserUUID)
@@ -550,9 +578,7 @@ func (c *barClient) ArgWithQueryHeader(
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithQueryHeader", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryHeader", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryHeader"
@@ -598,9 +624,7 @@ func (c *barClient) ArgWithQueryParams(
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "argWithQueryParams", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryParams"
@@ -654,9 +678,7 @@ func (c *barClient) MissingArg(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "missingArg", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "MissingArg", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/missing-arg-path"
@@ -716,9 +738,7 @@ func (c *barClient) NoRequest(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "noRequest", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "NoRequest", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/no-request-path"
@@ -779,9 +799,7 @@ func (c *barClient) Normal(
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "normal", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "Normal", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar-path"
@@ -842,9 +860,7 @@ func (c *barClient) NormalRecur(
 	r *clientsBarBar.Bar_NormalRecur_Args,
 ) (*clientsBarBar.BarResponseRecur, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponseRecur
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "normalRecur", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "NormalRecur", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/recur"
@@ -904,9 +920,7 @@ func (c *barClient) TooManyArgs(
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "tooManyArgs", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "TooManyArgs", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/too-many-args-path"
@@ -967,9 +981,7 @@ func (c *barClient) EchoBinary(
 	r *clientsBarBar.Echo_EchoBinary_Args,
 ) ([]byte, map[string]string, error) {
 	var defaultRes []byte
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoBinary", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBinary", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1015,9 +1027,7 @@ func (c *barClient) EchoBool(
 	r *clientsBarBar.Echo_EchoBool_Args,
 ) (bool, map[string]string, error) {
 	var defaultRes bool
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoBool", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBool", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1063,9 +1073,7 @@ func (c *barClient) EchoDouble(
 	r *clientsBarBar.Echo_EchoDouble_Args,
 ) (float64, map[string]string, error) {
 	var defaultRes float64
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoDouble", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoDouble", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1111,9 +1119,7 @@ func (c *barClient) EchoEnum(
 	r *clientsBarBar.Echo_EchoEnum_Args,
 ) (clientsBarBar.Fruit, map[string]string, error) {
 	var defaultRes clientsBarBar.Fruit
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoEnum", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoEnum", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1159,9 +1165,7 @@ func (c *barClient) EchoI16(
 	r *clientsBarBar.Echo_EchoI16_Args,
 ) (int16, map[string]string, error) {
 	var defaultRes int16
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI16", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI16", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1207,9 +1211,7 @@ func (c *barClient) EchoI32(
 	r *clientsBarBar.Echo_EchoI32_Args,
 ) (int32, map[string]string, error) {
 	var defaultRes int32
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI32", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI32", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1255,9 +1257,7 @@ func (c *barClient) EchoI64(
 	r *clientsBarBar.Echo_EchoI64_Args,
 ) (int64, map[string]string, error) {
 	var defaultRes int64
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI64", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI64", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1303,9 +1303,7 @@ func (c *barClient) EchoI8(
 	r *clientsBarBar.Echo_EchoI8_Args,
 ) (int8, map[string]string, error) {
 	var defaultRes int8
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoI8", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI8", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1351,9 +1349,7 @@ func (c *barClient) EchoString(
 	r *clientsBarBar.Echo_EchoString_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoString", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoString", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1399,9 +1395,7 @@ func (c *barClient) EchoStringList(
 	r *clientsBarBar.Echo_EchoStringList_Args,
 ) ([]string, map[string]string, error) {
 	var defaultRes []string
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringList", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringList", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1447,9 +1441,7 @@ func (c *barClient) EchoStringMap(
 	r *clientsBarBar.Echo_EchoStringMap_Args,
 ) (map[string]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes map[string]*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringMap", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringMap", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1495,9 +1487,7 @@ func (c *barClient) EchoStringSet(
 	r *clientsBarBar.Echo_EchoStringSet_Args,
 ) (map[string]struct{}, map[string]string, error) {
 	var defaultRes map[string]struct{}
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStringSet", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringSet", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1543,9 +1533,7 @@ func (c *barClient) EchoStructList(
 	r *clientsBarBar.Echo_EchoStructList_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructList", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructList", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1597,9 +1585,7 @@ func (c *barClient) EchoStructMap(
 		Key   *clientsBarBar.BarResponse
 		Value string
 	}
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructMap", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructMap", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1648,9 +1634,7 @@ func (c *barClient) EchoStructSet(
 	r *clientsBarBar.Echo_EchoStructSet_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoStructSet", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructSet", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -1696,9 +1680,7 @@ func (c *barClient) EchoTypedef(
 	r *clientsBarBar.Echo_EchoTypedef_Args,
 ) (clientsBarBar.UUID, map[string]string, error) {
 	var defaultRes clientsBarBar.UUID
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "echoTypedef", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoTypedef", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -25,7 +25,8 @@ package googlenowClient
 
 import (
 	"context"
-	"strconv"
+	"fmt"
+	"time"
 
 	clientsGooglenowGooglenow "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/googlenow/googlenow"
 	"github.com/uber/zanzibar/runtime"
@@ -55,11 +56,21 @@ type googleNowClient struct {
 func NewClient(gateway *zanzibar.Gateway) Client {
 	ip := gateway.Config.MustGetString("clients.google-now.ip")
 	port := gateway.Config.MustGetInt("clients.google-now.port")
+	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
+	timeout := time.Duration(gateway.Config.MustGetInt("clients.google-now.timeout")) * time.Millisecond
 
-	baseURL := "http://" + ip + ":" + strconv.Itoa(int(port))
 	return &googleNowClient{
-		clientID:   "google-now",
-		httpClient: zanzibar.NewHTTPClient(gateway, baseURL),
+		clientID: "google-now",
+		httpClient: zanzibar.NewHTTPClient(
+			gateway,
+			"google-now",
+			[]string{
+				"AddCredentials",
+				"CheckCredentials",
+			},
+			baseURL,
+			timeout,
+		),
 	}
 }
 
@@ -75,9 +86,7 @@ func (c *googleNowClient) AddCredentials(
 	headers map[string]string,
 	r *clientsGooglenowGooglenow.GoogleNowService_AddCredentials_Args,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "addCredentials", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "AddCredentials", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.
@@ -121,9 +130,7 @@ func (c *googleNowClient) CheckCredentials(
 	ctx context.Context,
 	headers map[string]string,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(
-		c.clientID, "checkCredentials", c.httpClient,
-	)
+	req := zanzibar.NewClientHTTPRequest(c.clientID, "CheckCredentials", c.httpClient)
 	// TODO(jakev): Ensure we validate mandatory headers
 
 	// Generate full URL.

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -1,6 +1,7 @@
 {
 	"clients.bar.ip": "127.0.0.1",
 	"clients.bar.port": 4001,
+	"clients.bar.timeout": 1000,
 	"clients.baz.ip": "127.0.0.1",
 	"clients.baz.port": 4002,
 	"clients.baz.serviceName": "Qux",
@@ -8,8 +9,10 @@
 	"clients.baz.timeoutPerAttempt": 1000,
 	"clients.contacts.ip": "127.0.0.1",
 	"clients.contacts.port": 4000,
+	"clients.contacts.timeout": 1000,
 	"clients.google-now.ip": "127.0.0.1",
 	"clients.google-now.port": 14120,
+	"clients.google-now.timeout": 1000,
 	"clients.googleNowTChannel.connectionType": "p2p",
 	"clients.googleNowTChannel.hostList": [
 		"127.0.0.1:4002"

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -1,7 +1,7 @@
 {
 	"clients.bar.ip": "127.0.0.1",
 	"clients.bar.port": 4001,
-	"clients.bar.timeout": 1000,
+	"clients.bar.timeout": 10000,
 	"clients.baz.ip": "127.0.0.1",
 	"clients.baz.port": 4002,
 	"clients.baz.serviceName": "Qux",
@@ -9,15 +9,15 @@
 	"clients.baz.timeoutPerAttempt": 1000,
 	"clients.contacts.ip": "127.0.0.1",
 	"clients.contacts.port": 4000,
-	"clients.contacts.timeout": 1000,
+	"clients.contacts.timeout": 10000,
 	"clients.google-now.ip": "127.0.0.1",
 	"clients.google-now.port": 14120,
-	"clients.google-now.timeout": 1000,
+	"clients.google-now.timeout": 10000,
 	"clients.googleNowTChannel.connectionType": "p2p",
 	"clients.googleNowTChannel.hostList": [
 		"127.0.0.1:4002"
 	],
-	"clients.googleNowTChannel.timeout": 5000,
+	"clients.googleNowTChannel.timeout": 10000,
 	"http.port": 7783,
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",

--- a/runtime/call_metrics.go
+++ b/runtime/call_metrics.go
@@ -197,35 +197,18 @@ func NewInboundHTTPMetrics(scope tally.Scope) *InboundHTTPMetrics {
 //}
 
 // NewOutboundHTTPMetrics returns outbound HTTP metrics
-//func NewOutboundHTTPMetrics(scope tally.Scope) *OutboundHTTPMetrics {
-//	metrics := OutboundHTTPMetrics{}
-//	metrics.Sent = scope.Counter(outboundCallsSent)
-//	metrics.Latency = scope.Timer(outboundCallsLatency)
-//	metrics.Success = scope.Counter(outboundCallsSuccess)
-//	metrics.Errors = scope.Counter(outboundCallsErrors)
-//	metrics.Status = make(map[int]tally.Counter, len(knownStatusCodes))
-//	for statusCode := range knownStatusCodes {
-//		metrics.Status[statusCode] = scope.Counter(fmt.Sprintf("%s.%d", outboundCallsStatus, statusCode))
-//	}
-//	return &metrics
-//}
-
-// CollectMetrics for outbound HTTP calls
-//func (m *OutboundHTTPMetrics) CollectMetrics(startTime time.Time, statusCode int) {
-//	m.Sent.Inc(1)
-//	_, known := knownStatusCodes[statusCode]
-//	if !known {
-//		m.logger.Error("Could not emit statusCode metric", zap.Int("UnknownStatusCode", statusCode))
-//	} else {
-//		m.Status[statusCode].Inc(1)
-//	}
-//	if !known || statusCode >= 400 && statusCode < 600 {
-//		m.Errors.Inc(1)
-//	} else {
-//		m.Success.Inc(1)
-//	}
-//	m.Latency.Record(time.Now().Sub(startTime))
-//}
+func NewOutboundHTTPMetrics(scope tally.Scope) *OutboundHTTPMetrics {
+	metrics := OutboundHTTPMetrics{}
+	metrics.Sent = scope.Counter(outboundCallsSent)
+	metrics.Latency = scope.Timer(outboundCallsLatency)
+	metrics.Success = scope.Counter(outboundCallsSuccess)
+	metrics.Errors = scope.Counter(outboundCallsErrors)
+	metrics.Status = make(map[int]tally.Counter, len(knownStatusCodes))
+	for statusCode := range knownStatusCodes {
+		metrics.Status[statusCode] = scope.Counter(fmt.Sprintf("%s.%d", outboundCallsStatus, statusCode))
+	}
+	return &metrics
+}
 
 // NewOutboundTChannelMetrics returns outbound TChannel metrics
 //func NewOutboundTChannelMetrics(scope tally.Scope) *OutboundTChannelMetrics {

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	clientsBarBar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/bar/bar"
@@ -32,7 +33,6 @@ import (
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 	"github.com/uber/zanzibar/test/lib/util"
-	"time"
 )
 
 var defaultTestOptions *testGateway.Options = &testGateway.Options{
@@ -67,11 +67,13 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 
 	err = req.WriteJSON("GET", "/foo", nil, &failingJsonObj{})
 	assert.NotNil(t, err)
-
 	assert.Equal(t,
 		"Could not serialize clientID.DoStuff request json: cannot serialize",
 		err.Error(),
 	)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Could not serialize request json"], 1)
 }
 
 func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
@@ -97,11 +99,13 @@ func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 
 	err = req.WriteJSON("@INVALIDMETHOD", "/foo", nil, nil)
 	assert.NotNil(t, err)
-
 	assert.Equal(t,
 		"Could not create outbound clientID.DoStuff request: net/http: invalid method \"@INVALIDMETHOD\"",
 		err.Error(),
 	)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Could not create outbound request"], 1)
 }
 
 func TestMakingClientCalLWithHeaders(t *testing.T) {
@@ -143,13 +147,14 @@ func TestMakingClientCalLWithHeaders(t *testing.T) {
 
 	res, err := req.Do(context.Background())
 	assert.NoError(t, err)
-
 	assert.Equal(t, 200, res.StatusCode)
 
 	bytes, err := res.ReadAll()
 	assert.NoError(t, err)
-
 	assert.Equal(t, []byte("Example-Value"), bytes)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestMakingClientCallWithRespHeaders(t *testing.T) {
@@ -187,9 +192,11 @@ func TestMakingClientCallWithRespHeaders(t *testing.T) {
 		context.Background(), nil, &clientsBarBar.Bar_Normal_Args{},
 	)
 	assert.NoError(t, err)
-
 	assert.NotNil(t, body)
 	assert.Equal(t, "Example-Value", headers["Example-Header"])
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestMakingClientCallWithThriftException(t *testing.T) {
@@ -224,6 +231,9 @@ func TestMakingClientCallWithThriftException(t *testing.T) {
 
 	realError := err.(*clientsBarBar.BarException)
 	assert.Equal(t, realError.StringField, "test")
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestMakingClientCallWithBadStatusCode(t *testing.T) {
@@ -255,8 +265,11 @@ func TestMakingClientCallWithBadStatusCode(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Nil(t, body)
-
 	assert.Equal(t, "Unexpected http client response (402)", err.Error())
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Unknown response status code"], 1)
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestMakingCallWithThriftException(t *testing.T) {
@@ -292,6 +305,9 @@ func TestMakingCallWithThriftException(t *testing.T) {
 
 	realError := err.(*clientsBarBar.BarException)
 	assert.Equal(t, realError.StringField, "test")
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestMakingClientCallWithServerError(t *testing.T) {
@@ -323,6 +339,9 @@ func TestMakingClientCallWithServerError(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Nil(t, body)
-
 	assert.Equal(t, "Unexpected http client response (500)", err.Error())
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Unknown response status code"], 1)
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }

--- a/runtime/client_http_response_test.go
+++ b/runtime/client_http_response_test.go
@@ -83,6 +83,9 @@ func TestReadAndUnmarshalNonStructBody(t *testing.T) {
 	var resp string
 	assert.NoError(t, res.ReadAndUnmarshalBody(&resp))
 	assert.Equal(t, "foo", resp)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
@@ -134,6 +137,10 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 	var resp string
 	assert.Error(t, res.ReadAndUnmarshalBody(&resp))
 	assert.Equal(t, "", resp)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Could not parse response json"], 1)
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 func TestUnknownStatusCode(t *testing.T) {
@@ -194,6 +201,11 @@ func TestUnknownStatusCode(t *testing.T) {
 	lineStruct := logLines[0]
 	code := lineStruct["UnknownStatusCode"].(float64)
 	assert.Equal(t, 999.0, code)
+
+	logs := bgateway.AllLogs()
+	assert.Len(t, logs["Could not parse response json"], 1)
+	assert.Len(t, logs["Could not emit statusCode metric"], 1)
+	assert.Len(t, logs["Finished an outgoing client HTTP request"], 1)
 }
 
 type myJson struct{}

--- a/runtime/client_http_response_test.go
+++ b/runtime/client_http_response_test.go
@@ -24,14 +24,14 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-	zanzibar "github.com/uber/zanzibar/runtime"
+	exampleGateway "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
+	"github.com/uber/zanzibar/runtime"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
 	"github.com/uber/zanzibar/test/lib/util"
-
-	exampleGateway "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
 )
 
 func TestReadAndUnmarshalNonStructBody(t *testing.T) {
@@ -39,7 +39,7 @@ func TestReadAndUnmarshalNonStructBody(t *testing.T) {
 		defaultTestConfig,
 		&testGateway.Options{
 			LogWhitelist: map[string]bool{
-				"Could not ReadAll() body": true,
+				"Could not read response body": true,
 			},
 			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
@@ -66,7 +66,13 @@ func TestReadAndUnmarshalNonStructBody(t *testing.T) {
 	addr := bgateway.HTTPBackends()["bar"].RealAddr
 	baseURL := "http://" + addr
 
-	client := zanzibar.NewHTTPClient(bgateway.ActualGateway, baseURL)
+	client := zanzibar.NewHTTPClient(
+		bgateway.ActualGateway,
+		"bar",
+		[]string{"echo"},
+		baseURL,
+		time.Second,
+	)
 	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
 
 	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
@@ -84,10 +90,11 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 		defaultTestConfig,
 		&testGateway.Options{
 			LogWhitelist: map[string]bool{
-				"Could not ReadAll() body": true,
+				"Could not read response body": true,
 			},
 			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
+			ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
 		},
 		exampleGateway.CreateGateway,
 	)
@@ -110,7 +117,13 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 	addr := bgateway.HTTPBackends()["bar"].RealAddr
 	baseURL := "http://" + addr
 
-	client := zanzibar.NewHTTPClient(bgateway.ActualGateway, baseURL)
+	client := zanzibar.NewHTTPClient(
+		bgateway.ActualGateway,
+		"bar",
+		[]string{"echo"},
+		baseURL,
+		time.Second,
+	)
 	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
 
 	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
@@ -121,6 +134,66 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 	var resp string
 	assert.Error(t, res.ReadAndUnmarshalBody(&resp))
 	assert.Equal(t, "", resp)
+}
+
+func TestUnknownStatusCode(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		&testGateway.Options{
+			LogWhitelist: map[string]bool{
+				"Could not emit statusCode metric": true,
+			},
+			KnownHTTPBackends: []string{"bar"},
+			ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		},
+		exampleGateway.CreateGateway,
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer gateway.Close()
+
+	bgateway := gateway.(*benchGateway.BenchGateway)
+
+	fakeEcho := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(999)
+		_, err := w.Write([]byte(`false`))
+		assert.NoError(t, err)
+	}
+
+	bgateway.HTTPBackends()["bar"].HandleFunc("POST", "/bar/echo", fakeEcho)
+
+	addr := bgateway.HTTPBackends()["bar"].RealAddr
+	baseURL := "http://" + addr
+
+	client := zanzibar.NewHTTPClient(
+		bgateway.ActualGateway,
+		"bar",
+		[]string{"echo"},
+		baseURL,
+		time.Second,
+	)
+
+	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
+
+	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
+	assert.NoError(t, err)
+
+	res, err := req.Do(context.Background())
+	assert.NoError(t, err)
+
+	var resp string
+	assert.Error(t, res.ReadAndUnmarshalBody(&resp))
+	assert.Equal(t, "", resp)
+	assert.Equal(t, 999, res.StatusCode)
+
+	logLines := bgateway.Logs("error", "Could not emit statusCode metric")
+	assert.NotNil(t, logLines)
+	assert.Equal(t, 1, len(logLines))
+
+	lineStruct := logLines[0]
+	code := lineStruct["UnknownStatusCode"].(float64)
+	assert.Equal(t, 999.0, code)
 }
 
 type myJson struct{}

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -409,9 +409,9 @@ func (req *ServerHTTPRequest) ReadAndUnmarshalBody(
 func (req *ServerHTTPRequest) ReadAll() ([]byte, bool) {
 	rawBody, err := ioutil.ReadAll(req.httpRequest.Body)
 	if err != nil {
-		req.Logger.Error("Could not ReadAll() body", zap.Error(err))
+		req.Logger.Error("Could not read request body", zap.Error(err))
 		if !req.parseFailed {
-			req.res.SendErrorString(500, "Could not ReadAll() body")
+			req.res.SendErrorString(500, "Could not read request body")
 			req.parseFailed = true
 		}
 		return nil, false

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -29,13 +29,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
+	exampleGateway "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
 	zanzibar "github.com/uber/zanzibar/runtime"
-
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-
-	exampleGateway "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
+	"github.com/uber/zanzibar/test/lib/util"
 )
 
 func TestInvalidReadAndUnmarshalBody(t *testing.T) {
@@ -43,10 +41,11 @@ func TestInvalidReadAndUnmarshalBody(t *testing.T) {
 		defaultTestConfig,
 		&testGateway.Options{
 			LogWhitelist: map[string]bool{
-				"Could not ReadAll() body": true,
+				"Could not read request body": true,
 			},
 			KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
 			KnownTChannelBackends: []string{"baz"},
+			ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
 		},
 		exampleGateway.CreateGateway,
 	)
@@ -85,7 +84,7 @@ func TestInvalidReadAndUnmarshalBody(t *testing.T) {
 	dJ := &dummyJson{}
 	assert.False(t, req.ReadAndUnmarshalBody(dJ))
 
-	logLines := gateway.Logs("error", "Could not ReadAll() body")
+	logLines := gateway.Logs("error", "Could not read request body")
 	assert.NotNil(t, logLines)
 	assert.Equal(t, 1, len(logLines))
 }

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -99,14 +99,11 @@ func (res *ServerHTTPResponse) finish() {
 	// write logs
 	res.Request.Logger.Info(
 		"Finished an incoming server HTTP request",
-		logFields(res.Request, res)...,
+		serverHTTPLogFields(res.Request, res)...,
 	)
 }
 
-func logFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapcore.Field {
-	// TODO: Allocating a fixed size array causes the zap logger to fail
-	// with ``unknown field type: { 0 0  <nil>}'' errors. Investigate this
-	// further to see if we can avoid reallocating underlying arrays for slices.
+func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapcore.Field {
 	fields := []zapcore.Field{
 		zap.String("method", req.httpRequest.Method),
 		zap.String("remoteAddr", req.httpRequest.RemoteAddr),
@@ -129,7 +126,6 @@ func logFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapcore.Field 
 			fields = append(fields, zap.String("Request-Header-"+k, v[0]))
 		}
 	}
-
 	for k, v := range req.res.responseWriter.Header() {
 		if len(v) > 0 {
 			fields = append(fields, zap.String("Response-Header-"+k, v[0]))

--- a/test/clients/bar/bar_test.go
+++ b/test/clients/bar/bar_test.go
@@ -841,7 +841,9 @@ func TestEchoStructMap(t *testing.T) {
 
 func TestNestedQueryParamCallWithNil(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		defaultTestConfig, defaultTestOptions, exampleGateway.CreateGateway,
+		defaultTestConfig,
+		defaultTestOptions,
+		exampleGateway.CreateGateway,
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -864,7 +866,9 @@ func TestNestedQueryParamCallWithNil(t *testing.T) {
 
 func TestNormalRecur(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
-		defaultTestConfig, defaultTestOptions, exampleGateway.CreateGateway,
+		defaultTestConfig,
+		defaultTestOptions,
+		exampleGateway.CreateGateway,
 	)
 	if !assert.NoError(t, err) {
 		return

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bar_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+	"github.com/uber/zanzibar/test/lib/test_gateway"
+	"github.com/uber/zanzibar/test/lib/util"
+)
+
+func TestCallMetrics(t *testing.T) {
+	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
+		CountMetrics:      true,
+		KnownHTTPBackends: []string{"bar"},
+		TestBinary:        util.DefaultMainFile("example-gateway"),
+		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+	})
+	if !assert.NoError(t, err, "got bootstrap err") {
+		return
+	}
+	defer gateway.Close()
+
+	gateway.HTTPBackends()["bar"].HandleFunc(
+		"POST", "/bar-path",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			if _, err := w.Write([]byte(`{
+				"stringField": "stringValue",
+				"intWithRange": 0,
+				"intWithoutRange": 0,
+				"mapIntWithRange": {},
+				"mapIntWithoutRange": {}
+			}`)); err != nil {
+				t.Fatal("can't write fake response")
+			}
+		},
+	)
+
+	numMetrics := 8
+	cg := gateway.(*testGateway.ChildProcessGateway)
+	cg.MetricsWaitGroup.Add(numMetrics)
+
+	_, err = gateway.MakeRequest(
+		"POST", "/bar/bar-path", nil,
+		bytes.NewReader([]byte(`{
+			"request":{"stringField":"foo","boolField":true}
+		}`)),
+	)
+	if !assert.NoError(t, err, "got http error") {
+		return
+	}
+
+	cg.MetricsWaitGroup.Wait()
+	metrics := cg.M3Service.GetMetrics()
+	assert.Equal(t, numMetrics, len(metrics))
+
+	endpointNames := []string{
+		"inbound.calls.latency",
+		"inbound.calls.recvd",
+		"inbound.calls.success",
+		"inbound.calls.status.200",
+	}
+	endpointTags := map[string]string{
+		"env":      "test",
+		"service":  "test-gateway",
+		"endpoint": "bar",
+		"handler":  "normal",
+	}
+	for _, name := range endpointNames {
+		key := tally.KeyForPrefixedStringMap(name, endpointTags)
+		assert.Contains(t, metrics, key, "expected metric: %s", key)
+	}
+
+	inboundLatency := metrics[tally.KeyForPrefixedStringMap("inbound.calls.latency", endpointTags)]
+	value := *inboundLatency.MetricValue.Timer.I64Value
+	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
+	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
+
+	inboundRecvd := metrics[tally.KeyForPrefixedStringMap("inbound.calls.recvd", endpointTags)]
+	value = *inboundRecvd.MetricValue.Count.I64Value
+	assert.Equal(t, int64(1), value)
+
+	inboundStatus := metrics[tally.KeyForPrefixedStringMap("inbound.calls.status.200", endpointTags)]
+	value = *inboundStatus.MetricValue.Count.I64Value
+	assert.Equal(t, int64(1), value, "expected counter to be 1")
+
+	httpClientNames := []string{
+		"outbound.calls.latency",
+		"outbound.calls.sent",
+		"outbound.calls.success",
+		"outbound.calls.status.200",
+	}
+	httpClientTags := map[string]string{
+		"env":     "test",
+		"service": "test-gateway",
+		"client":  "bar",
+		"method":  "Normal",
+	}
+	for _, name := range httpClientNames {
+		key := tally.KeyForPrefixedStringMap(name, httpClientTags)
+		assert.Contains(t, metrics, key, "expected metric: %s", key)
+	}
+
+	outboundLatency := metrics[tally.KeyForPrefixedStringMap("outbound.calls.latency", httpClientTags)]
+	value = *outboundLatency.MetricValue.Timer.I64Value
+	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
+	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
+
+	outboundSent := metrics[tally.KeyForPrefixedStringMap("outbound.calls.sent", httpClientTags)]
+	value = *outboundSent.MetricValue.Count.I64Value
+	assert.Equal(t, int64(1), value, "expected counter to be 1")
+
+	outboundSuccess := metrics[tally.KeyForPrefixedStringMap("outbound.calls.success", httpClientTags)]
+	value = *outboundSuccess.MetricValue.Count.I64Value
+	assert.Equal(t, int64(1), value, "expected counter to be 1")
+
+	statusSuccess := metrics[tally.KeyForPrefixedStringMap("outbound.calls.status.200", httpClientTags)]
+	value = *statusSuccess.MetricValue.Count.I64Value
+	assert.Equal(t, int64(1), value, "expected counter to be 1")
+}

--- a/test/endpoints/bar/bar_normal_test.go
+++ b/test/endpoints/bar/bar_normal_test.go
@@ -85,7 +85,7 @@ func TestBarNormalMalformedClientResponseReadAll(t *testing.T) {
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
 		LogWhitelist: map[string]bool{
-			"Could not ReadAll() client body": true,
+			"Could not read response body": true,
 		},
 		TestBinary:  util.DefaultMainFile("example-gateway"),
 		ConfigFiles: util.DefaultConfigFiles("example-gateway"),

--- a/test/endpoints/googlenow/googlenow_test.go
+++ b/test/endpoints/googlenow/googlenow_test.go
@@ -154,7 +154,7 @@ func TestGoogleNowFailReadAllCall(t *testing.T) {
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		LogWhitelist: map[string]bool{
-			"Could not ReadAll() body": true,
+			"Could not read request body": true,
 		},
 		KnownHTTPBackends: []string{"google-now"},
 		TestBinary:        util.DefaultMainFile("example-gateway"),
@@ -206,7 +206,7 @@ func TestGoogleNowFailReadAllCall(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	logLines := gateway.Logs("error", "Could not ReadAll() body")
+	logLines := gateway.Logs("error", "Could not read request body")
 	assert.NotNil(t, logLines)
 	assert.Equal(t, 1, len(logLines))
 
@@ -329,7 +329,7 @@ func TestAddCredentialsBackendDown(t *testing.T) {
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"google-now"},
 		LogWhitelist: map[string]bool{
-			"Could not make client request": true,
+			"Could not make outbound request": true,
 		},
 		TestBinary:  util.DefaultMainFile("example-gateway"),
 		ConfigFiles: util.DefaultConfigFiles("example-gateway"),
@@ -559,7 +559,7 @@ func TestCheckCredentialsBackendDown(t *testing.T) {
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"google-now"},
 		LogWhitelist: map[string]bool{
-			"Could not make client request": true,
+			"Could not make outbound request": true,
 		},
 		TestBinary:  util.DefaultMainFile("example-gateway"),
 		ConfigFiles: util.DefaultConfigFiles("example-gateway"),


### PR DESCRIPTION
HTTP client emits the following metrics:

Names:
- outbound.calls.sent
- outbound.calls.success
- outbound.calls.errors
- outbound.calls.latency
- outbound.calls.status.XXX

Tags:
- host - “all”
- env - environment, e.g. “production”, “staging”, “test”
- service - service name, e.g. “example-gateway”
- client - module instance name, e.g. “bar”, etc.
- method - module instance exposed method, e.g. “echostring”
