### PR TITLE
Add a status tag for HTTP metrics

### DIFF
--- a/runtime/call_metrics.go
+++ b/runtime/call_metrics.go
@@ -165,7 +165,9 @@ func NewInboundHTTPMetrics(scope tally.Scope) *InboundHTTPMetrics {
 	metrics.Errors = scope.Counter(inboundCallsErrors)
 	metrics.Status = make(map[int]tally.Counter, len(knownStatusCodes))
 	for statusCode := range knownStatusCodes {
-		metrics.Status[statusCode] = scope.Counter(fmt.Sprintf("%s.%d", inboundCallsStatus, statusCode))
+		metrics.Status[statusCode] = scope.Tagged(map[string]string{
+			"status": fmt.Sprintf("%d", statusCode),
+		}).Counter(fmt.Sprintf("%s.%d", inboundCallsStatus, statusCode))
 	}
 	return &metrics
 }
@@ -190,7 +192,9 @@ func NewOutboundHTTPMetrics(scope tally.Scope) *OutboundHTTPMetrics {
 	metrics.Errors = scope.Counter(outboundCallsErrors)
 	metrics.Status = make(map[int]tally.Counter, len(knownStatusCodes))
 	for statusCode := range knownStatusCodes {
-		metrics.Status[statusCode] = scope.Counter(fmt.Sprintf("%s.%d", outboundCallsStatus, statusCode))
+		metrics.Status[statusCode] = scope.Tagged(map[string]string{
+			"status": fmt.Sprintf("%d", statusCode),
+		}).Counter(fmt.Sprintf("%s.%d", outboundCallsStatus, statusCode))
 	}
 	return &metrics
 }

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -82,13 +82,19 @@ func TestCallMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.inbound.calls.latency",
 		"test-gateway.test.all-workers.inbound.calls.recvd",
 		"test-gateway.test.all-workers.inbound.calls.success",
-		"test-gateway.test.all-workers.inbound.calls.status.200",
 	}
 	endpointTags := map[string]string{
 		"env":      "test",
 		"service":  "test-gateway",
 		"endpoint": "bar",
 		"handler":  "normal",
+	}
+	eStatusTags := map[string]string{
+		"env":      "test",
+		"service":  "test-gateway",
+		"endpoint": "bar",
+		"handler":  "normal",
+		"status":   "200",
 	}
 	for _, name := range endpointNames {
 		key := tally.KeyForPrefixedStringMap(name, endpointTags)
@@ -109,7 +115,7 @@ func TestCallMetrics(t *testing.T) {
 	assert.Equal(t, int64(1), value)
 
 	inboundStatus := metrics[tally.KeyForPrefixedStringMap(
-		"test-gateway.test.all-workers.inbound.calls.status.200", endpointTags,
+		"test-gateway.test.all-workers.inbound.calls.status.200", eStatusTags,
 	)]
 	value = *inboundStatus.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
@@ -118,7 +124,6 @@ func TestCallMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.outbound.calls.latency",
 		"test-gateway.test.all-workers.outbound.calls.sent",
 		"test-gateway.test.all-workers.outbound.calls.success",
-		"test-gateway.test.all-workers.outbound.calls.status.200",
 	}
 	httpClientTags := map[string]string{
 		"env":     "test",
@@ -126,6 +131,14 @@ func TestCallMetrics(t *testing.T) {
 		"client":  "bar",
 		"method":  "Normal",
 	}
+	cStatusTags := map[string]string{
+		"env":     "test",
+		"service": "test-gateway",
+		"client":  "bar",
+		"method":  "Normal",
+		"status":  "200",
+	}
+
 	for _, name := range httpClientNames {
 		key := tally.KeyForPrefixedStringMap(name, httpClientTags)
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
@@ -152,7 +165,7 @@ func TestCallMetrics(t *testing.T) {
 
 	statusSuccess := metrics[tally.KeyForPrefixedStringMap(
 		"test-gateway.test.all-workers.outbound.calls.status.200",
-		httpClientTags,
+		cStatusTags,
 	)]
 	value = *statusSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -95,13 +95,19 @@ func TestCallMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.inbound.calls.latency",
 		"test-gateway.test.all-workers.inbound.calls.recvd",
 		"test-gateway.test.all-workers.inbound.calls.success",
-		"test-gateway.test.all-workers.inbound.calls.status.204",
 	}
 	endpointTags := map[string]string{
 		"env":      "test",
 		"service":  "test-gateway",
 		"endpoint": "baz",
 		"handler":  "call",
+	}
+	statusTags := map[string]string{
+		"env":      "test",
+		"service":  "test-gateway",
+		"endpoint": "baz",
+		"handler":  "call",
+		"status":   "204",
 	}
 	for _, name := range endpointNames {
 		key := tally.KeyForPrefixedStringMap(name, endpointTags)
@@ -128,7 +134,7 @@ func TestCallMetrics(t *testing.T) {
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	statusMetric := metrics[tally.KeyForPrefixedStringMap(
-		"test-gateway.test.all-workers.inbound.calls.status.204", endpointTags,
+		"test-gateway.test.all-workers.inbound.calls.status.204", statusTags,
 	)]
 	value = *statusMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -129,13 +129,19 @@ func TestHealthMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.inbound.calls.latency",
 		"test-gateway.test.all-workers.inbound.calls.recvd",
 		"test-gateway.test.all-workers.inbound.calls.success",
-		"test-gateway.test.all-workers.inbound.calls.status.200",
 	}
 	tags := map[string]string{
 		"env":      "test",
 		"service":  "test-gateway",
 		"endpoint": "health",
 		"handler":  "health",
+	}
+	statusTags := map[string]string{
+		"env":      "test",
+		"service":  "test-gateway",
+		"endpoint": "health",
+		"handler":  "health",
+		"status":   "200",
 	}
 	defaultTags := map[string]string{
 		"env":     "test",
@@ -146,6 +152,11 @@ func TestHealthMetrics(t *testing.T) {
 		key := tally.KeyForPrefixedStringMap(name, tags)
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
+
+	statusKey := tally.KeyForPrefixedStringMap(
+		"test-gateway.test.all-workers.inbound.calls.status.200", statusTags,
+	)
+	assert.Contains(t, metrics, statusKey, "expected metrics: %s", statusKey)
 
 	loggedKey := tally.KeyForPrefixedStringMap(
 		"test-gateway.test.all-workers.zap.logged.info", defaultTags,
@@ -172,7 +183,7 @@ func TestHealthMetrics(t *testing.T) {
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
 	statusMetric := metrics[tally.KeyForPrefixedStringMap(
-		"test-gateway.test.all-workers.inbound.calls.status.200", tags,
+		"test-gateway.test.all-workers.inbound.calls.status.200", statusTags,
 	)]
 	value = *statusMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")


### PR DESCRIPTION
By adding a tag for status we can utilize in `aliasByTags()`
for pretty printing.

This extra tag should be relatively cheap but some older metrics
will not have this tag at all.

r: @uber/zanzibar-team