### PR TITLE
travis: no longer test on 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: true
 go:
-  - 1.7.x
   - 1.8.x
   - 1.9.x
 go_import_path: github.com/uber/zanzibar


### PR DESCRIPTION
We just upgraded our deployment to use 1.8 instead of 1.7

Now we longer have to test 1.7 and we can go back to only 2 versions instead of 3.

@uber/zanzibar-team 