### PR TITLE
Bug fix for updating `endpoint-config.json` file

### DIFF
--- a/backend/repository/endpoint_update.go
+++ b/backend/repository/endpoint_update.go
@@ -89,10 +89,13 @@ func (r *Repository) validateEndpointCfg(req *EndpointConfig) error {
 func updateEndpointMetaJSON(configDir, metaFile, newFile string, cfg *EndpointConfig) error {
 	metaFilePath := filepath.Join(configDir, metaFile)
 	fileContent := new(codegen.EndpointClassConfig)
-	err := readJSONFile(metaFilePath, fileContent)
-	if err != nil {
-		return err
+	if _, err := os.Stat(metaFilePath); !os.IsNotExist(err) {
+		err := readJSONFile(metaFilePath, fileContent)
+		if err != nil {
+			return err
+		}
 	}
+	var err error
 	fileContent.Config.Endpoints, err = addToEndpointList(fileContent.Config.Endpoints, newFile, configDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
Every endpoint group has an `endpoint-config.json`file for the configuration of all endpoints in the group.

This PR fixes the issue of throwing an error when `endpoint-config.json` not exist. Instead, the file should be created if not exist.