### PR TITLE
thrift module validator 

### DIFF
--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2000,7 +2000,12 @@
 										"clientId": "baz",
 										"clientMethod": "compare",
 										"clientReqHeaders": {},
-										"clientRequest": {},
+										"clientRequest": {
+											"requestType": "http",
+											"httpRequest": {
+												"method": "GET"
+											}
+										},
 										"clientResHeaders": {},
 										"clientResponse": {
 											"httpResponse": {
@@ -2019,15 +2024,18 @@
 								"endpointId": "baz",
 								"endpointReqHeaders": {},
 								"endpointRequest": {
-									"arg1": {
-										"b1": true,
-										"i3": 42,
-										"s2": "hello"
-									},
-									"arg2": {
-										"b1": true,
-										"i3": 42,
-										"s2": "hola"
+									"requestType": "tchannel",
+									"tchannelRequest": {
+										"arg1": {
+											"b1": true,
+											"i3": 42,
+											"s2": "hello"
+										},
+										"arg2": {
+											"b1": true,
+											"i3": 42,
+											"s2": "hola"
+										}
 									}
 								},
 								"endpointResHeaders": {},

--- a/backend/repository/endpoint_update.go
+++ b/backend/repository/endpoint_update.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uber/zanzibar/codegen"
+	reqerr "github.com/uber/zanzibar/codegen/errors"
 )
 
 // WriteEndpointConfig writes endpoint configs and its test cases into a runtime repository and
@@ -67,15 +68,15 @@ func (r *Repository) validateEndpointCfg(req *EndpointConfig) error {
 	}
 	clientCfg, ok := gatewayConfig.Clients[req.ClientID]
 	if !ok {
-		return NewRequestError(
-			ClientID, errors.Errorf("can't find client %q", req.ClientID))
+		return reqerr.NewRequestError(
+			reqerr.EndpointsClientID, errors.Errorf("can't find client %q", req.ClientID))
 	}
 	if clientCfg.Type == HTTP {
 		req.WorkflowType = "httpClient"
 	} else if clientCfg.Type == TCHANNEL {
 		req.WorkflowType = "tchannelClient"
 	} else {
-		return NewRequestError(ClientType,
+		return reqerr.NewRequestError(reqerr.ClientsType,
 			errors.Errorf("client type %q is not supported", clientCfg.Type))
 	}
 

--- a/backend/repository/manager_test.go
+++ b/backend/repository/manager_test.go
@@ -93,6 +93,30 @@ func TestIDLThriftService(t *testing.T) {
 	assert.Error(t, err, "Should return an error for thrift not found.")
 }
 
+func TestValidate(t *testing.T) {
+	r, err := manager.NewRuntimeRepository(gatewayID)
+	assert.Nil(t, err)
+	b, err := ioutil.ReadFile(tchannelClientUpdateRequestFile)
+	assert.Nil(t, err)
+	clientReq := &ClientConfig{}
+	err = json.Unmarshal(b, clientReq)
+	assert.Nil(t, err)
+	endpointCfgUpdateRequestFile := filepath.Join(endpointUpdateRequestDir, "baz/compare.json")
+	b, err = ioutil.ReadFile(endpointCfgUpdateRequestFile)
+	assert.Nil(t, err)
+	endpointReq := &EndpointConfig{}
+	err = json.Unmarshal(b, endpointReq)
+
+	assert.Nil(t, err)
+	req := &UpdateRequest{
+		ThriftFiles:     []string{"clients/baz/baz.thrift"},
+		ClientUpdates:   []ClientConfig{*clientReq},
+		EndpointUpdates: []EndpointConfig{*endpointReq},
+	}
+	err = manager.Validate(r, req)
+	assert.Nil(t, err)
+}
+
 func TestUpdateAll(t *testing.T) {
 	r, err := manager.NewRuntimeRepository(gatewayID)
 	if !assert.NoError(t, err, "Failed to create runtime repository.") {

--- a/codegen/errors/errors.go
+++ b/codegen/errors/errors.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package repository
+package errors
 
 import "fmt"
 
@@ -31,11 +31,31 @@ type RequestError struct {
 // RequestField is a field name in a request.
 type RequestField string
 
+// unique camel-cased key naming with module name + field name
+// comment annotates jq style field path in json payload from UI
+// json tag used by UI follows previous convention
+// TODO: fix mixed-case-naming introduced in early commits
 const (
-	// ClientID field.
-	ClientID RequestField = "client_id"
-	// ClientType field.
-	ClientType RequestField = "client_type"
+	// ClientsType: .client_updates[idx].type
+	ClientsType RequestField = "client_type"
+	// ClientsServiceName: .client_updates[idx].serviceName
+	ClientsServiceName RequestField = "service_name"
+	// ClientsIP: .client_updates[idx].ip
+	ClientsIP RequestField = "ip"
+	// ClientsPort: .client_updates[idx].port
+	ClientsPort RequestField = "port"
+	// ClientsThriftFile: .client_updates[idx].thriftFile
+	ClientsThriftFile RequestField = "ThriftFile"
+	// ClientsExposedMethods: .client_updates[idx].exposedMethods
+	ClientsExposedMethods RequestField = "exposedMethods"
+	// EndpointsThriftFile: .endpoint_updates[idx].thriftFile
+	EndpointsThriftFile RequestField = "ThriftFile"
+	// EndpointsClientID: .endpoint_updates[idx].ClientId
+	EndpointsClientID RequestField = "client_id"
+	// EndpointThriftMethodName: .endpoint_updates[idx].ClientMethod
+	EndpointThriftMethodName RequestField = "thriftMethodName"
+	// ThriftFiles: .thrift_files
+	ThriftFiles RequestField = "thrift_files"
 )
 
 // NewRequestError returns an error for invalid request.

--- a/codegen/module.go
+++ b/codegen/module.go
@@ -846,11 +846,12 @@ func readPackageInfo(
 
 // GenerateBuild will, given a module system configuration directory and a
 // target build directory, run the generators assigned to each type of module
-// and write the generated output to the module build directory
+// and write the generated output to the module build directory if commitChange
 func (system *ModuleSystem) GenerateBuild(
 	packageRoot string,
 	baseDirectory string,
 	targetGenDir string,
+	commitChange bool,
 ) (map[string][]*ModuleInstance, error) {
 	resolvedModules, err := system.ResolveModules(
 		packageRoot,
@@ -922,9 +923,10 @@ func (system *ModuleSystem) GenerateBuild(
 			if buildResult == nil {
 				continue
 			}
-
 			classInstance.genSpec = buildResult.Spec
-
+			if !commitChange {
+				continue
+			}
 			for filePath, content := range buildResult.Files {
 				filePath = filepath.Clean(filePath)
 

--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -173,6 +173,7 @@ func TestExampleService(t *testing.T) {
 		"github.com/uber/zanzibar/codegen/test-service",
 		testServiceDir,
 		path.Join(testServiceDir, "build"),
+		true,
 	)
 	if err != nil {
 		t.Errorf("Unexpected error generating build %s", err)
@@ -467,6 +468,7 @@ func TestExampleServiceCycles(t *testing.T) {
 		"github.com/uber/zanzibar/codegen/test-service",
 		testServiceDir,
 		path.Join(testServiceDir, "build"),
+		true,
 	)
 	if err == nil {
 		t.Errorf("Expected cycle error generating build")

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -104,6 +104,7 @@ func main() {
 		packageHelper.PackageRoot(),
 		configRoot,
 		packageHelper.CodeGenTargetPath(),
+		true,
 	)
 	checkError(err, "Failed to generate module system components")
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -81,6 +81,7 @@ func TestGenerateBar(t *testing.T) {
 		"github.com/uber/zanzibar/examples/example-gateway",
 		absGatewayPath,
 		packageHelper.CodeGenTargetPath(),
+		true,
 	)
 	if !assert.NoError(t, buildErr, "failed to create clients init %s", buildErr) {
 		return


### PR DESCRIPTION
This PR improves user input validation passed in from UI

- added validation before codegen
- BFS walk & compare thrift module ASTs between client and endpoint
- throw user friendly errors

cc @uber/zanzibar-team 


===========
I want to reiterate why we don't want generate logic in validation:
- currently there's no easy way to walk through the whole generate process for validation only, the generate process is scripting on file system, cannot be plugin in to endpoint call without major refactor
- full generate process yield intermediate result, leave error stack confusing for users
- deep in generate stack, there's no obvious lead to exactly what user input was wrong

My original plan was to visit & check separately *on user input*, and leave other errors to ci system log, my rationale is: all user related errors should be able to detect from user input only, if the error is hiding deep that we need to generate to detect, we should probably debug / fix our gen system instead of depend on user to fix input. 

Since we have concern validation diverge with code gen, I'm going to call codegen in validation 
anyway, we need to change codegen, raise errors that links to exactly which user input and why, this require 
[-] 1: error type shared between codegen & backend
2: refactor in type convert

==============

synced offline with @Raynos 
1: backend is already touching file system for diff gen, this is not optimal but consistent with existing structure
2: we're deferring the full generate process to ci jobs, generate -> type convert path we have a way to not generating intermediate result
3: is the only thing we need -> require changes in type converter
