### PR TITLE
Properly create options for middleware configs

### DIFF
--- a/backend/repository/data/gateway_config_expected.json
+++ b/backend/repository/data/gateway_config_expected.json
@@ -822,6 +822,12 @@
 				"Bar": {
 					"type": "integer"
 				},
+				"Baz": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
 				"Foo": {
 					"type": "string"
 				}

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -220,6 +220,12 @@
 						"Bar": {
 							"type": "integer"
 						},
+						"Baz": {
+							"items": {
+								"type": "string"
+							},
+							"type": "array"
+						},
 						"Foo": {
 							"type": "string"
 						}
@@ -2632,6 +2638,12 @@
 								"Bar": {
 									"type": "integer"
 								},
+								"Baz": {
+									"items": {
+										"type": "string"
+									},
+									"type": "array"
+								},
 								"Foo": {
 									"type": "string"
 								}
@@ -3514,6 +3526,12 @@
 						"properties": {
 							"Bar": {
 								"type": "integer"
+							},
+							"Baz": {
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
 							},
 							"Foo": {
 								"type": "string"

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -178,7 +178,7 @@ func New{{$handlerName}}(
 			{{$middleware.Name}}.NewMiddleWare(
 				g,
 				{{$middleware.Name}}.Options{
-				{{range $key, $value := $middleware.Options -}}
+				{{range $key, $value := $middleware.PrettyOptions -}}
 					{{$key}} : {{$value}},
 				{{end -}}
 				},
@@ -469,7 +469,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 9825, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 9831, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -71,8 +71,8 @@ func New{{$handlerName}}(
 			{{$middleware.Name}}.NewMiddleWare(
 				g,
 				{{$middleware.Name}}.Options{
-				{{range $key, $value := $middleware.Options -}}
-					{{$key}} : {{printf "%#v" $value}},
+				{{range $key, $value := $middleware.PrettyOptions -}}
+					{{$key}} : {{$value}},
 				{{end -}}
 				},
 			),

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -72,7 +72,7 @@ func New{{$handlerName}}(
 				g,
 				{{$middleware.Name}}.Options{
 				{{range $key, $value := $middleware.Options -}}
-					{{$key}} : {{$value}},
+					{{$key}} : {{printf "%#v" $value}},
 				{{end -}}
 				},
 			),

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -58,6 +58,7 @@ func NewBarNormalHandler(
 			example.NewMiddleWare(
 				g,
 				example.Options{
+					Baz: []string{"foo", "bar"},
 					Foo: "test",
 				},
 			),

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -58,6 +58,7 @@ func NewBarNormalHandler(
 			example.NewMiddleWare(
 				g,
 				example.Options{
+					Baz: []string{"foo", "bar"},
 					Foo: "test",
 				},
 			),

--- a/examples/example-gateway/endpoints/bar/normal.json
+++ b/examples/example-gateway/endpoints/bar/normal.json
@@ -80,7 +80,11 @@
 		{
 			"name": "example",
 			"options": {
-				"Foo": "\"test\""
+				"Baz": [
+					"foo",
+					"bar"
+				],
+				"Foo": "test"
 			}
 		}
 	],

--- a/examples/example-gateway/middlewares/example/example.go
+++ b/examples/example-gateway/middlewares/example/example.go
@@ -33,8 +33,9 @@ type exampleMiddleware struct {
 
 // Options for middleware configuration
 type Options struct {
-	Foo string `json:"Foo"`
-	Bar int    `json:",omitempty"`
+	Foo string   `json:"Foo"`
+	Bar int      `json:",omitempty"`
+	Baz []string `json:"Baz"`
 }
 
 // MiddlewareState accessible by other middlewares and endpoint handler

--- a/examples/example-gateway/middlewares/example/example_schema.json
+++ b/examples/example-gateway/middlewares/example/example_schema.json
@@ -5,6 +5,12 @@
 		"Bar": {
 			"type": "integer"
 		},
+		"Baz": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"Foo": {
 			"type": "string"
 		}

--- a/examples/example-gateway/middlewares/example/example_test.go
+++ b/examples/example-gateway/middlewares/example/example_test.go
@@ -37,16 +37,23 @@ func TestNoRequestSuccessfulRequestOKResponse(t *testing.T) {
 		"        \"Bar\": {\n" +
 		"            \"type\": \"integer\"\n" +
 		"        },\n" +
+		"        \"Baz\": {\n" +
+		"            \"type\": \"array\",\n" +
+		"            \"items\": {\n" +
+		"                \"type\": \"string\"\n" +
+		"            }\n" +
+		"        },\n" +
 		"        \"Foo\": {\n" +
 		"            \"type\": \"string\"\n" +
 		"        }\n" +
 		"    },\n" +
 		"    \"required\": [\n" +
-		"        \"Foo\"\n" +
+		"        \"Foo\",\n" +
+		"        \"Baz\"\n" +
 		"    ]\n" +
 		"}"
 
 	json, err := schema.Marshal()
 	assert.Nil(t, err)
-	assert.Equal(t, string(json), expected)
+	assert.Equal(t, expected, string(json))
 }


### PR DESCRIPTION
Currently we do not create options in a fashion that supports
our gateway UI.

I've changed the code to generate proper Go initialization code
based on the value in the JSON file.

This only supports primitives and arrays of primitives, no
maps and no nested structs.

r: @uber/zanzibar-team