### PR TITLE
runtime/router: add stacktrace for runtime panic

### DIFF
--- a/runtime/router.go
+++ b/runtime/router.go
@@ -141,7 +141,7 @@ func (router *HTTPRouter) handlePanic(
 	if !ok {
 		err = errors.Errorf("http router panic: %v", v)
 	}
-	_, ok = v.(fmt.Formatter)
+	_, ok = err.(fmt.Formatter)
 	if !ok {
 		err = errors.Wrap(err, "wrapped")
 	}

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -22,6 +22,7 @@ package zanzibar
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -139,6 +140,10 @@ func (router *HTTPRouter) handlePanic(
 	err, ok := v.(error)
 	if !ok {
 		err = errors.Errorf("http router panic: %v", v)
+	}
+	_, ok = v.(fmt.Formatter)
+	if !ok {
+		err = errors.Wrap(err, "wrapped")
 	}
 
 	router.gateway.Logger.Error(


### PR DESCRIPTION
When we get a nil pointer panic in a http handler there is no visibility into the stacktrace that caused the panic.

By allocating an `error.Wrap()` error we can print the stack trace for the nilpointer panic.