### PR TITLE
Add panic handler with logs / metrics.

### DIFF
--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -202,6 +202,9 @@ func TestRouterPanic(t *testing.T) {
 	)
 
 	resp, err := gateway.MakeRequest("GET", "/panic", nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
 
 	assert.Equal(t, resp.Status, "500 Internal Server Error")
 	assert.Equal(t, resp.StatusCode, 500)
@@ -259,6 +262,9 @@ func TestRouterPanicObject(t *testing.T) {
 	)
 
 	resp, err := gateway.MakeRequest("GET", "/panic", nil, nil)
+	if !assert.NoError(t, err) {
+		return
+	}
 
 	assert.Equal(t, resp.Status, "500 Internal Server Error")
 	assert.Equal(t, resp.StatusCode, 500)


### PR DESCRIPTION
Currently we have panics in production that are only
visible in the STDOUT logs of our docker container.

This panic handler will ensure we write to kafka/metrics.

This is only for panics in the goroutine for the http proxy.

Any panics that occur in other goroutines ( the main goroutine
or any goroutine spawned by any other code ) will cause the
process to Exit() to the operating system and then cause the
deployment software to restart it.

r: @uber/zanzibar-team