### PR TITLE
middleware shared state fix up

### DIFF
--- a/examples/example-gateway/middlewares/example/example.go
+++ b/examples/example-gateway/middlewares/example/example.go
@@ -66,14 +66,11 @@ func (m *exampleMiddleware) HandleRequest(
 	res *zanzibar.ServerHTTPResponse,
 	shared zanzibar.SharedState,
 ) bool {
-	err := shared.SetState(
-		m.Name(),
+	shared.SetState(
+		m,
 		MiddlewareState{
 			Baz: m.options.Foo,
 		})
-	if err != nil && m.deps.Default.Logger != nil {
-		m.deps.Default.Logger.Info("Example SharedState Not Set")
-	}
 	return true
 }
 

--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -22,7 +22,6 @@ package zanzibar
 
 import (
 	"context"
-	"errors"
 
 	jsonschema "github.com/mcuadros/go-jsonschema-generator"
 )
@@ -93,12 +92,8 @@ func (s SharedState) GetState(name string) interface{} {
 }
 
 // SetState sets value of a middleware shared state
-func (s SharedState) SetState(name string, state interface{}) error {
-	if _, containsKey := s.middlewareDict[name]; !containsKey {
-		return errors.New("middleware shared state must be keyed by middleware name")
-	}
-	s.middlewareDict[name] = state
-	return nil
+func (s SharedState) SetState(m MiddlewareHandle, state interface{}) {
+	s.middlewareDict[m.Name()] = state
 }
 
 // Handle executes the middlewares in a stack and underlying handler.

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -293,7 +293,7 @@ func TestMiddlewareSharedStates(t *testing.T) {
 }
 
 // Ensures that a middleware can read state from a middeware earlier in the stack.
-func TestMiddlewareSharedStateValidationOnSet(t *testing.T) {
+func TestMiddlewareSharedStateSet(t *testing.T) {
 	ex := example.NewMiddleware(
 		nil, // *zanzibar.Gateway
 		nil,
@@ -315,12 +315,8 @@ func TestMiddlewareSharedStateValidationOnSet(t *testing.T) {
 
 	ss := zanzibar.NewSharedState(middles)
 
-	err := ss.SetState("example", "foo")
-	assert.NoError(t, err)
+	ss.SetState(ex, "foo")
 	assert.Equal(t, ss.GetState("example").(string), "foo")
-
-	err = ss.SetState("NoSuchMiddleware", "foo")
-	assert.Error(t, err)
 }
 
 func noopHandlerFn(ctx context.Context,


### PR DESCRIPTION
removes the need to error check SetState  by changing the method signature to one which does not require validation