### PR TITLE
Add metric scope prefixes

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -333,10 +333,14 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 	)
 	// As per M3 best practices, creating separate all-host and per-host metrics
 	// to reduce metric cardinality when querying metrics for all hosts.
-	gateway.AllHostScope = gateway.RootScope
-	gateway.PerHostScope = gateway.RootScope.Tagged(
+	gateway.AllHostScope = gateway.RootScope.SubScope(
+		service + ".production.all-workers",
+	)
+	gateway.PerHostScope = gateway.RootScope.SubScope(
+		service + ".production.per-worker",
+	).Tagged(
 		map[string]string{"host": GetHostname()},
-	).SubScope("per-worker")
+	)
 
 	// start collecting runtime metrics
 	collectInterval := time.Duration(config.MustGetInt("metrics.runtime.collectInterval")) * time.Millisecond

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -334,10 +334,10 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 	// As per M3 best practices, creating separate all-host and per-host metrics
 	// to reduce metric cardinality when querying metrics for all hosts.
 	gateway.AllHostScope = gateway.RootScope.SubScope(
-		service + ".production.all-workers",
+		service + "." + env + ".all-workers",
 	)
 	gateway.PerHostScope = gateway.RootScope.SubScope(
-		service + ".production.per-worker",
+		service + "." + env + ".per-worker",
 	).Tagged(
 		map[string]string{"host": GetHostname()},
 	)

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -78,10 +78,10 @@ func TestCallMetrics(t *testing.T) {
 	assert.Equal(t, numMetrics, len(metrics))
 
 	endpointNames := []string{
-		"inbound.calls.latency",
-		"inbound.calls.recvd",
-		"inbound.calls.success",
-		"inbound.calls.status.200",
+		"test-gateway.test.all-workers.inbound.calls.latency",
+		"test-gateway.test.all-workers.inbound.calls.recvd",
+		"test-gateway.test.all-workers.inbound.calls.success",
+		"test-gateway.test.all-workers.inbound.calls.status.200",
 	}
 	endpointTags := map[string]string{
 		"env":      "test",
@@ -94,24 +94,30 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	inboundLatency := metrics[tally.KeyForPrefixedStringMap("inbound.calls.latency", endpointTags)]
+	inboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.latency", endpointTags,
+	)]
 	value := *inboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	inboundRecvd := metrics[tally.KeyForPrefixedStringMap("inbound.calls.recvd", endpointTags)]
+	inboundRecvd := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.recvd", endpointTags,
+	)]
 	value = *inboundRecvd.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value)
 
-	inboundStatus := metrics[tally.KeyForPrefixedStringMap("inbound.calls.status.200", endpointTags)]
+	inboundStatus := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.status.200", endpointTags,
+	)]
 	value = *inboundStatus.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	httpClientNames := []string{
-		"outbound.calls.latency",
-		"outbound.calls.sent",
-		"outbound.calls.success",
-		"outbound.calls.status.200",
+		"test-gateway.test.all-workers.outbound.calls.latency",
+		"test-gateway.test.all-workers.outbound.calls.sent",
+		"test-gateway.test.all-workers.outbound.calls.success",
+		"test-gateway.test.all-workers.outbound.calls.status.200",
 	}
 	httpClientTags := map[string]string{
 		"env":     "test",
@@ -124,20 +130,29 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	outboundLatency := metrics[tally.KeyForPrefixedStringMap("outbound.calls.latency", httpClientTags)]
+	outboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.latency", httpClientTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundSent := metrics[tally.KeyForPrefixedStringMap("outbound.calls.sent", httpClientTags)]
+	outboundSent := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.sent", httpClientTags,
+	)]
 	value = *outboundSent.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	outboundSuccess := metrics[tally.KeyForPrefixedStringMap("outbound.calls.success", httpClientTags)]
+	outboundSuccess := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.success", httpClientTags,
+	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	statusSuccess := metrics[tally.KeyForPrefixedStringMap("outbound.calls.status.200", httpClientTags)]
+	statusSuccess := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.status.200",
+		httpClientTags,
+	)]
 	value = *statusSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
@@ -146,7 +161,9 @@ func TestCallMetrics(t *testing.T) {
 		"service": "test-gateway",
 	}
 
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)]
+	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.zap.logged.info", defaultTags,
+	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
 	assert.Equal(t, int64(5), value, "expected counter to be 5")
 }

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -92,10 +92,10 @@ func TestCallMetrics(t *testing.T) {
 	assert.Equal(t, numMetrics, len(metrics))
 
 	endpointNames := []string{
-		"inbound.calls.latency",
-		"inbound.calls.recvd",
-		"inbound.calls.success",
-		"inbound.calls.status.204",
+		"test-gateway.test.all-workers.inbound.calls.latency",
+		"test-gateway.test.all-workers.inbound.calls.recvd",
+		"test-gateway.test.all-workers.inbound.calls.success",
+		"test-gateway.test.all-workers.inbound.calls.status.204",
 	}
 	endpointTags := map[string]string{
 		"env":      "test",
@@ -108,28 +108,36 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	latencyMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.latency", endpointTags)]
+	latencyMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.latency", endpointTags,
+	)]
 	value := *latencyMetric.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	recvdMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.recvd", endpointTags)]
