### PR TITLE
Configure zap to emit metrics for info/warn/error

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,10 @@
-hash: d56fe7e20f1073c0eb26832409312c725e5277b869c682fc9e03a4f5126d843d
-updated: 2017-10-03T02:22:44.720922676-07:00
+hash: 40fbb60fd143ee8d617119db53d53dc3ab109cedda5ebd8950061b9f1b36dcf9
+updated: 2017-10-04T16:10:53.450806832-07:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
-  repo: git://git.apache.org/thrift.git
-  vcs: git
   subpackages:
   - lib/go/thrift
 - name: github.com/buger/jsonparser
@@ -81,7 +79,7 @@ imports:
   - thrift-gen/zipkincore
   - utils
 - name: github.com/uber/jaeger-lib
-  version: 3b2a9ad2a045881ab7a0f81d465be54c8292ee4f
+  version: 5b29ee594f76a8f6a822c18b02ef985d68ddd991
   subpackages:
   - metrics
   - metrics/tally
@@ -139,7 +137,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 0a9397675ba34b2845f758fe3cd68828369c6517
+  version: a04bdaca5b32abe1c069418fb7088ae607de5bd0
   subpackages:
   - context
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,8 +24,6 @@ import:
   version: e682c1008ac17bf26d2e4b5ad6cdd08520ed0b22
 - package: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
