### PR TITLE
Adding metrics and logs to tchannel client

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -385,7 +385,6 @@ func (g *TChannelClientGenerator) Generate(
 		IncludedPackages: clientSpec.ModuleSpec.IncludedPackages,
 		ClientID:         clientSpec.ClientID,
 		ExposedMethods:   exposedMethods,
-		LogDownstream:    true,
 		SidecarRouter:    clientSpec.SidecarRouter,
 	}
 
@@ -1098,7 +1097,6 @@ type ClientMeta struct {
 	IncludedPackages []GoPackageImport
 	Services         []*ServiceSpec
 	ExposedMethods   map[string]string
-	LogDownstream    bool
 	SidecarRouter    string
 }
 

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1560,9 +1560,21 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		gateway.Config.MustGetInt("clients.{{$clientID}}.timeoutPerAttempt"),
 	)
 
+	methodNames := map[string]string{
+		{{range $svc := .Services -}}
+		{{range .Methods -}}
+		{{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
+		{{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
+			"{{$serviceMethod}}": "{{$methodName}}",
+		{{ end -}}
+		{{ end -}}
+	}
+
 	client := zanzibar.NewTChannelClient(gateway.Channel,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
+			ClientID:          "{{$clientID}}",
+			MethodNames:       methodNames,
 			Timeout:           timeout,
 			TimeoutPerAttempt: timeoutPerAttempt,
 			RoutingKey:        &routingKey,

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1661,7 +1661,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4596, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4806, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1570,7 +1570,9 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		{{ end -}}
 	}
 
-	client := zanzibar.NewTChannelClient(gateway.Channel,
+	client := zanzibar.NewTChannelClient(
+		gateway.Channel,
+		gateway.Logger,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "{{$clientID}}",
@@ -1681,7 +1683,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5295, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5267, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1661,7 +1661,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4391, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4596, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1511,7 +1511,6 @@ import (
 {{$exposedMethods := .ExposedMethods -}}
 {{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
-{{- $logDownstream := .LogDownstream}}
 {{- $sidecarRouter := .SidecarRouter}}
 
 // Client defines {{$clientID}} client interface.
@@ -1617,31 +1616,9 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
-		{{if $logDownstream -}}
-			var fields []zapcore.Field
-			fields = append(fields, zap.String("Downstream-Client", "{{$clientName}}"))
-			fields = append(fields, zap.String("Downstream-Method", "{{$methodName}}"))
-			fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-			for k, v := range reqHeaders {
-				fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-			}
-			fields = append(fields, zap.Any("Downstream-Request-Body", args))
-		{{end -}}
-
 		success, respHeaders, err := c.client.Call(
 			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 		)
-
-		{{if $logDownstream -}}
-			for k, v := range respHeaders {
-				fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-			}
-			fields = append(fields, zap.Any("Downstream-Response-Body", result))
-			fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-			c.logger.Info(
-				"Finished a downstream TChannel request",
-				fields...)
-		{{end -}}
 
 		if err == nil && !success {
 			switch {
@@ -1683,7 +1660,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5267, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4367, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1572,6 +1572,7 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	client := zanzibar.NewTChannelClient(
 		gateway.Channel,
 		gateway.Logger,
+		gateway.AllHostScope,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "{{$clientID}}",
@@ -1660,7 +1661,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4367, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 4391, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -84,6 +84,7 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 	client := zanzibar.NewTChannelClient(
 		gateway.Channel,
 		gateway.Logger,
+		gateway.AllHostScope,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "{{$clientID}}",

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -23,7 +23,6 @@ import (
 {{$exposedMethods := .ExposedMethods -}}
 {{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
-{{- $logDownstream := .LogDownstream}}
 {{- $sidecarRouter := .SidecarRouter}}
 
 // Client defines {{$clientID}} client interface.
@@ -129,31 +128,9 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
-		{{if $logDownstream -}}
-			var fields []zapcore.Field
-			fields = append(fields, zap.String("Downstream-Client", "{{$clientName}}"))
-			fields = append(fields, zap.String("Downstream-Method", "{{$methodName}}"))
-			fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-			for k, v := range reqHeaders {
-				fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-			}
-			fields = append(fields, zap.Any("Downstream-Request-Body", args))
-		{{end -}}
-
 		success, respHeaders, err := c.client.Call(
 			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 		)
-
-		{{if $logDownstream -}}
-			for k, v := range respHeaders {
-				fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-			}
-			fields = append(fields, zap.Any("Downstream-Response-Body", result))
-			fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-			c.logger.Info(
-				"Finished a downstream TChannel request",
-				fields...)
-		{{end -}}
 
 		if err == nil && !success {
 			switch {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -72,9 +72,21 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		gateway.Config.MustGetInt("clients.{{$clientID}}.timeoutPerAttempt"),
 	)
 
+	methodNames := map[string]string{
+		{{range $svc := .Services -}}
+		{{range .Methods -}}
+		{{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
+		{{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
+			"{{$serviceMethod}}": "{{$methodName}}",
+		{{ end -}}
+		{{ end -}}
+	}
+
 	client := zanzibar.NewTChannelClient(gateway.Channel,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
+			ClientID:          "{{$clientID}}",
+			MethodNames:       methodNames,
 			Timeout:           timeout,
 			TimeoutPerAttempt: timeoutPerAttempt,
 			RoutingKey:        &routingKey,

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -82,7 +82,9 @@ func {{$exportName}}(gateway *zanzibar.Gateway) Client {
 		{{ end -}}
 	}
 
-	client := zanzibar.NewTChannelClient(gateway.Channel,
+	client := zanzibar.NewTChannelClient(
+		gateway.Channel,
+		gateway.Logger,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "{{$clientID}}",

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/uber/tchannel-go"
 	"github.com/uber/zanzibar/runtime"
@@ -221,26 +220,10 @@ func (c *bazClient) EchoBinary(
 	var result clientsBazBaz.SecondService_EchoBinary_Result
 	var resp []byte
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoBinary"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -264,26 +247,10 @@ func (c *bazClient) EchoBool(
 	var result clientsBazBaz.SecondService_EchoBool_Result
 	var resp bool
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoBool"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -307,26 +274,10 @@ func (c *bazClient) EchoDouble(
 	var result clientsBazBaz.SecondService_EchoDouble_Result
 	var resp float64
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoDouble"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -350,26 +301,10 @@ func (c *bazClient) EchoEnum(
 	var result clientsBazBaz.SecondService_EchoEnum_Result
 	var resp clientsBazBaz.Fruit
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoEnum"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -393,26 +328,10 @@ func (c *bazClient) EchoI16(
 	var result clientsBazBaz.SecondService_EchoI16_Result
 	var resp int16
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoI16"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -436,26 +355,10 @@ func (c *bazClient) EchoI32(
 	var result clientsBazBaz.SecondService_EchoI32_Result
 	var resp int32
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoI32"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -479,26 +382,10 @@ func (c *bazClient) EchoI64(
 	var result clientsBazBaz.SecondService_EchoI64_Result
 	var resp int64
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoI64"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -522,26 +409,10 @@ func (c *bazClient) EchoI8(
 	var result clientsBazBaz.SecondService_EchoI8_Result
 	var resp int8
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoI8"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -565,26 +436,10 @@ func (c *bazClient) EchoString(
 	var result clientsBazBaz.SecondService_EchoString_Result
 	var resp string
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoString"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoString", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -608,26 +463,10 @@ func (c *bazClient) EchoStringList(
 	var result clientsBazBaz.SecondService_EchoStringList_Result
 	var resp []string
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStringList"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -651,26 +490,10 @@ func (c *bazClient) EchoStringMap(
 	var result clientsBazBaz.SecondService_EchoStringMap_Result
 	var resp map[string]*clientsBazBase.BazResponse
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStringMap"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -694,26 +517,10 @@ func (c *bazClient) EchoStringSet(
 	var result clientsBazBaz.SecondService_EchoStringSet_Result
 	var resp map[string]struct{}
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStringSet"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -737,26 +544,10 @@ func (c *bazClient) EchoStructList(
 	var result clientsBazBaz.SecondService_EchoStructList_Result
 	var resp []*clientsBazBase.BazResponse
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStructList"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -786,26 +577,10 @@ func (c *bazClient) EchoStructMap(
 		Value string
 	}
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStructMap"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStructMap", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -829,26 +604,10 @@ func (c *bazClient) EchoStructSet(
 	var result clientsBazBaz.SecondService_EchoStructSet_Result
 	var resp []*clientsBazBase.BazResponse
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoStructSet"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -872,26 +631,10 @@ func (c *bazClient) EchoTypedef(
 	var result clientsBazBaz.SecondService_EchoTypedef_Result
 	var resp clientsBazBase.UUID
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "EchoTypedef"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -914,26 +657,10 @@ func (c *bazClient) Call(
 ) (map[string]string, error) {
 	var result clientsBazBaz.SimpleService_Call_Result
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "Call"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SimpleService", "call", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		case result.AuthErr != nil:
@@ -958,26 +685,10 @@ func (c *bazClient) Compare(
 	var result clientsBazBaz.SimpleService_Compare_Result
 	var resp *clientsBazBase.BazResponse
 
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "Compare"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SimpleService", "compare", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		case result.AuthErr != nil:
@@ -1005,26 +716,10 @@ func (c *bazClient) Ping(
 	var resp *clientsBazBase.BazResponse
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "Ping"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SimpleService", "ping", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		default:
@@ -1047,26 +742,10 @@ func (c *bazClient) DeliberateDiffNoop(
 	var result clientsBazBaz.SimpleService_SillyNoop_Result
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
-	var fields []zapcore.Field
-	fields = append(fields, zap.String("Downstream-Client", "bazClient"))
-	fields = append(fields, zap.String("Downstream-Method", "DeliberateDiffNoop"))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	for k, v := range reqHeaders {
-		fields = append(fields, zap.String("Downstream-Request-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Request-Body", args))
 	success, respHeaders, err := c.client.Call(
 		ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 	)
 
-	for k, v := range respHeaders {
-		fields = append(fields, zap.String("Downstream-Response-Header-"+k, v))
-	}
-	fields = append(fields, zap.Any("Downstream-Response-Body", result))
-	fields = append(fields, zap.Time("timestamp-finished", time.Now().UTC()))
-	c.logger.Info(
-		"Finished a downstream TChannel request",
-		fields...)
 	if err == nil && !success {
 		switch {
 		case result.AuthErr != nil:

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -189,6 +189,7 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 	client := zanzibar.NewTChannelClient(
 		gateway.Channel,
 		gateway.Logger,
+		gateway.AllHostScope,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "baz",

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -164,9 +164,34 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		gateway.Config.MustGetInt("clients.baz.timeoutPerAttempt"),
 	)
 
+	methodNames := map[string]string{
+		"SecondService::echoBinary":     "EchoBinary",
+		"SecondService::echoBool":       "EchoBool",
+		"SecondService::echoDouble":     "EchoDouble",
+		"SecondService::echoEnum":       "EchoEnum",
+		"SecondService::echoI16":        "EchoI16",
+		"SecondService::echoI32":        "EchoI32",
+		"SecondService::echoI64":        "EchoI64",
+		"SecondService::echoI8":         "EchoI8",
+		"SecondService::echoString":     "EchoString",
+		"SecondService::echoStringList": "EchoStringList",
+		"SecondService::echoStringMap":  "EchoStringMap",
+		"SecondService::echoStringSet":  "EchoStringSet",
+		"SecondService::echoStructList": "EchoStructList",
+		"SecondService::echoStructMap":  "EchoStructMap",
+		"SecondService::echoStructSet":  "EchoStructSet",
+		"SecondService::echoTypedef":    "EchoTypedef",
+		"SimpleService::call":           "Call",
+		"SimpleService::compare":        "Compare",
+		"SimpleService::ping":           "Ping",
+		"SimpleService::sillyNoop":      "DeliberateDiffNoop",
+	}
+
 	client := zanzibar.NewTChannelClient(gateway.Channel,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
+			ClientID:          "baz",
+			MethodNames:       methodNames,
 			Timeout:           timeout,
 			TimeoutPerAttempt: timeoutPerAttempt,
 			RoutingKey:        &routingKey,

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -187,7 +187,9 @@ func NewClient(gateway *zanzibar.Gateway) Client {
 		"SimpleService::sillyNoop":      "DeliberateDiffNoop",
 	}
 
-	client := zanzibar.NewTChannelClient(gateway.Channel,
+	client := zanzibar.NewTChannelClient(
+		gateway.Channel,
+		gateway.Logger,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			ClientID:          "baz",

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
@@ -44,7 +44,13 @@ func (w CallEndpoint) Handle(
 	reqHeaders zanzibar.Header,
 	req *endpointBaz.SimpleService_Call_Args,
 ) (zanzibar.Header, error) {
-	var clientReqHeaders map[string]string
+	clientReqHeaders := make(map[string]string)
+	// passing endpoint reqHeaders to downstream client
+	for _, k := range reqHeaders.Keys() {
+		if v, ok := reqHeaders.Get(k); ok {
+			clientReqHeaders[k] = v
+		}
+	}
 
 	clientReq := &clientBaz.SimpleService_Call_Args{
 		Arg: (*clientBaz.BazRequest)(req.Arg),

--- a/runtime/call_metrics.go
+++ b/runtime/call_metrics.go
@@ -183,19 +183,6 @@ func NewInboundHTTPMetrics(scope tally.Scope) *InboundHTTPMetrics {
 //	return &metrics
 //}
 
-// CollectMetrics for inbound TChannel calls
-//func (m *InboundTChannelMetrics) CollectMetrics(startTime time.Time, success bool, err error) {
-//	m.Recvd.Inc(1)
-//	if err != nil {
-//		m.SystemErrors.Inc(1)
-//	} else if !success {
-//		m.AppErrors.Inc(1)
-//	} else {
-//		m.Success.Inc(1)
-//	}
-//	m.Latency.Record(time.Now().Sub(startTime))
-//}
-
 // NewOutboundHTTPMetrics returns outbound HTTP metrics
 func NewOutboundHTTPMetrics(scope tally.Scope) *OutboundHTTPMetrics {
 	metrics := OutboundHTTPMetrics{}
@@ -211,25 +198,12 @@ func NewOutboundHTTPMetrics(scope tally.Scope) *OutboundHTTPMetrics {
 }
 
 // NewOutboundTChannelMetrics returns outbound TChannel metrics
-//func NewOutboundTChannelMetrics(scope tally.Scope) *OutboundTChannelMetrics {
-//	metrics := OutboundTChannelMetrics{}
-//	metrics.Sent = scope.Counter(outboundCallsSent)
-//	metrics.Latency = scope.Timer(outboundCallsLatency)
-//	metrics.Success = scope.Counter(outboundCallsSuccess)
-//	metrics.AppErrors = scope.Counter(outboundCallsAppErrors)
-//	metrics.SystemErrors = scope.Counter(outboundCallsSystemErrors)
-//	return &metrics
-//}
-
-// CollectMetrics for outbound TChannel calls
-//func (m *OutboundTChannelMetrics) CollectMetrics(startTime time.Time, success bool, err error) {
-//	m.Sent.Inc(1)
-//	if err != nil {
-//		m.SystemErrors.Inc(1)
-//	} else if !success {
-//		m.AppErrors.Inc(1)
-//	} else {
-//		m.Success.Inc(1)
-//	}
-//	m.Latency.Record(time.Now().Sub(startTime))
-//}
+func NewOutboundTChannelMetrics(scope tally.Scope) *OutboundTChannelMetrics {
+	metrics := OutboundTChannelMetrics{}
+	metrics.Sent = scope.Counter(outboundCallsSent)
+	metrics.Latency = scope.Timer(outboundCallsLatency)
+	metrics.Success = scope.Counter(outboundCallsSuccess)
+	metrics.AppErrors = scope.Counter(outboundCallsAppErrors)
+	metrics.SystemErrors = scope.Counter(outboundCallsSystemErrors)
+	return &metrics
+}

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -172,7 +172,7 @@ func clientHTTPLogFields(req *ClientHTTPRequest, res *ClientHTTPResponse) []zapc
 		zap.Int("statusCode", res.StatusCode),
 
 		// TODO: Do not log body by default because PII and bandwidth.
-		// Temporarily log during the developement cycle
+		// Temporarily log during the development cycle
 		// TODO: Add a gateway level configurable body unmarshaller
 		// to extract only non-PII info.
 		zap.ByteString("Request Body", req.rawBody),

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -114,7 +114,7 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 		zap.Int("statusCode", res.StatusCode),
 
 		// TODO: Do not log body by default because PII and bandwidth.
-		// Temporarily log during the developement cycle
+		// Temporarily log during the development cycle
 		// TODO: Add a gateway level configurable body unmarshaller
 		// to extract only non-PII info.
 		zap.ByteString("Request Body", req.RawBody),

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uber/tchannel-go"
-
 	"go.uber.org/thriftrw/protocol"
 	netContext "golang.org/x/net/context"
 )
@@ -49,6 +48,18 @@ type tchannelClient struct {
 	routingKey        *string
 }
 
+type tchannelCall struct {
+	client     *tchannelClient
+	call       *tchannel.OutboundCall
+	success    bool
+	startTime  time.Time
+	finishTime time.Time
+	reqBody    []byte
+	resBody    []byte
+	reqHeaders map[string]string
+	resHeaders map[string]string
+}
+
 // NewTChannelClient returns a tchannelClient that makes calls over the given tchannel to the given thrift service.
 func NewTChannelClient(ch *tchannel.Channel, opt *TChannelClientOption) TChannelClient {
 	client := &tchannelClient{
@@ -62,137 +73,187 @@ func NewTChannelClient(ch *tchannel.Channel, opt *TChannelClientOption) TChannel
 	return client
 }
 
-func (c *tchannelClient) writeArgs(call *tchannel.OutboundCall, headers map[string]string, req RWTStruct) error {
-	structWireValue, err := req.ToWire()
-	if err != nil {
-		return errors.Wrapf(err, "could not write request for outbound call %s: ", c.serviceName)
-	}
-
-	twriter, err := call.Arg2Writer()
-	if err != nil {
-		return errors.Wrapf(err, "could not create arg2writer for outbound call %s: ", c.serviceName)
-	}
-
-	headers = tchannel.InjectOutboundSpan(call.Response(), headers)
-	if err := WriteHeaders(twriter, headers); err != nil {
-		_ = twriter.Close()
-
-		return errors.Wrapf(err, "could not write headers for outbound call %s: ", c.serviceName)
-	}
-	if err := twriter.Close(); err != nil {
-		return errors.Wrapf(err, "could not close arg2writer for outbound call %s: ", c.serviceName)
-	}
-
-	twriter, err = call.Arg3Writer()
-	if err != nil {
-		return errors.Wrapf(err, "could not create arg3writer for outbound call %s: ", c.serviceName)
-	}
-
-	err = protocol.Binary.Encode(structWireValue, twriter)
-	if err != nil {
-		_ = twriter.Close()
-
-		return errors.Wrapf(err, "could not write request for outbound call %s: ", c.serviceName)
-	}
-
-	return twriter.Close()
-}
-
-// readResponse reads the response struct into resp, and returns:
-// (response headers, whether there was an application error, unexpected error).
-func (c *tchannelClient) readResponse(response *tchannel.OutboundCallResponse, resp RWTStruct) (bool, map[string]string, error) {
-	treader, err := response.Arg2Reader()
-	if err != nil {
-		// Do not wrap system errors.
-		if _, ok := err.(tchannel.SystemError); ok {
-			return false, nil, err
-		}
-
-		return false, nil, errors.Wrapf(err, "could not create arg2reader for outbound call response: %s", c.serviceName)
-	}
-
-	headers, err := ReadHeaders(treader)
-	if err != nil {
-		_ = treader.Close()
-
-		return false, nil, errors.Wrapf(err, "could not read headers for outbound call response: %s", c.serviceName)
-	}
-
-	if err := EnsureEmpty(treader, "reading response headers"); err != nil {
-		_ = treader.Close()
-
-		return false, nil, errors.Wrapf(err, "could not ensure arg2reader is empty for outbound call response: %s", c.serviceName)
-	}
-
-	if err := treader.Close(); err != nil {
-		return false, nil, errors.Wrapf(err, "could not close arg2reader for outbound call response: %s", c.serviceName)
-	}
-
-	success := !response.ApplicationError()
-	treader, err = response.Arg3Reader()
-	if err != nil {
-		return success, headers, errors.Wrapf(err, "could not create arg3Reader for outbound call response: %s", c.serviceName)
-	}
-
-	if err := ReadStruct(treader, resp); err != nil {
-		_ = treader.Close()
-
-		return success, headers, errors.Wrapf(err, "could not read outbound call response: %s", c.serviceName)
-	}
-
-	if err := EnsureEmpty(treader, "reading response body"); err != nil {
-		_ = treader.Close()
-
-		return false, nil, errors.Wrapf(err, "could not ensure arg3reader is empty for outbound call response: %s", c.serviceName)
-	}
-
-	return success, headers, treader.Close()
-}
-
 // Call makes a RPC call to the given service.
-func (c *tchannelClient) Call(ctx context.Context, thriftService, methodName string, reqHeaders map[string]string, req, resp RWTStruct) (bool, map[string]string, error) {
-	var respHeaders map[string]string
-	var isOK bool
-
-	retryOpts := &tchannel.RetryOptions{
+func (c *tchannelClient) Call(
+	ctx context.Context,
+	thriftService, methodName string,
+	reqHeaders map[string]string,
+	req, resp RWTStruct,
+) (success bool, resHeaders map[string]string, err error) {
+	retryOpts := tchannel.RetryOptions{
 		TimeoutPerAttempt: c.timeoutPerAttempt,
 	}
 	ctxBuilder := tchannel.NewContextBuilder(c.timeout).
 		SetParentContext(ctx).
-		SetRetryOptions(retryOpts)
+		SetRetryOptions(&retryOpts)
 	if c.routingKey != nil {
 		ctxBuilder.SetRoutingKey(*c.routingKey)
 	}
 	ctx, cancel := ctxBuilder.Build()
 	defer cancel()
 
-	arg1 := thriftService + "::" + methodName
-	err := c.ch.RunWithRetry(ctx, func(ctx netContext.Context, rs *tchannel.RequestState) error {
-		respHeaders, isOK = nil, false
+	serviceMethod := thriftService + "::" + methodName
 
-		call, err := c.sc.BeginCall(ctx, arg1, &tchannel.CallOptions{
+	call := &tchannelCall{
+		client:     c,
+		reqHeaders: reqHeaders,
+	}
+	defer call.finish()
+	call.start()
+
+	err = c.ch.RunWithRetry(ctx, func(ctx netContext.Context, rs *tchannel.RequestState) (cerr error) {
+		call.resHeaders, call.success = nil, false
+
+		call.call, cerr = c.sc.BeginCall(ctx, serviceMethod, &tchannel.CallOptions{
 			Format:       tchannel.Thrift,
 			RequestState: rs,
 		})
-		if err != nil {
+		if cerr != nil {
 			return errors.Wrapf(err, "could not begin outbound call: %s", c.serviceName)
 		}
 
-		if err := c.writeArgs(call, reqHeaders, req); err != nil {
-			return err
+		// trace request
+		reqHeaders = tchannel.InjectOutboundSpan(call.call.Response(), reqHeaders)
+
+		if cerr := call.writeReqHeaders(reqHeaders); cerr != nil {
+			return cerr
+		}
+		if cerr := call.writeReqBody(req); cerr != nil {
+			return cerr
 		}
 
-		isOK, respHeaders, err = c.readResponse(call.Response(), resp)
-		return err
+		response := call.call.Response()
+		if cerr = call.readResHeaders(response); cerr != nil {
+			return cerr
+		}
+		if cerr = call.readResBody(response, resp); cerr != nil {
+			return cerr
+		}
+
+		return cerr
 	})
+
 	if err != nil {
 		// Do not wrap system errors.
 		if _, ok := err.(tchannel.SystemError); ok {
-			return false, nil, err
+			return call.success, nil, err
 		}
-
-		return false, nil, errors.Wrapf(err, "could not make outbound call: %s", c.serviceName)
+		return call.success, nil, errors.Wrapf(err, "could not make outbound call: %s", c.serviceName)
 	}
 
-	return isOK, respHeaders, nil
+	return call.success, call.resHeaders, err
+}
+
+func (c *tchannelCall) start() {
+	c.startTime = time.Now()
+}
+
+func (c *tchannelCall) finish() {
+	c.finishTime = time.Now()
+}
+
+// writeReqHeaders writes request headers to arg2
+func (c *tchannelCall) writeReqHeaders(reqHeaders map[string]string) error {
+	c.reqHeaders = reqHeaders
+
+	twriter, err := c.call.Arg2Writer()
+	if err != nil {
+		return errors.Wrapf(err, "could not create arg2writer for outbound call %s: ", c.client.serviceName)
+	}
+
+	if err := WriteHeaders(twriter, reqHeaders); err != nil {
+		_ = twriter.Close()
+		return errors.Wrapf(err, "could not write headers for outbound call %s: ", c.client.serviceName)
+	}
+
+	if err := twriter.Close(); err != nil {
+		return errors.Wrapf(err, "could not close arg2writer for outbound call %s: ", c.client.serviceName)
+	}
+
+	return nil
+}
+
+// writeReqBody writes request body to arg3
+func (c *tchannelCall) writeReqBody(req RWTStruct) error {
+	structWireValue, err := req.ToWire()
+	if err != nil {
+		return errors.Wrapf(err, "could not write request for outbound call %s: ", c.client.serviceName)
+	}
+	c.reqBody = structWireValue.GetBinary()
+
+	twriter, err := c.call.Arg3Writer()
+	if err != nil {
+		return errors.Wrapf(err, "could not create arg3writer for outbound call %s: ", c.client.serviceName)
+	}
+
+	if err := protocol.Binary.Encode(structWireValue, twriter); err != nil {
+		_ = twriter.Close()
+		return errors.Wrapf(err, "could not write request for outbound call %s: ", c.client.serviceName)
+	}
+
+	if err := twriter.Close(); err != nil {
+		return errors.Wrapf(err, "could not close arg3writer for outbound request %s: ", c.client.serviceName)
+	}
+
+	return nil
+}
+
+// readResHeaders read response headers from arg2
+func (c *tchannelCall) readResHeaders(response *tchannel.OutboundCallResponse) error {
+	treader, err := response.Arg2Reader()
+	if err != nil {
+		// Do not wrap system errors.
+		if _, ok := err.(tchannel.SystemError); ok {
+			return err
+		}
+		return errors.Wrapf(err, "could not create arg2reader for outbound call response: %s", c.client.serviceName)
+	}
+
+	if c.resHeaders, err = ReadHeaders(treader); err != nil {
+		_ = treader.Close()
+		return errors.Wrapf(err, "could not read headers for outbound call response: %s", c.client.serviceName)
+	}
+
+	if err := EnsureEmpty(treader, "reading response headers"); err != nil {
+		_ = treader.Close()
+		return errors.Wrapf(err, "could not ensure arg2reader is empty for outbound call response: %s", c.client.serviceName)
+	}
+
+	if err := treader.Close(); err != nil {
+		return errors.Wrapf(err, "could not close arg2reader for outbound call response: %s", c.client.serviceName)
+	}
+
+	// must have called Arg2Reader before calling ApplicationError
+	c.success = !response.ApplicationError()
+	return nil
+}
+
+// readResHeaders read response headers from arg2
+func (c *tchannelCall) readResBody(response *tchannel.OutboundCallResponse, resp RWTStruct) error {
+	treader, err := response.Arg3Reader()
+	if err != nil {
+		return errors.Wrapf(err, "could not create arg3Reader for outbound call response: %s", c.client.serviceName)
+	}
+
+	if err := ReadStruct(treader, resp); err != nil {
+		_ = treader.Close()
+		return errors.Wrapf(err, "could not read outbound call response: %s", c.client.serviceName)
+	}
+
+	structWireValue, err := resp.ToWire()
+	if err != nil {
+		return errors.Wrapf(err, "could not write response for outbound call response: %s: ", c.client.serviceName)
+	}
+	c.resBody = structWireValue.GetBinary()
+
+	if err := EnsureEmpty(treader, "reading response body"); err != nil {
+		_ = treader.Close()
+		return errors.Wrapf(err, "could not ensure arg3reader is empty for outbound call response: %s", c.client.serviceName)
+	}
+
+	if err := treader.Close(); err != nil {
+		return errors.Wrapf(err, "could not close arg3reader for outbound call response: %s", c.client.serviceName)
+	}
+
+	return nil
 }

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -33,6 +33,8 @@ import (
 // TChannelClientOption is used when creating a new tchannelClient
 type TChannelClientOption struct {
 	ServiceName       string
+	ClientID          string
+	MethodNames       map[string]string
 	Timeout           time.Duration
 	TimeoutPerAttempt time.Duration
 	RoutingKey        *string
@@ -43,6 +45,8 @@ type tchannelClient struct {
 	ch                *tchannel.Channel
 	sc                *tchannel.SubChannel
 	serviceName       string
+	clientID          string
+	methodNames       map[string]string
 	timeout           time.Duration
 	timeoutPerAttempt time.Duration
 	routingKey        *string
@@ -62,15 +66,16 @@ type tchannelCall struct {
 
 // NewTChannelClient returns a tchannelClient that makes calls over the given tchannel to the given thrift service.
 func NewTChannelClient(ch *tchannel.Channel, opt *TChannelClientOption) TChannelClient {
-	client := &tchannelClient{
+	return &tchannelClient{
 		ch:                ch,
 		sc:                ch.GetSubChannel(opt.ServiceName),
 		serviceName:       opt.ServiceName,
+		clientID:          opt.ClientID,
+		methodNames:       opt.MethodNames,
 		timeout:           opt.Timeout,
 		timeoutPerAttempt: opt.TimeoutPerAttempt,
 		routingKey:        opt.RoutingKey,
 	}
-	return client
 }
 
 // Call makes a RPC call to the given service.

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -196,7 +196,6 @@ func (c *tchannelClient) Call(
 
 func (c *tchannelCall) start() {
 	c.startTime = time.Now()
-	c.metrics.Sent.Inc(1)
 }
 
 func (c *tchannelCall) finish(err error) {
@@ -309,6 +308,8 @@ func (c *tchannelCall) writeReqBody(req RWTStruct) error {
 		)
 	}
 
+	// request sent when arg3writer is closed
+	c.metrics.Sent.Inc(1)
 	return nil
 }
 

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -206,7 +206,7 @@ func TestPingWithInvalidResponse(t *testing.T) {
 	allLogs := gateway.AllLogs()
 
 	assert.Equal(t, 10, len(allLogs))
-	assert.Equal(t, 1, len(allLogs["Finished a downstream TChannel request"]))
+	assert.Equal(t, 1, len(allLogs["Finished an outgoing client TChannel request"]))
 	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
 	assert.Equal(t, 1, len(allLogs["Outbound connection is active."]))
 	assert.Equal(t, 1, len(allLogs["Failed after non-retriable error."]))

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -156,7 +156,15 @@ func TestPing(t *testing.T) {
 }
 
 func TestPingWithInvalidResponse(t *testing.T) {
-	gateway, err := testGateway.CreateGateway(t, testConfig, testOptions)
+	gateway, err := testGateway.CreateGateway(t, testConfig, &testGateway.Options{
+		KnownTChannelBackends: []string{"baz"},
+		TestBinary:            util.DefaultMainFile("example-gateway"),
+		ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
+		LogWhitelist: map[string]bool{
+			"Could not create arg2reader for outbound response": true,
+			"Could not make outbound request":                   true,
+		},
+	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return
 	}
@@ -197,11 +205,13 @@ func TestPingWithInvalidResponse(t *testing.T) {
 
 	allLogs := gateway.AllLogs()
 
-	assert.Equal(t, 8, len(allLogs))
+	assert.Equal(t, 10, len(allLogs))
 	assert.Equal(t, 1, len(allLogs["Finished a downstream TChannel request"]))
 	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
 	assert.Equal(t, 1, len(allLogs["Outbound connection is active."]))
 	assert.Equal(t, 1, len(allLogs["Failed after non-retriable error."]))
+	assert.Equal(t, 1, len(allLogs["Could not create arg2reader for outbound response"]))
+	assert.Equal(t, 1, len(allLogs["Could not make outbound request"]))
 	assert.Equal(t, 1, len(allLogs["Could not make client request"]))
 	assert.Equal(t, 1, len(allLogs["Workflow for endpoint returned error"]))
 	assert.Equal(t, 1, len(allLogs["Sending error for endpoint request"]))

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -42,6 +42,9 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 		KnownTChannelBackends: []string{"baz"},
 		TestBinary:            util.DefaultMainFile("example-gateway"),
 		ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
+		TChannelClientMethods: map[string]string{
+			"SimpleService::Call": "Call",
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -25,12 +25,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
-
-	bazClient "github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
+	"github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
 	clientsBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/baz/baz"
 	endpointsBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints/tchannel/baz/baz"
+	"github.com/uber/zanzibar/test/lib/test_gateway"
+	"github.com/uber/zanzibar/test/lib/util"
 )
 
 func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
@@ -97,4 +96,24 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	assert.Equal(t, expectedHeaders, resHeaders)
 	assert.True(t, success)
 
+	allLogs := gateway.AllLogs()
+	assert.Equal(t, 4, len(allLogs))
+	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
+	assert.Equal(t, 1, len(allLogs["Inbound connection is active."]))
+	assert.Equal(t, 1, len(allLogs["Outbound connection is active."]))
+	assert.Equal(t, 1, len(allLogs["Finished an outgoing client TChannel request"]))
+
+	tags := allLogs["Finished an outgoing client TChannel request"][0]
+	assert.Equal(t, "info", tags["level"])
+	assert.Equal(t, "Finished an outgoing client TChannel request", tags["msg"])
+	assert.Equal(t, "baz", tags["clientID"])
+	assert.Equal(t, "bazService", tags["serviceName"])
+	assert.Equal(t, "Call", tags["methodName"])
+	assert.Equal(t, "SimpleService::call", tags["serviceMethod"])
+	assert.Equal(t, "token", tags["Request-Header-x-token"])
+	assert.Equal(t, "uuid", tags["Request-Header-x-uuid"])
+	assert.Equal(t, "something", tags["Response-Header-some-res-header"])
+	assert.Contains(t, tags["remoteAddr"], "127.0.0.1")
+	assert.NotNil(t, tags["timestamp-started"])
+	assert.NotNil(t, tags["timestamp-finished"])
 }

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -141,6 +141,7 @@ func CreateGateway(
 
 	benchGateway.tchannelClient = zanzibar.NewTChannelClient(
 		gateway.Channel,
+		gateway.Logger,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       gateway.ServiceName,
 			Timeout:           time.Duration(1000) * time.Millisecond,

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -144,6 +144,7 @@ func CreateGateway(
 		gateway.Logger,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       gateway.ServiceName,
+			MethodNames:       opts.TChannelClientMethods,
 			Timeout:           time.Duration(1000) * time.Millisecond,
 			TimeoutPerAttempt: time.Duration(100) * time.Millisecond,
 		})

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -142,6 +142,7 @@ func CreateGateway(
 	benchGateway.tchannelClient = zanzibar.NewTChannelClient(
 		gateway.Channel,
 		gateway.Logger,
+		gateway.AllHostScope,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       gateway.ServiceName,
 			MethodNames:       opts.TChannelClientMethods,

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/zanzibar/test/lib"
 	"github.com/uber/zanzibar/test/lib/test_backend"
 	"github.com/uber/zanzibar/test/lib/test_m3_server"
+	"go.uber.org/zap"
 )
 
 // TestGateway interface
@@ -176,11 +177,15 @@ func CreateGateway(
 		return nil, err
 	}
 
-	tchannelClient := zanzibar.NewTChannelClient(channel, &zanzibar.TChannelClientOption{
-		ServiceName:       serviceName,
-		Timeout:           time.Duration(1000) * time.Millisecond,
-		TimeoutPerAttempt: time.Duration(100) * time.Millisecond,
-	})
+	tchannelClient := zanzibar.NewTChannelClient(
+		channel,
+		zap.NewNop(),
+		&zanzibar.TChannelClientOption{
+			ServiceName:       serviceName,
+			Timeout:           time.Duration(1000) * time.Millisecond,
+			TimeoutPerAttempt: time.Duration(100) * time.Millisecond,
+		},
+	)
 
 	testGateway := &ChildProcessGateway{
 		channel:     channel,

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -109,6 +109,7 @@ type Options struct {
 	EnableRuntimeMetrics  bool
 	JaegerDisable         bool
 	JaegerFlushMillis     int64
+	TChannelClientMethods map[string]string
 }
 
 func (gateway *ChildProcessGateway) setupMetrics(
@@ -182,6 +183,7 @@ func CreateGateway(
 		zap.NewNop(),
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
+			MethodNames:       opts.TChannelClientMethods,
 			Timeout:           time.Duration(1000) * time.Millisecond,
 			TimeoutPerAttempt: time.Duration(100) * time.Millisecond,
 		},

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 	"github.com/uber-go/tally/m3"
 	"github.com/uber/jaeger-client-go/testutils"
 	"github.com/uber/tchannel-go"
@@ -181,6 +182,7 @@ func CreateGateway(
 	tchannelClient := zanzibar.NewTChannelClient(
 		channel,
 		zap.NewNop(),
+		tally.NoopScope,
 		&zanzibar.TChannelClientOption{
 			ServiceName:       serviceName,
 			MethodNames:       opts.TChannelClientMethods,


### PR DESCRIPTION
TChannel client emits the following metrics:

Names:
- outbound.calls.sent
- outbound.calls.success
- outbound.calls.app-errors
- outbound.calls.system-errors
- outbound.calls.latency

Tags:
- env - environment, e.g. “production”, “staging”, “test”
- service - service name, e.g. “example-gateway”
- client - module instance name, e.g. “bar”, etc.
- method - module instance exposed method, e.g. “echostring”
- target-service - thrift service, e.g. “bar”, etc.
- target-endpoint - thrift method, e.g. “Bar::echostring”
