### PR TITLE
add remote config

### DIFF
--- a/runtime/remote_config.go
+++ b/runtime/remote_config.go
@@ -1,0 +1,327 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/buger/jsonparser"
+	"github.com/pkg/errors"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
+
+// RemoteConfig allow accessing values from a periodically refreshed json file
+type RemoteConfig interface {
+	GetBoolean(string, bool) bool
+	GetFloat(string, float64) float64
+	GetInt(string, int64) int64
+	GetString(string, string) string
+	GetStruct(string, interface{}) bool
+	Subscribe(string, string, *func())
+	Unsubscribe(string)
+	Refresh() error
+	Close()
+}
+
+// RemoteConfigOptions configs remote config file path and refresh frequency
+type RemoteConfigOptions struct {
+	FilePath        string
+	PollingInterval time.Duration
+}
+
+// Subscriber is used to track subscribers' callbacks and keys they subscribe
+type Subscriber struct {
+	Callback *func()
+	Key      string
+}
+
+// RemoteConfigValue represents a json serialized string
+type RemoteConfigValue struct {
+	bytes    []byte
+	dataType jsonparser.ValueType
+}
+
+// RemoteConfigMap allows lock-free concurrent rw
+// TODO consider https://golang.org/pkg/sync/#Map golang@1.9^
+type RemoteConfigMap map[string]*RemoteConfigValue
+
+type remoteConfig struct {
+	config      *RemoteConfigOptions
+	subscribers map[string]*Subscriber
+	props       atomic.Value
+	close       chan struct{}
+	currStat    os.FileInfo
+	logger      *zap.Logger
+	scope       tally.Scope
+	poller      *time.Ticker
+	mutex       sync.RWMutex
+	wg          sync.WaitGroup
+}
+
+// NewRemoteConfig allocates a config that can be dynamically changed during runtime.
+// RemoteConfigOptions takes two args, config file path (that remote config will read from)
+// and polling interval (decides how frequent we check ).
+// remote config file follows the same requirements with runtime/static_config/StaticConfig
+// remote config consider fallback legit case, fallback happens silent without throwing error
+// Why RemoteConfig:
+// 		What diverge staticConfig with remoteConfig is that staticConfig allows value setting
+//		while remoteConfig is read only.
+//		remoteConfig also provides pub/sub to allow caller act on specific key changes
+func NewRemoteConfig(cfg *RemoteConfigOptions, logger *zap.Logger, scope tally.Scope) (RemoteConfig, error) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	if len(cfg.FilePath) < 1 || cfg.PollingInterval == 0 {
+		return nil, errors.Errorf("invalid remote config options")
+	}
+	if _, err := os.Stat(cfg.FilePath); os.IsNotExist(err) {
+		return nil, errors.Errorf("invalid remote config file path")
+	}
+	if scope == nil {
+		logger.Warn("no valid metrics scope")
+		scope = tally.NoopScope
+	}
+	rc := &remoteConfig{
+		config:      cfg,
+		close:       make(chan struct{}, 1),
+		subscribers: make(map[string]*Subscriber),
+		logger:      logger,
+		scope:       scope,
+		poller:      time.NewTicker(cfg.PollingInterval),
+	}
+	rc.props.Store(make(RemoteConfigMap))
+	if err := rc.Refresh(); err != nil {
+		return nil, err
+	}
+	rc.wg.Add(1)
+	go rc.poll()
+	return rc, nil
+}
+
+func (rc *remoteConfig) loadConfig() RemoteConfigMap {
+	return rc.props.Load().(RemoteConfigMap)
+}
+
+func (rc *remoteConfig) getValidatedValue(key string, vt jsonparser.ValueType) (*RemoteConfigValue, bool) {
+	ret, ok := rc.loadConfig()[key]
+	if !ok {
+		rc.logger.Warn(fmt.Sprintf("Key <%s> missing", key))
+		return nil, false
+	}
+	if ret.dataType != vt {
+		rc.logger.Warn(fmt.Sprintf("Key <%s> type mismatch (expected %s actual %s)", key, vt, ret.dataType))
+		return nil, false
+	}
+	return ret, true
+}
+
+// GetBoolean returns the value as a boolean
+func (rc *remoteConfig) GetBoolean(key string, fallback bool) bool {
+	if ret, ok := rc.getValidatedValue(key, jsonparser.Boolean); ok {
+		v, _ := jsonparser.ParseBoolean(ret.bytes)
+		return v
+	}
+	return fallback
+}
+
+// GetFloat returns the value as a float64
+func (rc *remoteConfig) GetFloat(key string, fallback float64) float64 {
+	if ret, ok := rc.getValidatedValue(key, jsonparser.Number); ok {
+		v, _ := jsonparser.ParseFloat(ret.bytes)
+		return v
+	}
+	return fallback
+}
+
+// GetInt returns the value as int64
+func (rc *remoteConfig) GetInt(key string, fallback int64) int64 {
+	ret, ok := rc.getValidatedValue(key, jsonparser.Number)
+	if !ok {
+		return fallback
+	}
+	if v, err := jsonparser.ParseInt(ret.bytes); err == nil {
+		return v
+	}
+	rc.logger.Warn(fmt.Sprintf("Key <%s> is not int64", key))
+	return fallback
+}
+
+// GetString returns the value as string
+func (rc *remoteConfig) GetString(key string, fallback string) string {
+	if ret, ok := rc.getValidatedValue(key, jsonparser.String); ok {
+		v, _ := jsonparser.ParseString(ret.bytes)
+		return v
+	}
+	return fallback
+}
+
+// GetStruct loads struct ptr interface{}
+func (rc *remoteConfig) GetStruct(key string, ptr interface{}) bool {
+	ret, ok := rc.getValidatedValue(key, jsonparser.Object)
+	if !ok {
+		return false
+	}
+	if err := json.Unmarshal(ret.bytes, ptr); err != nil {
+		return false
+	}
+	return true
+}
+
+func changedKeys(prev, curr RemoteConfigMap) map[string]bool {
+	ret := make(map[string]bool)
+	diff := func(a, b RemoteConfigMap) {
+		for key, val := range a {
+			if bval, ok := b[key]; ok && bytes.Compare(bval.bytes, val.bytes) == 0 && bval.dataType == val.dataType {
+				continue
+			}
+			ret[key] = true
+		}
+	}
+	diff(prev, curr)
+	diff(curr, prev)
+	return ret
+}
+
+// Refresh refreshes remote config and trigger callbacks if necessary.
+// Refresh will check file stat to decide if reload in-mem config
+// necessary. Reload config from file success will record keys
+// been added/removed/updated, and trigger callbacks that registered
+// via Subscribe.
+func (rc *remoteConfig) Refresh() error {
+	var (
+		err  error
+		stat os.FileInfo
+	)
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	stat, refresh := rc.checkAndReturnStat()
+	if !refresh {
+		return nil
+	}
+	changedMap, err := rc.reloadConfigAndReturnChanged()
+	if stat != nil && err == nil {
+		rc.currStat = stat
+	}
+	rc.execCallbacks(changedMap)
+	return err
+}
+
+// checkAndReturnStat returns file stat and boolean of `whether we should refresh from config file`
+// don't refresh if config file hasn't change since last refresh
+func (rc *remoteConfig) checkAndReturnStat() (os.FileInfo, bool) {
+	stat, err := os.Stat(rc.config.FilePath)
+	if err != nil {
+		rc.logger.Error("Error stat remote config file " + rc.config.FilePath)
+		return nil, true
+	}
+	if rc.currStat != nil && rc.currStat.ModTime().Equal(stat.ModTime()) && rc.currStat.Size() == stat.Size() {
+		return stat, false
+	}
+	return stat, true
+}
+
+// reloadConfigAndReturnChanged atomically stores remote config properties
+// and return keys been added/removed/updated
+func (rc *remoteConfig) reloadConfigAndReturnChanged() (map[string]bool, error) {
+	bytes, err := ioutil.ReadFile(rc.config.FilePath)
+	changedMap := make(map[string]bool)
+	if err != nil {
+		return changedMap, err
+	}
+	currProps := make(RemoteConfigMap)
+	err = jsonparser.ObjectEach(bytes, func(
+		key []byte,
+		value []byte,
+		dataType jsonparser.ValueType,
+		offset int,
+	) error {
+		currProps[string(key)] = &RemoteConfigValue{
+			bytes:    value,
+			dataType: dataType,
+		}
+		return nil
+	})
+	prevProps := rc.loadConfig()
+	if err == nil {
+		changedMap = changedKeys(prevProps, currProps)
+		rc.props.Store(currProps)
+	}
+	return changedMap, err
+}
+
+// Close wait for all running refresh to complete, then shuts down the client
+func (rc *remoteConfig) Close() {
+	rc.poller.Stop()
+	rc.close <- struct{}{}
+	rc.wg.Wait()
+}
+
+// Subscribe adds a callback function to be executed when config refresh is complete
+// Subscribe takes a string identifier and a function pointer to be called after
+// a completed config refresh
+func (rc *remoteConfig) Subscribe(identifier, key string, fn *func()) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	rc.subscribers[identifier] = &Subscriber{
+		Callback: fn,
+		Key:      key,
+	}
+}
+
+// Unsubscribe will stop an identifer's callback function from being executed upon
+// config refresh
+func (rc *remoteConfig) Unsubscribe(identifier string) {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	delete(rc.subscribers, identifier)
+}
+
+func (rc *remoteConfig) execCallbacks(changedMap map[string]bool) {
+	for _, s := range rc.subscribers {
+		if _, ok := changedMap[s.Key]; ok {
+			go (*s.Callback)()
+		}
+	}
+}
+
+func (rc *remoteConfig) poll() {
+	for {
+		select {
+		case <-rc.poller.C:
+			result := "ok"
+			if err := rc.Refresh(); err != nil {
+				result = "err"
+			}
+			rc.scope.Tagged(map[string]string{"result": result}).Counter("remote_config.polling")
+		case <-rc.close:
+			rc.wg.Done()
+			return
+		}
+	}
+}