+	recvdMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.recvd", endpointTags,
+	)]
 	value = *recvdMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	successMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.success", endpointTags)]
+	successMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.success", endpointTags,
+	)]
 	value = *successMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	statusMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.status.204", endpointTags)]
+	statusMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.status.204", endpointTags,
+	)]
 	value = *statusMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	tchannelNames := []string{
-		"tchannel.outbound.calls.latency",
-		"tchannel.outbound.calls.per-attempt.latency",
-		"tchannel.outbound.calls.send",
-		"tchannel.outbound.calls.success",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.latency",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.per-attempt.latency",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.send",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.success",
 	}
 	tchannelTags := map[string]string{
 		"env":             "test",
@@ -144,28 +152,40 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	outboundLatency := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.latency", tchannelTags)]
+	outboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.latency",
+		tchannelTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	perAttemptOutboundLatency := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.per-attempt.latency", tchannelTags)]
+	perAttemptOutboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.per-attempt.latency",
+		tchannelTags,
+	)]
 	value = *perAttemptOutboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundSend := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.send", tchannelTags)]
+	outboundSend := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.send",
+		tchannelTags,
+	)]
 	value = *outboundSend.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	outboundSuccess := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.success", tchannelTags)]
+	outboundSuccess := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.success",
+		tchannelTags,
+	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	clientNames := []string{
-		"outbound.calls.latency",
-		"outbound.calls.sent",
-		"outbound.calls.success",
+		"test-gateway.test.all-workers.outbound.calls.latency",
+		"test-gateway.test.all-workers.outbound.calls.sent",
+		"test-gateway.test.all-workers.outbound.calls.success",
 	}
 	clientTags := map[string]string{
 		"env":             "test",
@@ -180,16 +200,22 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	outboundLatency = metrics[tally.KeyForPrefixedStringMap("outbound.calls.latency", clientTags)]
+	outboundLatency = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.latency", clientTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundSend = metrics[tally.KeyForPrefixedStringMap("outbound.calls.sent", clientTags)]
+	outboundSend = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.sent", clientTags,
+	)]
 	value = *outboundSend.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	outboundSuccess = metrics[tally.KeyForPrefixedStringMap("outbound.calls.success", clientTags)]
+	outboundSuccess = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.success", clientTags,
+	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
@@ -198,7 +224,9 @@ func TestCallMetrics(t *testing.T) {
 		"service": "test-gateway",
 	}
 
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)]
+	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.zap.logged.info", defaultTags,
+	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
 	assert.Equal(t, int64(4), value, "expected counter to be 4")
 }

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -108,9 +108,9 @@ func TestCallMetrics(t *testing.T) {
 	assert.Equal(t, numMetrics, len(metrics))
 
 	tchannelInboundNames := []string{
-		"tchannel.inbound.calls.latency",
-		"tchannel.inbound.calls.recvd",
-		"tchannel.inbound.calls.success",
+		"test-gateway.test.all-workers.tchannel.inbound.calls.latency",
+		"test-gateway.test.all-workers.tchannel.inbound.calls.recvd",
+		"test-gateway.test.all-workers.tchannel.inbound.calls.success",
 	}
 	tchannelInboundTags := map[string]string{
 		"app":             "test-gateway",
@@ -126,23 +126,32 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	inboundLatency := metrics[tally.KeyForPrefixedStringMap("tchannel.inbound.calls.latency", tchannelInboundTags)]
+	inboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.inbound.calls.latency",
+		tchannelInboundTags,
+	)]
 	value := *inboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	inboundRecvd := metrics[tally.KeyForPrefixedStringMap("tchannel.inbound.calls.recvd", tchannelInboundTags)]
+	inboundRecvd := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.inbound.calls.recvd",
+		tchannelInboundTags,
+	)]
 	value = *inboundRecvd.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value)
 