-  repo: git://git.apache.org/thrift.git
-  vcs: git
   subpackages:
   - lib/go/thrift
 - package: github.com/uber-go/tally

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -111,11 +111,11 @@ func CreateGateway(
 	config.Freeze()
 
 	// order matters for following setup method calls
-	if err := gateway.setupLogger(config); err != nil {
+	if err := gateway.setupMetrics(config); err != nil {
 		return nil, err
 	}
 
-	if err := gateway.setupMetrics(config); err != nil {
+	if err := gateway.setupLogger(config); err != nil {
 		return nil, err
 	}
 
@@ -389,10 +389,13 @@ func (gateway *Gateway) setupLogger(config *StaticConfig) error {
 	}
 
 	zapLogger := zap.New(
-		zapcore.NewCore(
-			zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
-			output,
-			zap.InfoLevel,
+		NewLoggingZapCore(
+			zapcore.NewCore(
+				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+				output,
+				zap.InfoLevel,
+			),
+			gateway.AllHostScope,
 		),
 	)
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -388,14 +388,14 @@ func (gateway *Gateway) setupLogger(config *StaticConfig) error {
 		}
 	}
 
+	prodCore := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		output,
+		zap.InfoLevel,
+	)
 	zapLogger := zap.New(
-		NewLoggingZapCore(
-			zapcore.NewCore(
-				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
-				output,
-				zap.InfoLevel,
-			),
-			gateway.AllHostScope,
+		NewInstrumentedZapCore(
+			prodCore, gateway.AllHostScope,
 		),
 	)
 

--- a/runtime/logger_metrics.go
+++ b/runtime/logger_metrics.go
@@ -45,8 +45,6 @@ func NewLoggingZapCore(
 	core zapcore.Core,
 	allHostsScope tally.Scope,
 ) zapcore.Core {
-	// fmt.Fprintf(os.Stdout, "allocating a logging zap core\n")
-
 	return &loggingZapCore{
 		Core:          core,
 		allHostsScope: allHostsScope,

--- a/runtime/logger_metrics.go
+++ b/runtime/logger_metrics.go
@@ -107,6 +107,7 @@ func (lcore *loggingZapCore) Write(
 	case zapcore.PanicLevel:
 		lcore.panicCounter.Inc(1)
 	case zapcore.FatalLevel:
+		/* coverage ignore next line */
 		lcore.fatalCounter.Inc(1)
 	default:
 		// noop

--- a/runtime/logger_metrics.go
+++ b/runtime/logger_metrics.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar
+
+import (
+	"github.com/uber-go/tally"
+	"go.uber.org/zap/zapcore"
+)
+
+type loggingZapCore struct {
+	zapcore.Core
+
+	allHostsScope tally.Scope
+
+	debugCounter  tally.Counter
+	infoCounter   tally.Counter
+	warnCounter   tally.Counter
+	errorCounter  tally.Counter
+	dPanicCounter tally.Counter
+	panicCounter  tally.Counter
+	fatalCounter  tally.Counter
+}
+
+// NewLoggingZapCore will return a zapcore.Core that emits
+// "logged" metrics, one counter for each level.
+func NewLoggingZapCore(
+	core zapcore.Core,
+	allHostsScope tally.Scope,
+) zapcore.Core {
+	// fmt.Fprintf(os.Stdout, "allocating a logging zap core\n")
+
+	return &loggingZapCore{
+		Core:          core,
+		allHostsScope: allHostsScope,
+
+		debugCounter:  allHostsScope.Counter("zap.logged.debug"),
+		infoCounter:   allHostsScope.Counter("zap.logged.info"),
+		warnCounter:   allHostsScope.Counter("zap.logged.warn"),
+		errorCounter:  allHostsScope.Counter("zap.logged.error"),
+		dPanicCounter: allHostsScope.Counter("zap.logged.dpanic"),
+		panicCounter:  allHostsScope.Counter("zap.logged.panic"),
+		fatalCounter:  allHostsScope.Counter("zap.logged.fatal"),
+	}
+}
+
+func copyLoggingZapCore(
+	core zapcore.Core,
+	lcore *loggingZapCore,
+) zapcore.Core {
+	return &loggingZapCore{
+		Core:          core,
+		allHostsScope: lcore.allHostsScope,
+		debugCounter:  lcore.debugCounter,
+		infoCounter:   lcore.infoCounter,
+		warnCounter:   lcore.warnCounter,
+		errorCounter:  lcore.errorCounter,
+		dPanicCounter: lcore.dPanicCounter,
+		panicCounter:  lcore.panicCounter,
+		fatalCounter:  lcore.fatalCounter,
+	}
+}
+
+func (lcore *loggingZapCore) With(fields []zapcore.Field) zapcore.Core {
+	newCore := lcore.Core.With(fields)
+	return copyLoggingZapCore(newCore, lcore)
+}
+
+func (lcore *loggingZapCore) Check(
+	ent zapcore.Entry, ce *zapcore.CheckedEntry,
+) *zapcore.CheckedEntry {
+	if lcore.Enabled(ent.Level) {
+		return ce.AddCore(ent, lcore)
+	}
+	return ce
+}
+
+func (lcore *loggingZapCore) Write(
+	entry zapcore.Entry, fields []zapcore.Field,
+) error {
+	switch entry.Level {
+	case zapcore.DebugLevel:
+		lcore.debugCounter.Inc(1)
+	case zapcore.InfoLevel:
+		lcore.infoCounter.Inc(1)
+	case zapcore.WarnLevel:
+		lcore.warnCounter.Inc(1)
+	case zapcore.ErrorLevel:
+		lcore.errorCounter.Inc(1)
+	case zapcore.DPanicLevel:
+		lcore.dPanicCounter.Inc(1)
+	case zapcore.PanicLevel:
+		lcore.panicCounter.Inc(1)
+	case zapcore.FatalLevel:
+		lcore.fatalCounter.Inc(1)
+	default:
+		// noop
+	}
+
+	return lcore.Core.Write(entry, fields)
+}

--- a/runtime/logger_metrics.go
+++ b/runtime/logger_metrics.go
@@ -39,9 +39,9 @@ type loggingZapCore struct {
 	fatalCounter  tally.Counter
 }
 
-// NewLoggingZapCore will return a zapcore.Core that emits
+// NewInstrumentedZapCore will return a zapcore.Core that emits
 // "logged" metrics, one counter for each level.
-func NewLoggingZapCore(
+func NewInstrumentedZapCore(
 	core zapcore.Core,
 	allHostsScope tally.Scope,
 ) zapcore.Core {

--- a/runtime/logger_metrics_test.go
+++ b/runtime/logger_metrics_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber-go/tally"
+	zanzibar "github.com/uber/zanzibar/runtime"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestLoggingZapCore(t *testing.T) {
+	metricsScope := tally.NewTestScope("test", nil)
+
+	tempLogger := zap.New(
+		zanzibar.NewLoggingZapCore(
+			zapcore.NewCore(
+				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+				zapcore.AddSync(ioutil.Discard),
+				zap.InfoLevel,
+			),
+			metricsScope,
+		),
+	)
+
+	tempLogger.Debug("debug msg")
+	tempLogger.Info("info msg")
+	tempLogger.Warn("warn msg")
+	tempLogger.Error("error msg")
+
+	assert.Panics(t, func() {
+		tempLogger.DPanic("dpanic msg")
+		tempLogger.Panic("panic msg")
+		tempLogger.Fatal("fatal msg")
+	})
+
+	snapshot := metricsScope.Snapshot()
+	counters := snapshot.Counters()
+
+	assert.Equal(t, 7, len(counters))
+
+	expectedKeys := []string{
+		"test.zap.logged.debug+",
+		"test.zap.logged.info+",
+		"test.zap.logged.warn+",
+		"test.zap.logged.error+",
+		"test.zap.logged.dpanic+",
+		"test.zap.logged.panic+",
+		"test.zap.logged.fatal+",
+	}
+
+	for _, key := range expectedKeys {
+		assert.Contains(t, counters, key, "should contain %s", key)
+	}
+}

--- a/runtime/logger_metrics_test.go
+++ b/runtime/logger_metrics_test.go
@@ -40,7 +40,7 @@ func TestLoggingZapCore(t *testing.T) {
 			zapcore.NewCore(
 				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 				zapcore.AddSync(ioutil.Discard),
-				zap.InfoLevel,
+				zap.DebugLevel,
 			),
 			metricsScope,
 		),
@@ -50,11 +50,10 @@ func TestLoggingZapCore(t *testing.T) {
 	tempLogger.Info("info msg")
 	tempLogger.Warn("warn msg")
 	tempLogger.Error("error msg")
+	tempLogger.DPanic("dpanic msg")
 
 	assert.Panics(t, func() {
-		tempLogger.DPanic("dpanic msg")
 		tempLogger.Panic("panic msg")
-		tempLogger.Fatal("fatal msg")
 	})
 
 	snapshot := metricsScope.Snapshot()

--- a/runtime/logger_metrics_test.go
+++ b/runtime/logger_metrics_test.go
@@ -36,7 +36,7 @@ func TestLoggingZapCore(t *testing.T) {
 	metricsScope := tally.NewTestScope("test", nil)
 
 	tempLogger := zap.New(
-		zanzibar.NewLoggingZapCore(
+		zanzibar.NewInstrumentedZapCore(
 			zapcore.NewCore(
 				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 				zapcore.AddSync(ioutil.Discard),

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
@@ -74,6 +75,7 @@ func TestCallMetrics(t *testing.T) {
 	}
 
 	cg.MetricsWaitGroup.Wait()
+	time.Sleep(100 * time.Millisecond)
 	metrics := cg.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics))
 
@@ -148,5 +150,5 @@ func TestCallMetrics(t *testing.T) {
 
 	loggedMetrics := metrics[tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(5), value, "expected counter to be 4")
+	assert.Equal(t, int64(5), value, "expected counter to be 5")
 }

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -59,7 +59,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 8
+	numMetrics := 9
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 
@@ -140,4 +140,13 @@ func TestCallMetrics(t *testing.T) {
 	statusSuccess := metrics[tally.KeyForPrefixedStringMap("outbound.calls.status.200", httpClientTags)]
 	value = *statusSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
+
+	defaultTags := map[string]string{
+		"env":     "test",
+		"service": "test-gateway",
+	}
+
+	loggedMetrics := metrics[tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)]
+	value = *loggedMetrics.MetricValue.Count.I64Value
+	assert.Equal(t, int64(5), value, "expected counter to be 4")
 }

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
@@ -75,7 +74,6 @@ func TestCallMetrics(t *testing.T) {
 	}
 
 	cg.MetricsWaitGroup.Wait()
-	time.Sleep(100 * time.Millisecond)
 	metrics := cg.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics))
 

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
@@ -89,8 +88,6 @@ func TestCallMetrics(t *testing.T) {
 
 	cg.MetricsWaitGroup.Wait()
 
-	// Wait for all the metrics to settle (non deterministic).
-	time.Sleep(100 * time.Millisecond)
 	metrics := cg.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics))
 

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -72,7 +72,7 @@ func TestCallMetrics(t *testing.T) {
 		bazClient.NewSimpleServiceCallHandler(fakeCall),
 	)
 
-	numMetrics := 17
+	numMetrics := 18
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	ctx := context.Background()

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -23,7 +23,6 @@ package gateway_test
 import (
 	"io/ioutil"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
@@ -124,8 +123,6 @@ func TestHealthMetrics(t *testing.T) {
 
 	cgateway.MetricsWaitGroup.Wait()
 
-	// sleep to avoid race conditions with m3.Client
-	time.Sleep(100 * time.Millisecond)
 	metrics := cgateway.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics), "expected 5 metrics")
 	names := []string{

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -107,6 +107,7 @@ type Options struct {
 	KnownHTTPBackends     []string
 	KnownTChannelBackends []string
 	CountMetrics          bool
+	MaxMetrics            int
 	EnableRuntimeMetrics  bool
 	JaegerDisable         bool
 	JaegerFlushMillis     int64
@@ -127,6 +128,7 @@ func (gateway *ChildProcessGateway) setupMetrics(
 		false, countMetrics, m3.Compact,
 	)
 	gateway.M3Service = gateway.m3Server.Service
+	gateway.M3Service.MaxMetrics = opts.MaxMetrics
 	go gateway.m3Server.Serve()
 }
 

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -107,6 +107,8 @@ type Options struct {
 	KnownHTTPBackends     []string
 	KnownTChannelBackends []string
 	CountMetrics          bool
+	// If MaxMetrics is set we only collect the first N metrics upto
+	// the max metrics amount.
 	MaxMetrics            int
 	EnableRuntimeMetrics  bool
 	JaegerDisable         bool

--- a/test/lib/test_m3_server/test_m3_server.go
+++ b/test/lib/test_m3_server/test_m3_server.go
@@ -171,13 +171,11 @@ func (m *FakeM3Service) EmitMetricBatch(batch *m3.MetricBatch) (err error) {
 				m.seenMetricsCount++
 			}
 			if !seen && m.countMetrics {
-				// fmt.Fprintf(os.Stdout, "got a metric %s \n", metric.GetName())
 				m.wg.Done()
 			}
 		} else {
 			m.storeMetric(metric)
 			if m.countMetrics {
-				// fmt.Fprintf(os.Stdout, "got a metric %s \n", metric.GetName())
 				m.wg.Done()
 			}
 		}

--- a/test/lib/test_m3_server/test_m3_server.go
+++ b/test/lib/test_m3_server/test_m3_server.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"go.uber.org/thriftrw/ptr"
 
@@ -139,6 +140,11 @@ func (m *FakeM3Service) GetBatches() []*m3.MetricBatch {
 
 // GetMetrics gets the individual metrics
 func (m *FakeM3Service) GetMetrics() map[string]*m3.Metric {
+	// sleep to avoid race conditions with m3.Client
+	// Basically m3.Client can still be emitting and we might not
+	// yet have all metrics in `m.metrics`
+	time.Sleep(100 * time.Millisecond)
+
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 


### PR DESCRIPTION
This change adds new metrics to zanzibar.Gateway where
we will emit a Counter for info/warn/error showing the 
total log throughput of the gateway.

r: @uber/zanzibar-team