### PR TITLE
Update tchannel metrics to remove bad characters

### DIFF
--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -88,10 +88,9 @@ func NewTChannelClient(
 			zap.String("serviceMethod", serviceMethod),
 		)
 		metrics[serviceMethod] = NewOutboundTChannelMetrics(scope.Tagged(map[string]string{
-			"client":          opt.ClientID,
-			"method":          methodName,
-			"target-service":  opt.ServiceName,
-			"target-endpoint": serviceMethod,
+			"client":         opt.ClientID,
+			"method":         methodName,
+			"target-service": opt.ServiceName,
 		}))
 	}
 

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -112,10 +112,13 @@ func NewTChannelEndpointWithPostResponseCB(
 		zap.String("handlerID", handlerID),
 		zap.String("method", method),
 	)
+
+	cleanMethod := strings.Replace(method, ":", "-", -1)
+
 	scope = scope.Tagged(map[string]string{
 		"endpoint": endpointID,
 		"handler":  handlerID,
-		"method":   method,
+		"method":   cleanMethod,
 	})
 	return &TChannelEndpoint{
 		EndpointID: endpointID,

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -194,12 +194,11 @@ func TestCallMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.outbound.calls.success",
 	}
 	clientTags := map[string]string{
-		"env":             "test",
-		"service":         "test-gateway",
-		"client":          "baz",
-		"method":          "Call",
-		"target-service":  "bazService",
-		"target-endpoint": "SimpleService::call",
+		"env":            "test",
+		"service":        "test-gateway",
+		"client":         "baz",
+		"method":         "Call",
+		"target-service": "bazService",
 	}
 	for _, name := range clientNames {
 		key := tally.KeyForPrefixedStringMap(name, clientTags)

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -158,7 +158,7 @@ func TestCallMetrics(t *testing.T) {
 		"service":  "test-gateway",
 		"endpoint": "bazTChannel",
 		"handler":  "call",
-		"method":   "SimpleService::Call",
+		"method":   "SimpleService--Call",
 	}
 
 	for _, name := range endpointNames {
@@ -241,12 +241,11 @@ func TestCallMetrics(t *testing.T) {
 		"test-gateway.test.all-workers.outbound.calls.success",
 	}
 	clientTags := map[string]string{
-		"env":             "test",
-		"service":         "test-gateway",
-		"client":          "baz",
-		"method":          "Call",
-		"target-service":  "bazService",
-		"target-endpoint": "SimpleService::call",
+		"env":            "test",
+		"service":        "test-gateway",
+		"client":         "baz",
+		"method":         "Call",
+		"target-service": "bazService",
 	}
 
 	for _, name := range clientNames {


### PR DESCRIPTION
Currently our tchannel metrics are not being collected
because the tag values we send have characters that are not allowed,
in this case ":" ( allowed is /[a-zA-Z_-]/.

This change should hopefully make tchannel metrics available
for querying.

r: @uber/zanzibar-team