-	inboundSuccess := metrics[tally.KeyForPrefixedStringMap("tchannel.inbound.calls.success", tchannelInboundTags)]
+	inboundSuccess := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.inbound.calls.success",
+		tchannelInboundTags,
+	)]
 	value = *inboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	endpointNames := []string{
-		"inbound.calls.latency",
-		"inbound.calls.recvd",
-		"inbound.calls.success",
+		"test-gateway.test.all-workers.inbound.calls.latency",
+		"test-gateway.test.all-workers.inbound.calls.recvd",
+		"test-gateway.test.all-workers.inbound.calls.success",
 	}
 	endpointTags := map[string]string{
 		"env":      "test",
@@ -157,24 +166,30 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	inboundLatency = metrics[tally.KeyForPrefixedStringMap("inbound.calls.latency", endpointTags)]
+	inboundLatency = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.latency", endpointTags,
+	)]
 	value = *inboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	inboundRecvd = metrics[tally.KeyForPrefixedStringMap("inbound.calls.recvd", endpointTags)]
+	inboundRecvd = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.recvd", endpointTags,
+	)]
 	value = *inboundRecvd.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value)
 
-	inboundSuccess = metrics[tally.KeyForPrefixedStringMap("inbound.calls.success", endpointTags)]
+	inboundSuccess = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.success", endpointTags,
+	)]
 	value = *inboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	tchannelOutboundNames := []string{
-		"tchannel.outbound.calls.latency",
-		"tchannel.outbound.calls.per-attempt.latency",
-		"tchannel.outbound.calls.send",
-		"tchannel.outbound.calls.success",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.latency",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.per-attempt.latency",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.send",
+		"test-gateway.test.all-workers.tchannel.outbound.calls.success",
 	}
 	tchannelOutboundTags := map[string]string{
 		"app":             "test-gateway",
@@ -190,28 +205,40 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	outboundLatency := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.latency", tchannelOutboundTags)]
+	outboundLatency := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.latency",
+		tchannelOutboundTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundLatency = metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.per-attempt.latency", tchannelOutboundTags)]
+	outboundLatency = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.per-attempt.latency",
+		tchannelOutboundTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundSend := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.send", tchannelOutboundTags)]
+	outboundSend := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.send",
+		tchannelOutboundTags,
+	)]
 	value = *outboundSend.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value)
 
-	outboundSuccess := metrics[tally.KeyForPrefixedStringMap("tchannel.outbound.calls.success", tchannelOutboundTags)]
+	outboundSuccess := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.tchannel.outbound.calls.success",
+		tchannelOutboundTags,
+	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	clientNames := []string{
-		"outbound.calls.latency",
-		"outbound.calls.sent",
-		"outbound.calls.success",
+		"test-gateway.test.all-workers.outbound.calls.latency",
+		"test-gateway.test.all-workers.outbound.calls.sent",
+		"test-gateway.test.all-workers.outbound.calls.success",
 	}
 	clientTags := map[string]string{
 		"env":             "test",
@@ -227,16 +254,22 @@ func TestCallMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	outboundLatency = metrics[tally.KeyForPrefixedStringMap("outbound.calls.latency", clientTags)]
+	outboundLatency = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.latency", clientTags,
+	)]
 	value = *outboundLatency.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	outboundSent := metrics[tally.KeyForPrefixedStringMap("outbound.calls.sent", clientTags)]
+	outboundSent := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.sent", clientTags,
+	)]
 	value = *outboundSent.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value)
 
-	outboundSuccess = metrics[tally.KeyForPrefixedStringMap("outbound.calls.success", clientTags)]
+	outboundSuccess = metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.outbound.calls.success", clientTags,
+	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 }

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -126,10 +126,10 @@ func TestHealthMetrics(t *testing.T) {
 	metrics := cgateway.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics), "expected 5 metrics")
 	names := []string{
-		"inbound.calls.latency",
-		"inbound.calls.recvd",
-		"inbound.calls.success",
-		"inbound.calls.status.200",
+		"test-gateway.test.all-workers.inbound.calls.latency",
+		"test-gateway.test.all-workers.inbound.calls.recvd",
+		"test-gateway.test.all-workers.inbound.calls.success",
+		"test-gateway.test.all-workers.inbound.calls.status.200",
 	}
 	tags := map[string]string{
 		"env":      "test",
@@ -147,27 +147,39 @@ func TestHealthMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 
-	loggedKey := tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)
+	loggedKey := tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.zap.logged.info", defaultTags,
+	)
 	assert.Contains(t, metrics, loggedKey, "expected metrics: %s", loggedKey)
 
-	latencyMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.latency", tags)]
+	latencyMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.latency", tags,
+	)]
 	value := *latencyMetric.MetricValue.Timer.I64Value
 	assert.True(t, value > 1000, "expected timer to be >1000 nano seconds")
 	assert.True(t, value < 1000*1000*1000, "expected timer to be <1 second")
 
-	recvdMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.recvd", tags)]
+	recvdMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.recvd", tags,
+	)]
 	value = *recvdMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	successMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.success", tags)]
+	successMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.success", tags,
+	)]
 	value = *successMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	statusMetric := metrics[tally.KeyForPrefixedStringMap("inbound.calls.status.200", tags)]
