### PR TITLE
Update runtime-metrics to properly emit GC stats

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -350,7 +350,10 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		EnableGCMetrics:  config.MustGetBoolean("metrics.runtime.enableGCMetrics"),
 		CollectInterval:  collectInterval,
 	}
-	gateway.runtimeMetrics = StartRuntimeMetricsCollector(runtimeMetricsOpts, gateway.PerHostScope)
+	gateway.runtimeMetrics = StartRuntimeMetricsCollector(
+		runtimeMetricsOpts,
+		gateway.PerHostScope,
+	)
 
 	return nil
 }

--- a/runtime/runtime_metrics.go
+++ b/runtime/runtime_metrics.go
@@ -28,6 +28,8 @@ import (
 	"github.com/uber-go/tally"
 )
 
+const _numGCThreshold = uint32(len(runtime.MemStats{}.PauseEnd))
+
 // RuntimeMetricsOptions configuration.
 type RuntimeMetricsOptions struct {
 	EnableCPUMetrics bool          `json:"enableCPUMetrics"`
@@ -44,46 +46,26 @@ type RuntimeMetricsCollector interface {
 }
 
 type runtimeMetrics struct {
-	// CPU
-	goMaxProcs    tally.Gauge // maximum number of CPUs which are executing simultaneously
-	numCPUs       tally.Gauge // number of logical CPUs usable by the current process
-	numCgoCalls   tally.Gauge // number of cgo calls made by the current process
-	numGoRoutines tally.Gauge // number of goroutines that currently exist
+	// maximum number of CPUs which are executing simultaneously
+	goMaxProcs tally.Gauge
+	// number of logical CPUs usable by the current process
+	numCPUs tally.Gauge
+	// number of goroutines that currently exist
+	numGoRoutines tally.Gauge
 
-	// General
-	alloc      tally.Gauge // bytes of allocated heap objects
-	totalAlloc tally.Gauge // cumulative bytes allocated for heap objects
-	sys        tally.Gauge // total bytes of memory obtained from the OS
-	lookups    tally.Gauge // number of pointer lookups performed
-	mallocs    tally.Gauge // cumulative count of heap objects allocated
-	frees      tally.Gauge // cumulative count of heap objects freed
+	// bytes of allocated heap objects
+	heapAlloc tally.Gauge
+	// bytes in idle (unused) spans
+	heapIdle tally.Gauge
+	// bytes in in-use spans
+	heapInuse tally.Gauge
+	// bytes in stack spans
+	stackInuse tally.Gauge
 
-	// Heap
-	heapAlloc    tally.Gauge // bytes of allocated heap objects
-	heapSys      tally.Gauge // bytes of heap memory obtained from the OS
-	heapIdle     tally.Gauge // bytes in idle (unused) spans
-	heapInuse    tally.Gauge // bytes in in-use spans
-	heapReleased tally.Gauge // bytes of physical memory returned to the OS
-	heapObjects  tally.Gauge // number of allocated heap objects
-
-	// Stack
-	stackInuse  tally.Gauge // bytes in stack spans
-	stackSys    tally.Gauge // bytes of stack memory obtained from the OS
-	mspanInuse  tally.Gauge // bytes of allocated mspan structures
-	mspanSys    tally.Gauge // bytes of memory obtained from the OS for mspan
-	mcacheInuse tally.Gauge // bytes of allocated mcache structures
-	mcacheSys   tally.Gauge // bytes of memory obtained from the OS for mcache structures
-
-	otherSys tally.Gauge // bytes of memory in miscellaneous off-heap runtime allocations
-
-	// GC
-	gcSys         tally.Gauge // bytes of memory in garbage collection metadata
-	nextGC        tally.Gauge // target heap size of the next GC cycle
-	lastGC        tally.Gauge // time the last garbage collection finished, as nanoseconds since epoch
-	pauseTotalMs  tally.Gauge // cumulative nanoseconds in GC stop-the-world pauses since the program running
-	pauseMs       tally.Gauge // most recent pause timing
-	numGC         tally.Gauge // number of completed GC cycles
-	gcCPUFraction tally.Gauge // fraction of cpu consumed by GC
+	// number of completed GC cycles
+	numGC tally.Counter
+	// GC pause time
+	gcPauseMs tally.Timer
 }
 
 // runtimeCollector keeps the current state of runtime metrics
@@ -94,6 +76,7 @@ type runtimeCollector struct {
 	runningMutex sync.RWMutex
 	running      bool // protected by runningMutex
 	stop         chan struct{}
+	lastNumGC    uint32
 }
 
 // StartRuntimeMetricsCollector starts collecting runtime metrics periodically.
@@ -108,7 +91,9 @@ func StartRuntimeMetricsCollector(
 	if !config.EnableCPUMetrics && !config.EnableMemMetrics && !config.EnableGCMetrics {
 		return nil
 	}
-	rm := NewRuntimeMetricsCollector(config, scope.SubScope("runtime"))
+	rm := NewRuntimeMetricsCollector(
+		config, scope.SubScope("runtime"),
+	)
 	rm.Start()
 	return rm
 }
@@ -118,54 +103,31 @@ func NewRuntimeMetricsCollector(
 	opts RuntimeMetricsOptions,
 	scope tally.Scope,
 ) RuntimeMetricsCollector {
+	var memstats runtime.MemStats
+	runtime.ReadMemStats(&memstats)
+
 	return &runtimeCollector{
 		opts:  opts,
 		scope: scope,
 		metrics: runtimeMetrics{
 			// CPU
-			goMaxProcs:    scope.Gauge("cpu.goMaxProcs"),
-			numCPUs:       scope.Gauge("cpu.count"),
-			numCgoCalls:   scope.Gauge("cpu.cgoCalls"),
-			numGoRoutines: scope.Gauge("cpu.goroutines"),
+			goMaxProcs:    scope.Gauge("gomaxprocs"),
+			numCPUs:       scope.Gauge("num-cpu"),
+			numGoRoutines: scope.Gauge("num-goroutines"),
 
-			// General memory
-			alloc:      scope.Gauge("mem.alloc"),
-			totalAlloc: scope.Gauge("mem.total"),
-			sys:        scope.Gauge("mem.sys"),
-			lookups:    scope.Gauge("mem.lookups"),
-			mallocs:    scope.Gauge("mem.malloc"),
-			frees:      scope.Gauge("mem.frees"),
-
-			// Heap memory
-			heapAlloc:    scope.Gauge("mem.heap.alloc"),
-			heapSys:      scope.Gauge("mem.heap.sys"),
-			heapIdle:     scope.Gauge("mem.heap.idle"),
-			heapInuse:    scope.Gauge("mem.heap.inuse"),
-			heapReleased: scope.Gauge("mem.heap.released"),
-			heapObjects:  scope.Gauge("mem.heap.objects"),
-
-			// Stack memory
-			stackInuse:  scope.Gauge("mem.stack.inuse"),
-			stackSys:    scope.Gauge("mem.stack.sys"),
-			mspanInuse:  scope.Gauge("mem.stack.mspanInuse"),
-			mspanSys:    scope.Gauge("mem.stack.mspanSys"),
-			mcacheInuse: scope.Gauge("mem.stack.mcacheInuse"),
-			mcacheSys:   scope.Gauge("mem.stack.mcacheSys"),
-
-			// Other memory
-			otherSys: scope.Gauge("mem.otherSys"),
+			// Memory
+			heapAlloc:  scope.Gauge("memory.heap"),
+			heapIdle:   scope.Gauge("memory.heapidle"),
+			heapInuse:  scope.Gauge("memory.heapinuse"),
+			stackInuse: scope.Gauge("memory.stack"),
 
 			// GC
-			gcSys:         scope.Gauge("mem.gc.sys"),
-			nextGC:        scope.Gauge("mem.gc.next"),
-			lastGC:        scope.Gauge("mem.gc.last"),
-			pauseTotalMs:  scope.Gauge("mem.gc.pauseTotal"),
-			pauseMs:       scope.Gauge("mem.gc.pause"),
-			numGC:         scope.Gauge("mem.gc.count"),
-			gcCPUFraction: scope.Gauge("mem.gc.cpuFraction"),
+			numGC:     scope.Counter("memory.num-gc"),
+			gcPauseMs: scope.Timer("memory.gc-pause-ms"),
 		},
-		running: false,
-		stop:    make(chan struct{}),
+		running:   false,
+		stop:      make(chan struct{}),
+		lastNumGC: memstats.NumGC,
 	}
 }
 
@@ -231,41 +193,31 @@ func (r *runtimeCollector) collect() {
 func (r *runtimeCollector) collectCPUMetrics() {
 	r.metrics.goMaxProcs.Update(float64(runtime.GOMAXPROCS(0)))
 	r.metrics.numCPUs.Update(float64(runtime.NumCPU()))
-	r.metrics.numCgoCalls.Update(float64(runtime.NumCgoCall()))
 	r.metrics.numGoRoutines.Update(float64(runtime.NumGoroutine()))
 }
 
 func (r *runtimeCollector) collectMemMetrics(memStats *runtime.MemStats) {
-	r.metrics.alloc.Update(float64(memStats.Alloc))
-	r.metrics.totalAlloc.Update(float64(memStats.TotalAlloc))
-	r.metrics.sys.Update(float64(memStats.Sys))
-	r.metrics.lookups.Update(float64(memStats.Lookups))
-	r.metrics.mallocs.Update(float64(memStats.Mallocs))
-	r.metrics.frees.Update(float64(memStats.Frees))
-
 	r.metrics.heapAlloc.Update(float64(memStats.HeapAlloc))
-	r.metrics.heapSys.Update(float64(memStats.HeapSys))
 	r.metrics.heapIdle.Update(float64(memStats.HeapIdle))
 	r.metrics.heapInuse.Update(float64(memStats.HeapInuse))
-	r.metrics.heapReleased.Update(float64(memStats.HeapReleased))
-	r.metrics.heapObjects.Update(float64(memStats.HeapObjects))
-
 	r.metrics.stackInuse.Update(float64(memStats.StackInuse))
-	r.metrics.stackSys.Update(float64(memStats.StackSys))
-	r.metrics.mspanInuse.Update(float64(memStats.MSpanInuse))
-	r.metrics.mspanSys.Update(float64(memStats.MSpanSys))
-	r.metrics.mcacheInuse.Update(float64(memStats.MCacheInuse))
-	r.metrics.mcacheSys.Update(float64(memStats.MCacheSys))
-
-	r.metrics.otherSys.Update(float64(memStats.OtherSys))
 }
 
 func (r *runtimeCollector) collectGCMetrics(memStats *runtime.MemStats) {
-	r.metrics.gcSys.Update(float64(memStats.GCSys))
-	r.metrics.nextGC.Update(float64(memStats.NextGC))
-	r.metrics.lastGC.Update(float64(memStats.LastGC))
-	r.metrics.pauseTotalMs.Update(float64(memStats.PauseTotalNs / 1000))
-	r.metrics.pauseMs.Update(float64((memStats.PauseNs[(memStats.NumGC+255)%256]) / 1000))
-	r.metrics.numGC.Update(float64(memStats.NumGC))
-	r.metrics.gcCPUFraction.Update(memStats.GCCPUFraction)
+	num := memStats.NumGC
+	lastNum := r.lastNumGC
+	r.lastNumGC = num
+
+	if delta := num - lastNum; delta > 0 {
+		r.metrics.numGC.Inc(int64(delta))
+		if delta >= _numGCThreshold {
+			lastNum = num - _numGCThreshold
+		}
+
+		for i := lastNum; i != num; i++ {
+			pause := memStats.PauseNs[i%uint32(len(memStats.PauseNs))]
+			r.metrics.gcPauseMs.Record(time.Duration(pause))
+		}
+	}
+
 }

--- a/runtime/runtime_metrics.go
+++ b/runtime/runtime_metrics.go
@@ -211,6 +211,7 @@ func (r *runtimeCollector) collectGCMetrics(memStats *runtime.MemStats) {
 	if delta := num - lastNum; delta > 0 {
 		r.metrics.numGC.Inc(int64(delta))
 		if delta >= _numGCThreshold {
+			/* coverage ignore next line */
 			lastNum = num - _numGCThreshold
 		}
 

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -200,43 +200,24 @@ func TestRuntimeMetrics(t *testing.T) {
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
 
 	// Expect 30 runtime metrics + 1 logged metric
-	numMetrics := 31
+	numMetrics := 10
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 	cgateway.MetricsWaitGroup.Wait()
 
 	metrics := cgateway.M3Service.GetMetrics()
-	assert.Equal(t, numMetrics, len(metrics), "expected 31 metrics")
+	assert.Equal(t, numMetrics, len(metrics), "expected 10 metrics")
 	names := []string{
-		"test-gateway.test.per-worker.runtime.cpu.cgoCalls",
-		"test-gateway.test.per-worker.runtime.cpu.count",
-		"test-gateway.test.per-worker.runtime.cpu.goMaxProcs",
-		"test-gateway.test.per-worker.runtime.cpu.goroutines",
-		"test-gateway.test.per-worker.runtime.mem.alloc",
-		"test-gateway.test.per-worker.runtime.mem.frees",
-		"test-gateway.test.per-worker.runtime.mem.gc.count",
-		"test-gateway.test.per-worker.runtime.mem.gc.cpuFraction",
-		"test-gateway.test.per-worker.runtime.mem.gc.last",
-		"test-gateway.test.per-worker.runtime.mem.gc.next",
-		"test-gateway.test.per-worker.runtime.mem.gc.pause",
-		"test-gateway.test.per-worker.runtime.mem.gc.pauseTotal",
-		"test-gateway.test.per-worker.runtime.mem.gc.sys",
-		"test-gateway.test.per-worker.runtime.mem.heap.alloc",
-		"test-gateway.test.per-worker.runtime.mem.heap.idle",
-		"test-gateway.test.per-worker.runtime.mem.heap.inuse",
-		"test-gateway.test.per-worker.runtime.mem.heap.objects",
-		"test-gateway.test.per-worker.runtime.mem.heap.released",
-		"test-gateway.test.per-worker.runtime.mem.heap.sys",
-		"test-gateway.test.per-worker.runtime.mem.lookups",
-		"test-gateway.test.per-worker.runtime.mem.malloc",
-		"test-gateway.test.per-worker.runtime.mem.otherSys",
-		"test-gateway.test.per-worker.runtime.mem.stack.inuse",
-		"test-gateway.test.per-worker.runtime.mem.stack.mcacheInuse",
-		"test-gateway.test.per-worker.runtime.mem.stack.mcacheSys",
-		"test-gateway.test.per-worker.runtime.mem.stack.mspanInuse",
-		"test-gateway.test.per-worker.runtime.mem.stack.mspanSys",
-		"test-gateway.test.per-worker.runtime.mem.stack.sys",
-		"test-gateway.test.per-worker.runtime.mem.sys",
-		"test-gateway.test.per-worker.runtime.mem.total",
+		"test-gateway.test.per-worker.runtime.num-cpu",
+		"test-gateway.test.per-worker.runtime.gomaxprocs",
+		"test-gateway.test.per-worker.runtime.num-goroutines",
+
+		"test-gateway.test.per-worker.runtime.memory.heap",
+		"test-gateway.test.per-worker.runtime.memory.heapidle",
+		"test-gateway.test.per-worker.runtime.memory.heapinuse",
+		"test-gateway.test.per-worker.runtime.memory.stack",
+
+		"test-gateway.test.per-worker.runtime.memory.num-gc",
+		"test-gateway.test.per-worker.runtime.memory.gc-pause-ms",
 	}
 	tags := map[string]string{
 		"env":     "test",


### PR DESCRIPTION
This changes updates the GC metrics to Counter/Timer so that
we can track GC latencies per worker.

I've also culled some unnecessary metrics as every single
metric we emit at the host/worker granularity is expensive
for our metrics/grafana/graphite pipeline.

Brought the implementation inline with the original reference
implementation ( https://github.com/uber-go/fx/blob/v1.0.0-beta1/metrics/runtime_metrics.go )

r: @uber/zanzibar-team