### PR TITLE
Add default headers from the client config

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -917,6 +917,10 @@ func {{$exportName}}(
 	port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.{{$clientID}}.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.defaultHeaders", &defaultHeaders)
+	}
 
 	return &{{$clientName}}{
 		clientID: "{{$clientID}}",
@@ -929,6 +933,7 @@ func {{$exportName}}(
 				{{end}}
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}
@@ -1133,7 +1138,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 7122, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 7358, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -57,6 +57,10 @@ func {{$exportName}}(
 	port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.{{$clientID}}.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.defaultHeaders", &defaultHeaders)
+	}
 
 	return &{{$clientName}}{
 		clientID: "{{$clientID}}",
@@ -69,6 +73,7 @@ func {{$exportName}}(
 				{{end}}
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -208,6 +208,10 @@ func NewClient(
 	port := deps.Default.Config.MustGetInt("clients.bar.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.bar.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.bar.defaultHeaders") {
+        deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
+    }
 
 	return &barClient{
 		clientID: "bar",
@@ -247,6 +251,7 @@ func NewClient(
 				"EchoTypedef",
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -210,8 +210,8 @@ func NewClient(
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.bar.timeout")) * time.Millisecond
 	defaultHeaders := make(map[string]string)
 	if deps.Default.Config.ContainsKey("clients.bar.defaultHeaders") {
-        deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
-    }
+		deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
+	}
 
 	return &barClient{
 		clientID: "bar",

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -208,6 +208,10 @@ func NewClient(
 	port := deps.Default.Config.MustGetInt("clients.bar.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.bar.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.bar.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
+	}
 
 	return &barClient{
 		clientID: "bar",
@@ -247,6 +251,7 @@ func NewClient(
 				"EchoTypedef",
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -59,6 +59,10 @@ func NewClient(
 	port := deps.Default.Config.MustGetInt("clients.contacts.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.contacts.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.contacts.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("clients.contacts.defaultHeaders", &defaultHeaders)
+	}
 
 	return &contactsClient{
 		clientID: "contacts",
@@ -69,6 +73,7 @@ func NewClient(
 				"SaveContacts",
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -63,6 +63,10 @@ func NewClient(
 	port := deps.Default.Config.MustGetInt("clients.google-now.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)
 	timeout := time.Duration(deps.Default.Config.MustGetInt("clients.google-now.timeout")) * time.Millisecond
+	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("clients.google-now.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("clients.google-now.defaultHeaders", &defaultHeaders)
+	}
 
 	return &googleNowClient{
 		clientID: "google-now",
@@ -74,6 +78,7 @@ func NewClient(
 				"CheckCredentials",
 			},
 			baseURL,
+			defaultHeaders,
 			timeout,
 		),
 	}

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -1,10 +1,10 @@
 {
-	"clients.bar.ip": "127.0.0.1",
-	"clients.bar.port": 4001,
-	"clients.bar.timeout": 10000,
 	"clients.bar.defaultHeaders": {
 		"X-Client-ID": "bar"
 	},
+	"clients.bar.ip": "127.0.0.1",
+	"clients.bar.port": 4001,
+	"clients.bar.timeout": 10000,
 	"clients.baz.ip": "127.0.0.1",
 	"clients.baz.port": 4002,
 	"clients.baz.serviceName": "Qux",

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -2,6 +2,9 @@
 	"clients.bar.ip": "127.0.0.1",
 	"clients.bar.port": 4001,
 	"clients.bar.timeout": 10000,
+	"clients.bar.defaultHeaders": {
+		"X-Client-ID": "bar"
+	},
 	"clients.baz.ip": "127.0.0.1",
 	"clients.baz.port": 4002,
 	"clients.baz.serviceName": "Qux",

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -58,7 +58,7 @@ func NewClientHTTPRequest(
 		client:         client,
 		Logger:         client.loggers[methodName],
 		metrics:        client.metrics[methodName],
-		defaultHeaders: client.Headers,
+		defaultHeaders: client.DefaultHeaders,
 	}
 	req.res = NewClientHTTPResponse(req)
 	req.start()

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -59,6 +59,9 @@ func NewClientHTTPRequest(
 		metrics:    client.metrics[methodName],
 	}
 	req.res = NewClientHTTPResponse(req)
+	for headerKey, headerValue := range client.Headers {
+		req.httpReq.Header.Add(headerKey, headerValue)
+	}
 	req.start()
 	return req
 }

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -62,6 +62,7 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 		"clientID",
 		[]string{"DoStuff"},
 		"/",
+		map[string]string{},
 		time.Second,
 	)
 	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)
@@ -95,6 +96,7 @@ func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 		"clientID",
 		[]string{"DoStuff"},
 		"/",
+		map[string]string{},
 		time.Second,
 	)
 	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -112,7 +112,7 @@ func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 	assert.Len(t, logs["Could not create outbound request"], 1)
 }
 
-func TestMakingClientCalLWithHeaders(t *testing.T) {
+func TestMakingClientCallWithHeaders(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
 		defaultTestConfig,
 		defaultTestOptions,
@@ -130,6 +130,8 @@ func TestMakingClientCalLWithHeaders(t *testing.T) {
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(200)
 			_, _ = w.Write([]byte(r.Header.Get("Example-Header")))
+			// Check that the default header got set and actually sent to the server.
+			assert.Equal(t, r.Header.Get("X-Client-ID"), "bar")
 		},
 	)
 

--- a/runtime/client_http_response_test.go
+++ b/runtime/client_http_response_test.go
@@ -72,6 +72,7 @@ func TestReadAndUnmarshalNonStructBody(t *testing.T) {
 		"bar",
 		[]string{"echo"},
 		baseURL,
+		map[string]string{},
 		time.Second,
 	)
 	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
@@ -127,6 +128,7 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 		"bar",
 		[]string{"echo"},
 		baseURL,
+		map[string]string{},
 		time.Second,
 	)
 	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
@@ -181,6 +183,7 @@ func TestUnknownStatusCode(t *testing.T) {
 		"bar",
 		[]string{"echo"},
 		baseURL,
+		map[string]string{},
 		time.Second,
 	)
 

--- a/runtime/http_client.go
+++ b/runtime/http_client.go
@@ -31,11 +31,11 @@ import (
 
 // HTTPClient defines a http client.
 type HTTPClient struct {
-	Client  *http.Client
-	BaseURL string
-	Headers map[string]string
-	loggers map[string]*zap.Logger
-	metrics map[string]*OutboundHTTPMetrics
+	Client         *http.Client
+	BaseURL        string
+	DefaultHeaders map[string]string
+	loggers        map[string]*zap.Logger
+	metrics        map[string]*OutboundHTTPMetrics
 }
 
 // UnexpectedHTTPError defines an error for HTTP
@@ -80,9 +80,9 @@ func NewHTTPClient(
 			},
 			Timeout: timeout,
 		},
-		BaseURL: baseURL,
-		Headers: defaultHeaders,
-		loggers: loggers,
-		metrics: metrics,
+		BaseURL:        baseURL,
+		DefaultHeaders: defaultHeaders,
+		loggers:        loggers,
+		metrics:        metrics,
 	}
 }

--- a/runtime/http_client.go
+++ b/runtime/http_client.go
@@ -33,6 +33,7 @@ import (
 type HTTPClient struct {
 	Client  *http.Client
 	BaseURL string
+	Headers map[string]string
 	loggers map[string]*zap.Logger
 	metrics map[string]*OutboundHTTPMetrics
 }
@@ -55,6 +56,7 @@ func NewHTTPClient(
 	clientID string,
 	methodNames []string,
 	baseURL string,
+	defaultHeaders map[string]string,
 	timeout time.Duration,
 ) *HTTPClient {
 	loggers := make(map[string]*zap.Logger, len(methodNames))
@@ -79,6 +81,7 @@ func NewHTTPClient(
 			Timeout: timeout,
 		},
 		BaseURL: baseURL,
+		Headers: defaultHeaders,
 		loggers: loggers,
 		metrics: metrics,
 	}

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -206,7 +206,7 @@ func (conf *StaticConfig) MustGetInt(key string) int64 {
 	panic(errors.Errorf("Key (%s) not available", key))
 }
 
-// ContainsKey returns the value as a string or panics.
+// ContainsKey returns true if key is found otherwise false.
 func (conf *StaticConfig) ContainsKey(key string) bool {
 	if conf.destroyed {
 		panic(errors.Errorf("Cannot ContainsKey(%s) because destroyed", key))


### PR DESCRIPTION
Client config can specific a dict of default headers that should be
added to every request from that client.