+	statusMetric := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.status.200", tags,
+	)]
 	value = *statusMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap("zap.logged.info", defaultTags)]
+	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.zap.logged.info", defaultTags,
+	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
 	assert.Equal(t, int64(2), value, "expected counter to be 2")
 }
@@ -195,36 +207,36 @@ func TestRuntimeMetrics(t *testing.T) {
 	metrics := cgateway.M3Service.GetMetrics()
 	assert.Equal(t, numMetrics, len(metrics), "expected 31 metrics")
 	names := []string{
-		"per-worker.runtime.cpu.cgoCalls",
-		"per-worker.runtime.cpu.count",
-		"per-worker.runtime.cpu.goMaxProcs",
-		"per-worker.runtime.cpu.goroutines",
-		"per-worker.runtime.mem.alloc",
-		"per-worker.runtime.mem.frees",
-		"per-worker.runtime.mem.gc.count",
-		"per-worker.runtime.mem.gc.cpuFraction",
-		"per-worker.runtime.mem.gc.last",
-		"per-worker.runtime.mem.gc.next",
-		"per-worker.runtime.mem.gc.pause",
-		"per-worker.runtime.mem.gc.pauseTotal",
-		"per-worker.runtime.mem.gc.sys",
-		"per-worker.runtime.mem.heap.alloc",
-		"per-worker.runtime.mem.heap.idle",
-		"per-worker.runtime.mem.heap.inuse",
-		"per-worker.runtime.mem.heap.objects",
-		"per-worker.runtime.mem.heap.released",
-		"per-worker.runtime.mem.heap.sys",
-		"per-worker.runtime.mem.lookups",
-		"per-worker.runtime.mem.malloc",
-		"per-worker.runtime.mem.otherSys",
-		"per-worker.runtime.mem.stack.inuse",
-		"per-worker.runtime.mem.stack.mcacheInuse",
-		"per-worker.runtime.mem.stack.mcacheSys",
-		"per-worker.runtime.mem.stack.mspanInuse",
-		"per-worker.runtime.mem.stack.mspanSys",
-		"per-worker.runtime.mem.stack.sys",
-		"per-worker.runtime.mem.sys",
-		"per-worker.runtime.mem.total",
+		"test-gateway.test.per-worker.runtime.cpu.cgoCalls",
+		"test-gateway.test.per-worker.runtime.cpu.count",
+		"test-gateway.test.per-worker.runtime.cpu.goMaxProcs",
+		"test-gateway.test.per-worker.runtime.cpu.goroutines",
+		"test-gateway.test.per-worker.runtime.mem.alloc",
+		"test-gateway.test.per-worker.runtime.mem.frees",
+		"test-gateway.test.per-worker.runtime.mem.gc.count",
+		"test-gateway.test.per-worker.runtime.mem.gc.cpuFraction",
+		"test-gateway.test.per-worker.runtime.mem.gc.last",
+		"test-gateway.test.per-worker.runtime.mem.gc.next",
+		"test-gateway.test.per-worker.runtime.mem.gc.pause",
+		"test-gateway.test.per-worker.runtime.mem.gc.pauseTotal",
+		"test-gateway.test.per-worker.runtime.mem.gc.sys",
+		"test-gateway.test.per-worker.runtime.mem.heap.alloc",
+		"test-gateway.test.per-worker.runtime.mem.heap.idle",
+		"test-gateway.test.per-worker.runtime.mem.heap.inuse",
+		"test-gateway.test.per-worker.runtime.mem.heap.objects",
+		"test-gateway.test.per-worker.runtime.mem.heap.released",
+		"test-gateway.test.per-worker.runtime.mem.heap.sys",
+		"test-gateway.test.per-worker.runtime.mem.lookups",
+		"test-gateway.test.per-worker.runtime.mem.malloc",
+		"test-gateway.test.per-worker.runtime.mem.otherSys",
+		"test-gateway.test.per-worker.runtime.mem.stack.inuse",
+		"test-gateway.test.per-worker.runtime.mem.stack.mcacheInuse",
+		"test-gateway.test.per-worker.runtime.mem.stack.mcacheSys",
+		"test-gateway.test.per-worker.runtime.mem.stack.mspanInuse",
+		"test-gateway.test.per-worker.runtime.mem.stack.mspanSys",
+		"test-gateway.test.per-worker.runtime.mem.stack.sys",
+		"test-gateway.test.per-worker.runtime.mem.sys",
+		"test-gateway.test.per-worker.runtime.mem.total",
 	}
 	tags := map[string]string{
 		"env":     "test",


### PR DESCRIPTION
We lost the metric scope prefixes in a recent refactor.

Adding them back.

r: @uber/zanzibar-team