### PR TITLE
TypeConverter: use unique variable names

### DIFF
--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -173,12 +173,12 @@ func convertArgWithHeadersClientResponse(in *clientsBarBar.BarResponse) *endpoin
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -177,8 +177,8 @@ func convertArgWithHeadersClientResponse(in *clientsBarBar.BarResponse) *endpoin
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -304,8 +304,8 @@ func convertArgWithManyQueryParamsClientResponse(in *clientsBarBar.BarResponse) 
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -300,12 +300,12 @@ func convertArgWithManyQueryParamsClientResponse(in *clientsBarBar.BarResponse) 
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -252,8 +252,8 @@ func convertArgWithNestedQueryParamsClientResponse(in *clientsBarBar.BarResponse
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -248,12 +248,12 @@ func convertArgWithNestedQueryParamsClientResponse(in *clientsBarBar.BarResponse
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -168,12 +168,12 @@ func convertArgWithParamsClientResponse(in *clientsBarBar.BarResponse) *endpoint
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -172,8 +172,8 @@ func convertArgWithParamsClientResponse(in *clientsBarBar.BarResponse) *endpoint
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -159,12 +159,12 @@ func convertArgWithQueryHeaderClientResponse(in *clientsBarBar.BarResponse) *end
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -163,8 +163,8 @@ func convertArgWithQueryHeaderClientResponse(in *clientsBarBar.BarResponse) *end
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -178,8 +178,8 @@ func convertArgWithQueryParamsClientResponse(in *clientsBarBar.BarResponse) *end
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -174,12 +174,12 @@ func convertArgWithQueryParamsClientResponse(in *clientsBarBar.BarResponse) *end
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -164,12 +164,12 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -168,8 +168,8 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -168,8 +168,8 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -164,12 +164,12 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -197,12 +197,12 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -201,8 +201,8 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -211,8 +211,8 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
 		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
-		for key3, value4 := range in.Foo.FooMap {
-			out.Foo.FooMap[key3] = string(value4)
+		for key1, value2 := range in.Foo.FooMap {
+			out.Foo.FooMap[key1] = string(value2)
 		}
 		if in.Foo.Message != nil {
 			out.Foo.Message = &clientsFooBaseBase.Message{}
@@ -253,8 +253,8 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -211,8 +211,8 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
 		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
-		for key, value := range in.Foo.FooMap {
-			out.Foo.FooMap[key] = string(value)
+		for key3, value4 := range in.Foo.FooMap {
+			out.Foo.FooMap[key3] = string(value4)
 		}
 		if in.Foo.Message != nil {
 			out.Foo.Message = &clientsFooBaseBase.Message{}
@@ -249,12 +249,12 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -230,22 +230,29 @@ func (c *TypeConverter) genConverterForList(
 	valueStruct, isStruct := toFieldType.ValueSpec.(*compile.StructSpec)
 	sourceIdentifier := fromIdentifier
 	checkOverride := false
+
+	sourceListID := ""
+	isOverriddenID := ""
+
 	if overriddenIdentifier != "" {
+		sourceListID = c.makeUniqIdentifier("sourceList")
+		isOverriddenID = c.makeUniqIdentifier("isOverridden")
+
 		// Determine which map (from or overrride) to use
-		c.appendf("sourceList := %s", overriddenIdentifier)
+		c.appendf("%s := %s", sourceListID, overriddenIdentifier)
 		if isStruct {
-			c.appendf("isOverridden := false")
+			c.appendf("%s := false", isOverriddenID)
 		}
 		// TODO(sindelar): Verify how optional thrift lists are defined.
 		c.appendf("if %s != nil {", fromIdentifier)
 
-		c.appendf("\tsourceList = %s", fromIdentifier)
+		c.appendf("\t%s = %s", sourceListID, fromIdentifier)
 		if isStruct {
-			c.append("\tisOverridden = true")
+			c.appendf("\t%s = true", isOverriddenID)
 		}
 		c.append("}")
 
-		sourceIdentifier = "sourceList"
+		sourceIdentifier = sourceListID
 		checkOverride = true
 	}
 
@@ -273,7 +280,7 @@ func (c *TypeConverter) genConverterForList(
 
 		if checkOverride {
 			nestedIndent = "\t" + nestedIndent
-			c.append("\t", "if isOverridden {")
+			c.appendf("\tif %s {", isOverriddenID)
 		}
 		fromFieldType, ok := fromField.Type.(*compile.ListSpec)
 		if !ok {
@@ -384,23 +391,28 @@ func (c *TypeConverter) genConverterForMap(
 	}
 
 	checkOverride := false
+	sourceListID := ""
+	isOverriddenID := ""
 	if overriddenIdentifier != "" {
+		sourceListID = c.makeUniqIdentifier("sourceList")
+		isOverriddenID = c.makeUniqIdentifier("isOverridden")
+
 		// Determine which map (from or overrride) to use
-		c.appendf("sourceList := %s", overriddenIdentifier)
+		c.appendf("%s := %s", sourceListID, overriddenIdentifier)
 
 		if isStruct {
-			c.appendf("isOverridden := false")
+			c.appendf("%s := false", isOverriddenID)
 		}
 		// TODO(sindelar): Verify how optional thrift map are defined.
 		c.appendf("if %s != nil {", fromIdentifier)
 
-		c.appendf("\tsourceList = %s", fromIdentifier)
+		c.appendf("\t%s = %s", sourceListID, fromIdentifier)
 		if isStruct {
-			c.append("\tisOverridden = true")
+			c.appendf("\t%s = true", isOverriddenID)
 		}
 		c.append("}")
 
-		sourceIdentifier = "sourceList"
+		sourceIdentifier = sourceListID
 		checkOverride = true
 	}
 
@@ -428,7 +440,7 @@ func (c *TypeConverter) genConverterForMap(
 
 		if checkOverride {
 			nestedIndent = "\t" + nestedIndent
-			c.append("\t", "if isOverridden {")
+			c.appendf("\tif %s {", isOverriddenID)
 		}
 
 		fromFieldType, ok := fromField.Type.(*compile.MapSpec)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -173,12 +173,12 @@ func convertArgWithHeadersClientResponse(in *clientsBarBar.BarResponse) *endpoin
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -177,8 +177,8 @@ func convertArgWithHeadersClientResponse(in *clientsBarBar.BarResponse) *endpoin
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -304,8 +304,8 @@ func convertArgWithManyQueryParamsClientResponse(in *clientsBarBar.BarResponse) 
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -300,12 +300,12 @@ func convertArgWithManyQueryParamsClientResponse(in *clientsBarBar.BarResponse) 
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -252,8 +252,8 @@ func convertArgWithNestedQueryParamsClientResponse(in *clientsBarBar.BarResponse
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -248,12 +248,12 @@ func convertArgWithNestedQueryParamsClientResponse(in *clientsBarBar.BarResponse
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -168,12 +168,12 @@ func convertArgWithParamsClientResponse(in *clientsBarBar.BarResponse) *endpoint
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -172,8 +172,8 @@ func convertArgWithParamsClientResponse(in *clientsBarBar.BarResponse) *endpoint
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -159,12 +159,12 @@ func convertArgWithQueryHeaderClientResponse(in *clientsBarBar.BarResponse) *end
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -163,8 +163,8 @@ func convertArgWithQueryHeaderClientResponse(in *clientsBarBar.BarResponse) *end
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -178,8 +178,8 @@ func convertArgWithQueryParamsClientResponse(in *clientsBarBar.BarResponse) *end
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -174,12 +174,12 @@ func convertArgWithQueryParamsClientResponse(in *clientsBarBar.BarResponse) *end
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -164,12 +164,12 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -168,8 +168,8 @@ func convertMissingArgClientResponse(in *clientsBarBar.BarResponse) *endpointsBa
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -168,8 +168,8 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -164,12 +164,12 @@ func convertNoRequestClientResponse(in *clientsBarBar.BarResponse) *endpointsBar
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -197,12 +197,12 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -201,8 +201,8 @@ func convertNormalClientResponse(in *clientsBarBar.BarResponse) *endpointsBarBar
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -211,8 +211,8 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
 		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
-		for key3, value4 := range in.Foo.FooMap {
-			out.Foo.FooMap[key3] = string(value4)
+		for key1, value2 := range in.Foo.FooMap {
+			out.Foo.FooMap[key1] = string(value2)
 		}
 		if in.Foo.Message != nil {
 			out.Foo.Message = &clientsFooBaseBase.Message{}
@@ -253,8 +253,8 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key5, value6 := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key5] = int32(value6)
+	for key3, value4 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key3] = int32(value4)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -211,8 +211,8 @@ func convertToTooManyArgsClientRequest(in *endpointsBarBar.Bar_TooManyArgs_Args)
 		out.Foo.FooDouble = (*float64)(in.Foo.FooDouble)
 		out.Foo.FooBool = (*bool)(in.Foo.FooBool)
 		out.Foo.FooMap = make(map[string]string, len(in.Foo.FooMap))
-		for key, value := range in.Foo.FooMap {
-			out.Foo.FooMap[key] = string(value)
+		for key3, value4 := range in.Foo.FooMap {
+			out.Foo.FooMap[key3] = string(value4)
 		}
 		if in.Foo.Message != nil {
 			out.Foo.Message = &clientsFooBaseBase.Message{}
@@ -249,12 +249,12 @@ func convertTooManyArgsClientResponse(in *clientsBarBar.BarResponse) *endpointsB
 	out.IntWithRange = int32(in.IntWithRange)
 	out.IntWithoutRange = int32(in.IntWithoutRange)
 	out.MapIntWithRange = make(map[endpointsBarBar.UUID]int32, len(in.MapIntWithRange))
-	for key, value := range in.MapIntWithRange {
-		out.MapIntWithRange[endpointsBarBar.UUID(key)] = int32(value)
+	for key1, value2 := range in.MapIntWithRange {
+		out.MapIntWithRange[endpointsBarBar.UUID(key1)] = int32(value2)
 	}
 	out.MapIntWithoutRange = make(map[string]int32, len(in.MapIntWithoutRange))
-	for key, value := range in.MapIntWithoutRange {
-		out.MapIntWithoutRange[key] = int32(value)
+	for key5, value6 := range in.MapIntWithoutRange {
+		out.MapIntWithoutRange[key5] = int32(value6)
 	}
 	out.BinaryField = []byte(in.BinaryField)
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ebe6df5ec6d77b526557719d05bc71e5bf58f2b4c0ed3811db0897e3da867efe
-updated: 2017-10-23T10:56:00.946426-07:00
+hash: eeb75db0ca3cb98e99cee83dda58cc3ab8baf80d3a8a898e952e043b4a1829eb
+updated: 2017-11-17T14:24:27.765472993-08:00
 imports:
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
@@ -51,6 +51,8 @@ imports:
   version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
+- name: github.com/sergi/go-diff
+  version: feef008d51ad2b3778f85d387ccf91735543008d
 - name: github.com/stretchr/testify
   version: f6abca593680b2315d2075e0f5e2a9751e3f431a
   subpackages:
@@ -137,7 +139,7 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: aabf50738bcdd9b207582cbe796b59ed65d56680
+  version: 9dfe39835686865bff950a07b394c12a98ddc811
   subpackages:
   - context
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -46,3 +46,5 @@ import:
   version: f6abca593680b2315d2075e0f5e2a9751e3f431a
 - package: github.com/xeipuuv/gojsonschema
   version: 3f523f4c14b6e925da10475eb0447c2f28614aac
+- package: github.com/sergi/go-diff
+  version: feef008d51ad2b3778f85d387ccf91735543008d


### PR DESCRIPTION
We need to make sure all identifiers are unique so that
we dont use the wrong identifier in nested loops.

e.g.

```
for key, value := ... {
  for key, value := ... {
    out.Drivers[key].Vehicles[key] = ...
  }
}
```

The above code uses the shadowed local variable to index
both maps which leads to panic ( nil pointer dereference ).

r: @uber/zanzibar-team