--- a/runtime/remote_config.go
+++ b/runtime/remote_config.go
@@ -255,35 +255,6 @@ func (rc *remoteConfig) checkAndReturnStat() (os.FileInfo, bool) {
 	return stat, true
 }
 
-//// reloadConfigAndReturnChanged atomically stores remote config properties
-//// and return keys been added/removed/updated
-//func (rc *remoteConfig) reloadConfigAndReturnChanged() (map[string]bool, error) {
-//	bytes, err := ioutil.ReadFile(rc.config.FilePath)
-//	changedMap := make(map[string]bool)
-//	if err != nil {
-//		return changedMap, err
-//	}
-//	currProps := make(RemoteConfigMap)
-//	err = jsonparser.ObjectEach(bytes, func(
-//		key []byte,
-//		value []byte,
-//		dataType jsonparser.ValueType,
-//		offset int,
-//	) error {
-//		currProps[string(key)] = &RemoteConfigValue{
-//			bytes:    value,
-//			dataType: dataType,
-//		}
-//		return nil
-//	})
-//	prevProps := rc.loadConfig()
-//	if err == nil {
-//		changedMap = changedKeys(prevProps, currProps)
-//		rc.props.Store(currProps)
-//	}
-//	return changedMap, err
-//}
-
 // reloadConfigAndReturnChanged atomically stores remote config properties
 // and return keys been added/removed/updated
 func (rc *remoteConfig) reloadConfigAndReturnChanged() (map[string]bool, error) {

--- a/runtime/remote_config_test.go
+++ b/runtime/remote_config_test.go
@@ -1,0 +1,354 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
+)
+
+const tmpCfgPath = "/tmp/zanzibar_remote_cfg.json"
+const refreshInterval = time.Second * 10
+const defaultCfgJsonStr = `{
+		"cfgboolean": true,
+		"cfgint": 20,
+		"cfgfloat": 1.5,
+		"cfgstring": "testStr",
+		"cfgstruct": {
+			"NestedStruct":{
+				"ValBoolean": true,
+				"ValInt": 48,
+				"ValFloat": 3.1415926,
+				"ValString": "testNestedStructStr"
+			},
+			"ValBoolean":true,
+			"ValInt": 32,
+			"ValFloat": 3.14,
+			"ValString": "testStructStr"
+		}
+	}`
+
+type testSuite struct {
+	configFilePath string
+	configStr      string
+	remoteConfig   zanzibar.RemoteConfig
+}
+
+type testStruct struct {
+	NestedStruct *testNestedStruct
+	ValBoolean   bool
+	ValInt       int64
+	ValFloat     float64
+	ValString    string
+}
+
+type testNestedStruct struct {
+	ValBoolean bool
+	ValInt     int64
+	ValFloat   float64
+	ValString  string
+}
+
+func setupRemoteConfigTestSuite(filePath string, configStr string, interval time.Duration) *testSuite {
+	configFileStr := defaultCfgJsonStr
+	configFilePath := tmpCfgPath
+	pollingInternal := refreshInterval
+	if len(filePath) > 0 {
+		configFilePath = filePath
+	}
+	if len(configStr) > 0 {
+		configFileStr = configStr
+	}
+	if interval > 0 {
+		pollingInternal = interval
+	}
+	err := ioutil.WriteFile(configFilePath, []byte(configFileStr), 0644)
+	if err != nil {
+		panic("unable to setup remote config file in " + configFilePath)
+	}
+	cfg := &zanzibar.RemoteConfigOptions{
+		FilePath:        configFilePath,
+		PollingInterval: pollingInternal,
+	}
+	remoteConfig, err := zanzibar.NewRemoteConfig(cfg, nil, nil)
+	if err != nil {
+		panic("unable to init new remote config")
+	}
+	return &testSuite{
+		configFilePath: configFilePath,
+		configStr:      configFileStr,
+		remoteConfig:   remoteConfig,
+	}
+}
+
+func (ts *testSuite) tearDown() {
+	_ = os.Remove(ts.configFilePath)
+	ts.remoteConfig.Close()
+}
+
+func TestNilFileInitializeError(t *testing.T) {
+	rc, err := zanzibar.NewRemoteConfig(&zanzibar.RemoteConfigOptions{}, nil, nil)
+	assert.Nil(t, rc)
+	assert.NotNil(t, err)
+}
+
+func TestInvalidPathInitializeError(t *testing.T) {
+	rc, err := zanzibar.NewRemoteConfig(
+		&zanzibar.RemoteConfigOptions{FilePath: "invalid_path", PollingInterval: time.Second},
+		nil,
+		nil,
+	)
+	assert.Nil(t, rc)
+	assert.NotNil(t, err)
+}
+
+func TestInvalidJSJONInitializeError(t *testing.T) {
+	configFileStr := "{\\invalid%@;{ json"
+	err := ioutil.WriteFile(tmpCfgPath, []byte(configFileStr), 0644)
+	assert.Nil(t, err)
+	defer func() {
+		_ = os.Remove(tmpCfgPath)
+	}()
+	cfg := &zanzibar.RemoteConfigOptions{
+		FilePath:        tmpCfgPath,
+		PollingInterval: time.Second,
+	}
+	remoteConfig, err := zanzibar.NewRemoteConfig(cfg, nil, nil)
+	assert.Nil(t, remoteConfig)
+	assert.NotNil(t, err)
+}
+
+func TestTypeMisMatch(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", `{"cfgboolean": true}`, 0)
+	defer ts.tearDown()
+	vf := ts.remoteConfig.GetFloat("cfgboolean", float64(0))
+	assert.Equal(t, float64(0), vf)
+}
+
+func TestUnmarshalErrStruct(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", `{"cfgstruct":{"NestedStruct":123}}`, 0)
+	defer ts.tearDown()
+	ns := &testStruct{}
+	ok := ts.remoteConfig.GetStruct("cfgstruct", ns)
+	assert.False(t, ok)
+}
+
+func TestTypeMismatchNumber(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	vf := ts.remoteConfig.GetFloat("cfgint", float64(0))
+	assert.Equal(t, float64(20), vf)
+	vi := ts.remoteConfig.GetInt("cfgfloat", int64(0))
+	assert.Equal(t, int64(0), vi)
+}
+
+func TestConcurrentRW(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	go func() {
+		_ = ts.remoteConfig.Refresh()
+	}()
+	go func() {
+		v := ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+		assert.Equal(t, float64(1.5), v)
+	}()
+}
+
+func TestConcurrentR(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	f := func() {
+		v := ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+		assert.Equal(t, float64(1.5), v)
+	}
+	go f()
+	go f()
+}
+
+func TestConcurrentW(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	err := ioutil.WriteFile(tmpCfgPath, []byte(`{"test": 1}`), 0644)
+	if err != nil {
+		panic("unable to setup remote config file in " + tmpCfgPath)
+	}
+	f := func() {
+		err = ts.remoteConfig.Refresh()
+		assert.Nil(t, err)
+		wg.Done()
+	}
+	go f()
+	go f()
+	wg.Wait()
+	res := ts.remoteConfig.GetInt("test", int64(0))
+	assert.True(t, res == int64(1))
+}
+
+func TestRefresh(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	vf := ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+	assert.Equal(t, float64(1.5), vf)
+	configFileStr := `{"cfgfloat": 3.5}`
+	err := ioutil.WriteFile(tmpCfgPath, []byte(configFileStr), 0644)
+	assert.Nil(t, err)
+	err = ts.remoteConfig.Refresh()
+	assert.Nil(t, err)
+	vf = ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+	assert.Equal(t, float64(3.5), vf)
+}
+
+func TestTypeRemoteConfigAndDefaultFallback(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "{}", 0)
+	defer ts.tearDown()
+	vb := ts.remoteConfig.GetBoolean("cfgboolean", false)
+	assert.Equal(t, false, vb)
+
+	vi := ts.remoteConfig.GetInt("cfgint", int64(0))
+	assert.Equal(t, int64(0), vi)
+
+	vf := ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+	assert.Equal(t, float64(0), vf)
+
+	vs := ts.remoteConfig.GetString("cfgstring", "")
+	assert.Equal(t, "", vs)
+
+	teststruct := &testStruct{NestedStruct: &testNestedStruct{}}
+	err := ts.remoteConfig.GetStruct("cfgstruct", teststruct)
+	assert.NotNil(t, err)
+}
+
+func TestTypeHappyRemoteConfig(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+
+	vb := ts.remoteConfig.GetBoolean("cfgboolean", false)
+	assert.Equal(t, true, vb)
+
+	vi := ts.remoteConfig.GetInt("cfgint", int64(0))
+	assert.Equal(t, int64(20), vi)
+
+	vf := ts.remoteConfig.GetFloat("cfgfloat", float64(0))
+	assert.Equal(t, float64(1.5), vf)
+
+	vs := ts.remoteConfig.GetString("cfgstring", "")
+	assert.Equal(t, "testStr", vs)
+
+	teststruct := &testStruct{NestedStruct: &testNestedStruct{}}
+	ok := ts.remoteConfig.GetStruct("cfgstruct", teststruct)
+	expstruct := &testStruct{
+		NestedStruct: &testNestedStruct{
+			ValBoolean: true,
+			ValInt:     int64(48),
+			ValFloat:   float64(3.1415926),
+			ValString:  "testNestedStructStr",
+		},
+		ValInt:     int64(32),
+		ValBoolean: true,
+		ValFloat:   float64(3.14),
+		ValString:  "testStructStr",
+	}
+	assert.True(t, ok)
+	assert.EqualValues(t, expstruct, teststruct)
+}
+
+func TestSubscribe(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	ch := make(chan int, 2)
+	defer ts.tearDown()
+	var wg sync.WaitGroup
+	wg.Add(2)
+	concurrentSub := func(identifier, key string, fn *func()) {
+		ts.remoteConfig.Subscribe(identifier, key, fn)
+		wg.Done()
+	}
+	f1 := func() { ch <- 1 }
+	f2 := func() { ch <- 2 }
+	go concurrentSub("subscriber1", "cfgstring", &f1)
+	go concurrentSub("subscriber2", "cfgint", &f2)
+	wg.Wait()
+	err := ioutil.WriteFile(tmpCfgPath, []byte(`{"cfgint": 20}`), 0644)
+	assert.Nil(t, err)
+	err = ts.remoteConfig.Refresh()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, <-ch)
+}
+
+func TestUnsubscribe(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	ch := make(chan int)
+	defer ts.tearDown()
+	fn := func() {
+		ch <- 1
+	}
+	updateNRefresh := func() {
+		err := ioutil.WriteFile(tmpCfgPath, []byte("{}"), 0644)
+		assert.Nil(t, err)
+		err = ts.remoteConfig.Refresh()
+		assert.Nil(t, err)
+	}
+	ts.remoteConfig.Subscribe("subscriber", "cfgstring", &fn)
+	updateNRefresh()
+	assert.Equal(t, 1, <-ch)
+	ts.remoteConfig.Unsubscribe("subscriber")
+	updateNRefresh()
+	select {
+	case <-ch:
+		assert.Fail(t, "unsubscriber event should not emit")
+	default:
+		return
+	}
+}
+
+func TestPolling(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", time.Millisecond)
+	defer ts.tearDown()
+	err := ioutil.WriteFile(tmpCfgPath, []byte(`{"test": 1}`), 0644)
+	assert.Nil(t, err)
+	time.Sleep(2 * time.Millisecond)
+	res := ts.remoteConfig.GetInt("test", int64(0))
+	assert.Equal(t, int64(1), res)
+}
+
+func TestPollingNilFile(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", time.Millisecond)
+	defer ts.tearDown()
+	_ = os.Remove(tmpCfgPath)
+	time.Sleep(2 * time.Millisecond)
+	res := ts.remoteConfig.GetInt("test", int64(0))
+	assert.Equal(t, int64(0), res)
+}
+
+func TestRefreshNilFile(t *testing.T) {
+	ts := setupRemoteConfigTestSuite("", "", 0)
+	defer ts.tearDown()
+	_ = os.Remove(tmpCfgPath)
+	err := ts.remoteConfig.Refresh()
+	assert.NotNil(t, err)
+}

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -43,7 +43,7 @@ type StaticConfigValue struct {
 	dataType jsonparser.ValueType
 }
 
-// StaticConfig allows accessing values of out of json config files
+// StaticConfig allows accessing values out of json config files
 type StaticConfig struct {
 	seedConfig    map[string]interface{}
 	configOptions []*ConfigOption


### PR DESCRIPTION
implement remote config in addition to static config. What diverges remote config from static config is remote config is read only, remote config is been periodically reloaded from a config json file that could be updated by other services.

- periodically polling routine to refreshing config
- pub/sub with a callback function upon config change