### PR TITLE
Adding metrics and logs to server http request/response

### DIFF
--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -74,9 +74,7 @@ func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 	err := server.Serve(tcpKeepAliveListener{ln})
 	if err != nil && !server.closing {
 		/* coverage ignore next line */
-		server.Logger.Error("Error http serving",
-			zap.String("error", err.Error()),
-		)
+		server.Logger.Error("Error http serving", zap.Error(err))
 	}
 
 	waitGroup.Done()
@@ -93,9 +91,7 @@ func (server *HTTPServer) Close() {
 	err := server.listeningSocket.Close()
 	if err != nil {
 		/* coverage ignore next line */
-		server.Logger.Error("Error closing listening socket",
-			zap.String("error", err.Error()),
-		)
+		server.Logger.Error("Error closing listening socket", zap.Error(err))
 	}
 }
 

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -23,83 +23,15 @@ package zanzibar
 import (
 	"context"
 	"net/http"
-	"strconv"
-	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/uber-go/tally"
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap"
 )
 
-var knownStatusCodes = []int{
-	http.StatusContinue,           // 100
-	http.StatusSwitchingProtocols, // 101
-	http.StatusProcessing,         // 102
-
-	http.StatusOK,                   // 200
-	http.StatusCreated,              // 201
-	http.StatusAccepted,             // 202
-	http.StatusNonAuthoritativeInfo, // 203
-	http.StatusNoContent,            // 204
-	http.StatusResetContent,         // 205
-	http.StatusPartialContent,       // 206
-	http.StatusMultiStatus,          // 207
-	http.StatusAlreadyReported,      // 208
-	http.StatusIMUsed,               // 226
-
-	http.StatusMultipleChoices,   // 300
-	http.StatusMovedPermanently,  // 301
-	http.StatusFound,             // 302
-	http.StatusSeeOther,          // 303
-	http.StatusNotModified,       // 304
-	http.StatusUseProxy,          // 305
-	http.StatusTemporaryRedirect, // 307
-	http.StatusPermanentRedirect, // 308
-
-	http.StatusBadRequest,                   // 400
-	http.StatusUnauthorized,                 // 401
-	http.StatusPaymentRequired,              // 402
-	http.StatusForbidden,                    // 403
-	http.StatusNotFound,                     // 404
-	http.StatusMethodNotAllowed,             // 405
-	http.StatusNotAcceptable,                // 406
-	http.StatusProxyAuthRequired,            // 407
-	http.StatusRequestTimeout,               // 408
-	http.StatusConflict,                     // 409
-	http.StatusGone,                         // 410
-	http.StatusLengthRequired,               // 411
-	http.StatusPreconditionFailed,           // 412
-	http.StatusRequestEntityTooLarge,        // 413
-	http.StatusRequestURITooLong,            // 414
-	http.StatusUnsupportedMediaType,         // 415
-	http.StatusRequestedRangeNotSatisfiable, // 416
-	http.StatusExpectationFailed,            // 417
-	http.StatusTeapot,                       // 418
-	http.StatusUnprocessableEntity,          // 422
-	http.StatusLocked,                       // 423
-	http.StatusFailedDependency,             // 424
-	http.StatusUpgradeRequired,              // 426
-	http.StatusPreconditionRequired,         // 428
-	http.StatusTooManyRequests,              // 429
-	http.StatusRequestHeaderFieldsTooLarge,  // 431
-	http.StatusUnavailableForLegalReasons,   // 451
-
-	http.StatusInternalServerError,           // 500
-	http.StatusNotImplemented,                // 501
-	http.StatusBadGateway,                    // 502
-	http.StatusServiceUnavailable,            // 503
-	http.StatusGatewayTimeout,                // 504
-	http.StatusHTTPVersionNotSupported,       // 505
-	http.StatusVariantAlsoNegotiates,         // 506
-	http.StatusInsufficientStorage,           // 507
-	http.StatusLoopDetected,                  // 508
-	http.StatusNotExtended,                   // 510
-	http.StatusNetworkAuthenticationRequired, // 511
-}
-
-const statusCodeZapName = "statusCode"
+const (
+	notFound         = "NotFound"
+	methodNotAllowed = "MethodNotAllowed"
+)
 
 // HandlerFn is a func that handles ServerHTTPRequest
 type HandlerFn func(
@@ -108,23 +40,12 @@ type HandlerFn func(
 	*ServerHTTPResponse,
 )
 
-// EndpointMetrics contains pre allocated metrics structures
-// These are pre-allocated to cache tags maps and for performance
-type EndpointMetrics struct {
-	requestRecvd   tally.Counter
-	requestLatency tally.Timer
-	statusCodes    map[int]tally.Counter
-}
-
 // RouterEndpoint struct represents an endpoint that can be registered
 // into the router itself.
 type RouterEndpoint struct {
-	EndpointName string
-	HandlerName  string
-	HandlerFn    HandlerFn
-
-	metrics EndpointMetrics
-	gateway *Gateway
+	handlerFn HandlerFn
+	logger    *zap.Logger
+	metrics   *InboundHTTPMetrics
 }
 
 // NewRouterEndpoint creates an endpoint with all the necessary data
@@ -134,50 +55,28 @@ func NewRouterEndpoint(
 	handlerName string,
 	handler HandlerFn,
 ) *RouterEndpoint {
-	endpointTags := map[string]string{
+	logger := gateway.Logger.With(
+		zap.String("endpoint", endpointName),
+		zap.String("handler", handlerName),
+	)
+	scope := gateway.AllHostScope.Tagged(map[string]string{
 		"endpoint": endpointName,
 		"handler":  handlerName,
-	}
-	endpointScope := gateway.AllHostScope.Tagged(endpointTags)
-	requestRecvd := endpointScope.Counter("inbound.calls.recvd")
-	requestLatency := endpointScope.Timer("inbound.calls.latency")
-	statusCodes := make(map[int]tally.Counter, len(knownStatusCodes))
-
-	for _, statusCode := range knownStatusCodes {
-		metricName := "inbound.calls.status." + strconv.Itoa(statusCode)
-		statusCodes[statusCode] = endpointScope.Counter(metricName)
-	}
-
+	})
 	return &RouterEndpoint{
-		EndpointName: endpointName,
-		HandlerName:  handlerName,
-		HandlerFn:    handler,
-		gateway:      gateway,
-
-		metrics: EndpointMetrics{
-			requestRecvd:   requestRecvd,
-			statusCodes:    statusCodes,
-			requestLatency: requestLatency,
-		},
+		handlerFn: handler,
+		logger:    logger,
+		metrics:   NewInboundHTTPMetrics(scope),
 	}
 }
 
 // HandleRequest is called by the router and starts the request
 func (endpoint *RouterEndpoint) HandleRequest(
-	w http.ResponseWriter, r *http.Request, params httprouter.Params,
+	w http.ResponseWriter,
+	r *http.Request,
+	params httprouter.Params,
 ) {
-	reqFields := logRequestFields(r)
-	var resFields []zapcore.Field
-
-	defer func() {
-		writeLogs(endpoint.gateway.Logger, reqFields, resFields)
-	}()
-
 	req := NewServerHTTPRequest(w, r, params, endpoint)
-
-	fn := endpoint.HandlerFn
-
-	ctx := r.Context()
 
 	// TODO: (lu) get timeout from endpoint config
 	//_, ok := ctx.Deadline()
@@ -186,25 +85,25 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	//	ctx, cancel = context.WithTimeout(ctx, time.Duration(100)*time.Millisecond)
 	//	defer cancel()
 	//}
+	ctx := r.Context()
 
-	fn(ctx, req, req.res)
-
+	endpoint.handlerFn(ctx, req, req.res)
 	req.res.flush()
-	resFields = logResponseFields(req.res)
 }
 
 // HTTPRouter data structure to handle and register endpoints
 type HTTPRouter struct {
-	httpRouter *httprouter.Router
-	gateway    *Gateway
+	httpRouter               *httprouter.Router
+	notFoundEndpoint         *RouterEndpoint
+	methodNotAllowedEndpoint *RouterEndpoint
 }
 
 // NewHTTPRouter allocates a HTTP router
 func NewHTTPRouter(gateway *Gateway) *HTTPRouter {
 	router := &HTTPRouter{
-		gateway: gateway,
+		notFoundEndpoint:         NewRouterEndpoint(gateway, notFound, notFound, nil),
+		methodNotAllowedEndpoint: NewRouterEndpoint(gateway, methodNotAllowed, methodNotAllowed, nil),
 	}
-
 	router.httpRouter = &httprouter.Router{
 		// We handle trailing slash in Register() without redirect
 		RedirectTrailingSlash:  false,
@@ -215,7 +114,6 @@ func NewHTTPRouter(gateway *Gateway) *HTTPRouter {
 		// TODO add panic handler
 		// PanicHandler:           router.handlePanic,
 	}
-
 	return router
 }
 
@@ -227,14 +125,16 @@ func (router *HTTPRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Such a function take raw http req/writer.
 // Use this only to integrated third-party, like pprof debug handlers
 func (router *HTTPRouter) RegisterRaw(
-	method string, prefix string, handler http.HandlerFunc,
+	method, prefix string,
+	handler http.HandlerFunc,
 ) {
 	router.httpRouter.Handler(method, prefix, handler)
 }
 
 // Register will register an endpoint with the router.
 func (router *HTTPRouter) Register(
-	method string, urlpattern string, endpoint *RouterEndpoint,
+	method, urlpattern string,
+	endpoint *RouterEndpoint,
 ) {
 	canonicalPattern := urlpattern
 	if canonicalPattern[len(canonicalPattern)-1] == '/' {
@@ -250,74 +150,28 @@ func (router *HTTPRouter) Register(
 	)
 }
 
-func (router *HTTPRouter) handleNotFound(w http.ResponseWriter, r *http.Request) {
-	resFields := []zapcore.Field{
-		zap.Int(statusCodeZapName, 404),
-	}
-	writeLogs(router.gateway.Logger, logRequestFields(r), resFields)
+func (router *HTTPRouter) handleNotFound(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	req := NewServerHTTPRequest(w, r, nil, router.notFoundEndpoint)
 	// TODO custom NotFound
-	// A NotFound request is not started...
-	// TODO: inc.finish()
 	http.NotFound(w, r)
+	req.res.writeHeader(http.StatusNotFound)
+	req.res.finish()
 }
 
 func (router *HTTPRouter) handleMethodNotAllowed(
-	w http.ResponseWriter, r *http.Request,
+	w http.ResponseWriter,
+	r *http.Request,
 ) {
-	resFields := []zapcore.Field{
-		zap.Int(statusCodeZapName, 405),
-	}
-	writeLogs(router.gateway.Logger, logRequestFields(r), resFields)
+	req := NewServerHTTPRequest(w, r, nil, router.methodNotAllowedEndpoint)
 	// TODO: Remove coverage ignore when body unmarshaling supported.
 	// TODO custom MethodNotAllowed
 	http.Error(w,
 		http.StatusText(http.StatusMethodNotAllowed),
 		http.StatusMethodNotAllowed,
 	)
-}
-
-func logRequestFields(r *http.Request) []zapcore.Field {
-	// TODO: Allocating a fixed size array causes the zap logger to fail
-	// with ``unknown field type: { 0 0  <nil>}'' errors. Investigate this
-	// further to see if we can avoid reallocating underlying arrays for slices.
-	var fields []zapcore.Field
-	for k, v := range r.Header {
-		if len(v) > 0 {
-			fields = append(fields, zap.String("Request-Header-"+k, v[0]))
-		}
-	}
-
-	fields = append(fields, zap.String("method", r.Method))
-	fields = append(fields, zap.String("remoteAddr", r.RemoteAddr))
-	fields = append(fields, zap.String("pathname", r.URL.RequestURI()))
-	fields = append(fields, zap.String("host", r.Host))
-	fields = append(fields, zap.Time("timestamp", time.Now().UTC()))
-	// TODO add endpoint.id and endpoint.handlerId
-	// TODO log jaeger trace span
-
-	return fields
-}
-
-func logResponseFields(res *ServerHTTPResponse) []zapcore.Field {
-	var fields []zapcore.Field
-	fields = append(fields, zap.Int(statusCodeZapName, res.pendingStatusCode))
-	// TODO: Do not log body by default because PII and bandwidth.
-	// Temporarily log during the developement cycle
-	// TODO: Add a gateway level configurable body unmarshaller
-	// to extract only non-PII info.
-	fields = append(fields, zap.ByteString("Request Body", res.Request.RawBody))
-	fields = append(fields, zap.ByteString("Response Body", res.pendingBodyBytes))
-	fields = append(fields, zap.Time("timestamp-finished", res.finishTime))
-	return fields
-}
-
-func writeLogs(l *zap.Logger, reqFlds []zapcore.Field, resFlds []zapcore.Field) {
-	fields := reqFlds
-	if resFlds != nil {
-		fields = append(reqFlds, resFlds...)
-	}
-	l.Info(
-		"Finished an incoming server HTTP request",
-		fields...,
-	)
+	req.res.writeHeader(http.StatusMethodNotAllowed)
+	req.res.finish()
 }

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -23,42 +23,37 @@ package zanzibar
 import (
 	"encoding/json"
 	"net/http"
-
 	"time"
 
 	"github.com/buger/jsonparser"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // ServerHTTPResponse struct manages request
 type ServerHTTPResponse struct {
 	responseWriter    http.ResponseWriter
 	Request           *ServerHTTPRequest
-	gateway           *Gateway
-	finishTime        time.Time
-	finished          bool
-	metrics           *EndpointMetrics
 	flushed           bool
+	finished          bool
+	finishTime        time.Time
 	pendingBodyBytes  []byte
 	pendingBodyObj    interface{}
 	pendingStatusCode int
-
-	StatusCode int
+	StatusCode        int
+	logger            *zap.Logger
 }
 
 // NewServerHTTPResponse is helper function to alloc ServerHTTPResponse
 func NewServerHTTPResponse(
-	w http.ResponseWriter, req *ServerHTTPRequest,
+	w http.ResponseWriter,
+	req *ServerHTTPRequest,
 ) *ServerHTTPResponse {
-	res := &ServerHTTPResponse{
-		gateway:        req.gateway,
+	return &ServerHTTPResponse{
 		Request:        req,
 		responseWriter: w,
 		StatusCode:     200,
-		metrics:        req.metrics,
 	}
-
-	return res
 }
 
 // finish will handle final logic, like metrics
@@ -81,23 +76,41 @@ func (res *ServerHTTPResponse) finish() {
 		/* coverage ignore next line */
 		return
 	}
-
 	res.finished = true
 	res.finishTime = time.Now()
 
-	counter := res.metrics.statusCodes[res.StatusCode]
-	if counter == nil {
+	// emit metrics
+	res.Request.metrics.Latency.Record(res.finishTime.Sub(res.Request.startTime))
+	_, known := knownStatusCodes[res.StatusCode]
+	if !known {
 		res.Request.Logger.Error(
 			"Could not emit statusCode metric",
-			zap.Int("UnexpectedStatusCode", res.StatusCode),
+			zap.Int("UnknownStatusCode", res.StatusCode),
 		)
 	} else {
-		counter.Inc(1)
+		res.Request.metrics.Status[res.StatusCode].Inc(1)
+	}
+	if !known || res.StatusCode >= 400 && res.StatusCode < 600 {
+		res.Request.metrics.Errors.Inc(1)
+	} else {
+		res.Request.metrics.Success.Inc(1)
 	}
 
-	res.metrics.requestLatency.Record(
-		res.finishTime.Sub(res.Request.startTime),
-	)
+	// write logs
+	res.Request.Logger.Info("Finished an incoming server HTTP request", res.logResponseFields()...)
+}
+
+func (res *ServerHTTPResponse) logResponseFields() []zapcore.Field {
+	var fields []zapcore.Field
+	fields = append(fields, zap.Int("statusCode", res.StatusCode))
+	// TODO: Do not log body by default because PII and bandwidth.
+	// Temporarily log during the developement cycle
+	// TODO: Add a gateway level configurable body unmarshaller
+	// to extract only non-PII info.
+	fields = append(fields, zap.ByteString("Request Body", res.Request.RawBody))
+	fields = append(fields, zap.ByteString("Response Body", res.pendingBodyBytes))
+	fields = append(fields, zap.Time("timestamp-finished", res.finishTime))
+	return fields
 }
 
 // SendErrorString helper to send an error string
@@ -129,8 +142,7 @@ func (res *ServerHTTPResponse) WriteJSONBytes(
 	}
 
 	// TODO: mark header as pending ?
-	res.responseWriter.Header().
-		Set("content-type", "application/json")
+	res.responseWriter.Header().Set("content-type", "application/json")
 
 	res.pendingStatusCode = statusCode
 	res.pendingBodyBytes = bytes
@@ -150,7 +162,7 @@ func (res *ServerHTTPResponse) WriteJSON(
 	if err != nil {
 		res.SendErrorString(500, "Could not serialize json response")
 		res.Request.Logger.Error("Could not serialize json response",
-			zap.String("error", err.Error()),
+			zap.Error(err),
 		)
 		return
 	}
@@ -221,7 +233,7 @@ func (res *ServerHTTPResponse) writeBytes(bytes []byte) {
 	if err != nil {
 		/* coverage ignore next line */
 		res.Request.Logger.Error("Could not write string to resp body",
-			zap.String("error", err.Error()),
+			zap.Error(err),
 		)
 	}
 }

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -82,7 +82,7 @@ func TestInvalidStatusCode(t *testing.T) {
 	assert.Equal(t, 1, len(logLines))
 
 	lineStruct := logLines[0]
-	code := lineStruct["UnexpectedStatusCode"].(float64)
+	code := lineStruct["UnknownStatusCode"].(float64)
 	assert.Equal(t, 999.0, code)
 }
 


### PR DESCRIPTION
HTTP endpoint emits the following metrics:

Names:
- inbound.calls.latency
- inbound.calls.recvd
- inbound.calls.success
- inbound.calls.errors
- inbound.calls.status.XXX

Tags:
- host - “all”
- env - environment, e.g. “production”, “staging”, “test”
- service - service name, e.g. “example-gateway”
- endpoint - endpointId, e.g. “bar”
- handler - handleId, e.g. “normal”
