### PR TITLE
Add request error type

### DIFF
--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2158,6 +2158,79 @@
 		}
 	},
 	{
+		"name": "invalid create-diff request with unknown client ID",
+		"request": {
+			"method": "POST",
+			"url": "/create-diff",
+			"header": {
+				"gateway-id": "example-gateway"
+			},
+			"body": {
+				"client_updates": [
+					{
+						"clientTimeout": 10000,
+						"clientTimeoutPerAttempt": 2000,
+						"exposedMethods": {
+							"Call": "SimpleService::call",
+							"Compare": "SimpleService::compare",
+							"DeliberateDiffNoop": "SimpleService::sillyNoop",
+							"EchoBinary": "SecondService::echoBinary",
+							"EchoBool": "SecondService::echoBool",
+							"EchoDouble": "SecondService::echoDouble",
+							"EchoEnum": "SecondService::echoEnum",
+							"EchoI16": "SecondService::echoI16",
+							"EchoI32": "SecondService::echoI32",
+							"EchoI64": "SecondService::echoI64",
+							"EchoI8": "SecondService::echoI8",
+							"EchoString": "SecondService::echoString",
+							"EchoStringList": "SecondService::echoStringList",
+							"EchoStringMap": "SecondService::echoStringMap",
+							"EchoStringSet": "SecondService::echoStringSet",
+							"EchoStructList": "SecondService::echoStructList",
+							"EchoStructMap": "SecondService::echoStructMap",
+							"EchoStructSet": "SecondService::echoStructSet",
+							"EchoTypedef": "SecondService::echoTypedef",
+							"Ping": "SimpleService::ping"
+						},
+						"ip": "127.0.0.1",
+						"name": "baz",
+						"port": 4002,
+						"serviceName": "Qux",
+						"thriftFile": "clients/baz/baz.thrift",
+						"type": "tchannel"
+					}
+				],
+				"endpoint_updates": [
+					{
+						"clientID": "bazzzzzzzz",
+						"clientMethod": "Compare",
+						"endpointId": "baz",
+						"endpointType": "http",
+						"handleId": "compare",
+						"middlewares": [],
+						"reqHeaderMap": {},
+						"resHeaderMap": {},
+						"testFixtures": [],
+						"thriftFile": "endpoints/baz/baz.thrift",
+						"thriftFileSha": "{{placeholder}}",
+						"thriftMethodName": "SimpleService::compare",
+						"workflowType": "tchannelClient"
+					}
+				],
+				"thrift_files": [
+					"clients/baz/baz.thrift"
+				]
+			}
+		},
+		"response": {
+			"code": 400,
+			"body": {
+				"cause": "can't find client \"bazzzzzzzz\"",
+				"field_name": "client_id"
+			}
+		}
+	},
+	{
 		"name": "land-diff",
 		"request": {
 			"method": "POST",

--- a/backend/repository/endpoint_update.go
+++ b/backend/repository/endpoint_update.go
@@ -73,21 +73,23 @@ func (r *Repository) validateEndpointCfg(req *EndpointConfig) error {
 	}
 	clientCfg, ok := gatewayConfig.Clients[req.ClientID]
 	if !ok {
-		return errors.Errorf("can't find client %q", req.ClientID)
+		return NewRequestError(
+			ClientID, errors.Errorf("can't find client %q", req.ClientID))
 	}
 	if clientCfg.Type == HTTP {
 		req.WorkflowType = "httpClient"
 	} else if clientCfg.Type == TCHANNEL {
 		req.WorkflowType = "tchannelClient"
 	} else {
-		return errors.Errorf("client type %q is not supported", clientCfg.Type)
+		return NewRequestError(ClientType,
+			errors.Errorf("client type %q is not supported", clientCfg.Type))
 	}
 
 	for _, mid := range req.Middlewares {
 		for _, midCfg := range r.gatewayConfig.Middlewares {
 			if mid.Name == midCfg.Name {
 				err := codegen.SchemaValidateGo(midCfg.SchemaFile, mid.Options)
-				if err != nil  {
+				if err != nil {
 					return err
 				}
 			}

--- a/backend/repository/errors.go
+++ b/backend/repository/errors.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package repository
+
+import "fmt"
+
+// RequestError defines the errors for invalid requests.
+type RequestError struct {
+	FieldName RequestField
+	Cause     error
+}
+
+// RequestField is a field name in a request.
+type RequestField string
+
+const (
+	// ClientID field.
+	ClientID RequestField = "client_id"
+	// ClientType field.
+	ClientType RequestField = "client_type"
+)
+
+// NewRequestError returns an error for invalid request.
+func NewRequestError(fieldName RequestField, cause error) error {
+	return &RequestError{
+		FieldName: fieldName,
+		Cause:     cause,
+	}
+}
+
+// Error implements the error interface.
+func (r *RequestError) Error() string {
+	return fmt.Sprintf("invalid request for field %q: %s", r.FieldName, r.Cause.Error())
+}
+
+// JSON serializes the error into JSON.
+func (r *RequestError) JSON() string {
+	return fmt.Sprintf("{\"field_name\": %q, \"cause\": %q}", r.FieldName, r.Cause.Error())
+}

--- a/backend/repository/thrift_update.go
+++ b/backend/repository/thrift_update.go
@@ -79,7 +79,7 @@ func (r *Repository) writeThriftFile(idlRoot string, meta *ThriftMeta) error {
 	path := r.absPath(filepath.Join(idlRoot, meta.Path))
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "faile to creat dir %s", dir)
+		return errors.Wrapf(err, "failed to create dir %s", dir)
 	}
 	if err := ioutil.WriteFile(path, []byte(meta.Content), os.ModePerm); err != nil {
 		return errors.Wrap(err, "failed to write thrift file")


### PR DESCRIPTION
This PR adds `RequestError` type to capture invalid request fields so that the HTTP handlers can return accurate and structured errors.

This PR uses it at two places. There are more places to be changed to using `RequestError`.

r: @uber/zanzibar-team 