### PR TITLE
validate exceptions

### DIFF
--- a/codegen/service.go
+++ b/codegen/service.go
@@ -216,9 +216,6 @@ func (ms *ModuleSpec) SetDownstream(
 	}
 
 	// Exception validation
-	if len(method.ExceptionsIndex) < len(method.DownstreamMethod.ExceptionsIndex) {
-		return errors.New("Endpoint should surface all client exceptions")
-	}
 	for en := range method.DownstreamMethod.ExceptionsIndex {
 		if _, ok := method.ExceptionsIndex[en]; !ok {
 			return fmt.Errorf("Missing exception %s in Endpoint schema", en)

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -21,6 +21,7 @@
 package codegen
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -212,6 +213,16 @@ func (ms *ModuleSpec) SetDownstream(
 
 	if err != nil {
 		return err
+	}
+
+	// Exception validation
+	if len(method.ExceptionsIndex) < len(method.DownstreamMethod.ExceptionsIndex) {
+		return errors.New("Endpoint should surface all client exceptions")
+	}
+	for en := range method.DownstreamMethod.ExceptionsIndex {
+		if _, ok := method.ExceptionsIndex[en]; !ok {
+			return fmt.Errorf("Missing exception %s in Endpoint schema", en)
+		}
 	}
 
 	// If this is an endpoint then a downstream will be defined.


### PR DESCRIPTION
this PR address the error cases for exceptions

we require client exceptions to be surfaced to endpoint with exactly name 1:1 mapping, fail to do so will silent fail on template generating with something like this:

```
func convertGetReferralCodeInfoInvalidParameters(
	clientError *codeUberInternalGrowthReferralsReferrals.InvalidParametersException,
) * {
	// TODO: Add error fields mapping here.
	serverError := &{}
	return serverError
}
```

more todos around exceptions:

[] one status code maps multiple exceptions