### PR TITLE
fix EndpointName on http server req

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -64,7 +64,7 @@ func NewServerHTTPRequest(
 		queryValues:  nil,
 		Logger:       endpoint.logger,
 		metrics:      endpoint.metrics,
-		EndpointName: endpoint.HandlerName,
+		EndpointName: endpoint.EndpointName,
 		HandlerName:  endpoint.HandlerName,
 		URL:          r.URL,
 		Method:       r.Method,


### PR DESCRIPTION
This is a typo. A test for a middleware caught this.

r: @uber/zanzibar-team