### PR TITLE
type converter refactor

### DIFF
--- a/codegen/type_converter_test.go
+++ b/codegen/type_converter_test.go
@@ -2507,5 +2507,9 @@ func TestCoverIsTransform(t *testing.T) {
 		r := recover()
 		assert.NotNil(t, r)
 	}()
-	codegen.IsTransform("gg.field", "lol.field")
+	f := &codegen.FieldAssignment{
+		FromIdentifier: "gg.field",
+		ToIdentifier:   "lol.field",
+	}
+	f.IsTransform()
 }


### PR DESCRIPTION
followup of Jake's work on type converter refactor 

- pack params / line generate process in assignment
- dedup of typedef & primitives `required/optional` and type name tweaking before generate

there's a minor thing that introduced extra blank line after every assignment

@uber/zanzibar-team 
let me know if anything I missed