### PR TITLE
Generated tests import relative main/config.

### DIFF
--- a/codegen/templates/endpoint_test.tmpl
+++ b/codegen/templates/endpoint_test.tmpl
@@ -7,15 +7,16 @@ import (
 	"path/filepath"
 	"net/http"
 	"testing"
+	"runtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/bench_gateway"
 	"github.com/uber/zanzibar/test/lib/test_backend"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
 
 {{- $clientID := .ClientID }}
+{{- $relativePathToRoot := .RelativePathToRoot}}
 {{with .Method -}}
 {{- $clientPackage := .Downstream.PackageName -}}
 {{- $clientMethod := .DownstreamMethod -}}
@@ -27,13 +28,35 @@ import (
 
 {{range $.TestStubs}}
 
+func getDirName{{.HandlerID | title}}{{.TestName | title}}() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
+
 func Test{{.HandlerID | title}}{{.TestName | title}}OKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"{{$clientID}}"},
-		TestBinary:            util.DefaultMainFile("{{.TestServiceName}}"),
-		ConfigFiles:           util.DefaultConfigFiles("{{.TestServiceName}}"),
+		TestBinary: filepath.Join(
+			getDirName{{.HandlerID | title}}{{.TestName | title}}(),
+			"{{$relativePathToRoot}}",
+			"build", "services", "{{.TestServiceName}}",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirName{{.HandlerID | title}}{{.TestName | title}}(),
+				"{{$relativePathToRoot}}",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirName{{.HandlerID | title}}{{.TestName | title}}(),
+				"{{$relativePathToRoot}}",
+				"config", "{{.TestServiceName}}", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_argnotstruct_test.gogen
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameArgNotStructSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameArgNotStructSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameArgNotStructSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameArgNotStructSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_missingarg_test.gogen
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameMissingArgSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameMissingArgSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameMissingArgSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameMissingArgSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_norequest_test.gogen
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameNoRequestSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameNoRequestSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameNoRequestSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameNoRequestSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_normal_test.gogen
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameNormalSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameNormalSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameNormalSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameNormalSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
+++ b/codegen/test_data/endpoint_tests/bar_bar_method_toomanyargs_test.gogen
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameTooManyArgsSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameTooManyArgsSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameTooManyArgsSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameTooManyArgsSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/config/production.json
+++ b/config/production.json
@@ -12,6 +12,7 @@
 	"jaeger.sampler.param": 0.001,
 
 	"logger.output": "stdout",
+	"logger.fileName": "",
 
 	"metrics.type": "m3",
 	"metrics.flushInterval": 1000,

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -78,6 +78,7 @@ var _productionJson = []byte(`{
 	"jaeger.sampler.param": 0.001,
 
 	"logger.output": "stdout",
+	"logger.fileName": "",
 
 	"metrics.type": "m3",
 	"metrics.flushInterval": 1000,
@@ -109,7 +110,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 807, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 831, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct_test.go
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameArgNotStructSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestArgNotStructSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameArgNotStructSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameArgNotStructSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameArgNotStructSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg_test.go
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameMissingArgSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestMissingArgSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameMissingArgSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameMissingArgSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameMissingArgSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest_test.go
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameNoRequestSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameNoRequestSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameNoRequestSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameNoRequestSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal_test.go
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameNormalSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestNormalSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameNormalSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameNormalSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameNormalSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs_test.go
@@ -26,20 +26,43 @@ package barEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameTooManyArgsSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestTooManyArgsSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"bar"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameTooManyArgsSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameTooManyArgsSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameTooManyArgsSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials_test.go
@@ -26,20 +26,43 @@ package googlenowEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameAddCredentialsSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestAddCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"google-now"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameAddCredentialsSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameAddCredentialsSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameAddCredentialsSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials_test.go
@@ -26,20 +26,43 @@ package googlenowEndpoint
 import (
 	"bytes"
 	"net/http"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber/zanzibar/test/lib/test_gateway"
-	"github.com/uber/zanzibar/test/lib/util"
 )
+
+func getDirNameCheckCredentialsSuccessfulRequest() string {
+	_, file, _, _ := runtime.Caller(0)
+
+	return filepath.Dir(file)
+}
 
 func TestCheckCredentialsSuccessfulRequestOKResponse(t *testing.T) {
 	var counter int
 
 	gateway, err := testGateway.CreateGateway(t, nil, &testGateway.Options{
 		KnownHTTPBackends: []string{"google-now"},
-		TestBinary:        util.DefaultMainFile("example-gateway"),
-		ConfigFiles:       util.DefaultConfigFiles("example-gateway"),
+		TestBinary: filepath.Join(
+			getDirNameCheckCredentialsSuccessfulRequest(),
+			"../../..",
+			"build", "services", "example-gateway",
+			"main", "main.go",
+		),
+		ConfigFiles: []string{
+			filepath.Join(
+				getDirNameCheckCredentialsSuccessfulRequest(),
+				"../../..",
+				"config", "production.json",
+			),
+			filepath.Join(
+				getDirNameCheckCredentialsSuccessfulRequest(),
+				"../../..",
+				"config", "example-gateway", "production.json",
+			),
+		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return


### PR DESCRIPTION
This changes make the generated tests not use the
util package but instead import relative to their location
inside the generated code.

This unblocks edge-gateway

r: @uber/zanzibar-team