### PR TITLE
Remove the global gateway param from constructors

### DIFF
--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -55,10 +55,7 @@ type {{$handlerName}} struct {
 }
 
 // New{{$handlerName}} creates a handler
-func New{{$handlerName}}(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *{{$handlerName}} {
+func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 	handler := &{{$handlerName}}{
 		Clients: deps.Client,
 	}
@@ -69,7 +66,6 @@ func New{{$handlerName}}(
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{
 			{{range $idx, $middleware := $middlewares -}}
 			deps.Middleware.{{$middleware.Name | pascal}}.NewMiddlewareHandle(
-				g,
 				{{$middleware.Name}}.Options{
 				{{range $key, $value := $middleware.PrettyOptions -}}
 					{{$key}} : {{$value}},

--- a/codegen/templates/endpoint_collection.tmpl
+++ b/codegen/templates/endpoint_collection.tmpl
@@ -15,12 +15,12 @@ type Endpoint interface{
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
 		{{- range $idx, $meta := $endpointMeta }}
 		{{$serviceMethod := printf "%s%s" (title .Method.ThriftService) (title .Method.Name) -}}
 		{{$handlerName := printf "%sHandler"  $serviceMethod -}}
-		{{$handlerName}}: New{{$handlerName}}(g, deps),
+		{{$handlerName}}: New{{$handlerName}}(deps),
 		{{- end}}
 	}
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -49,10 +49,7 @@ type {{$clientName}} struct {
 }
 
 // {{$exportName}} returns a new http client.
-func {{$exportName}}(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func {{$exportName}}(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/codegen/templates/middleware.tmpl
+++ b/codegen/templates/middleware.tmpl
@@ -14,15 +14,15 @@ type Middleware struct {
 }
 
 // NewMiddleware is a factory method for the struct
-func NewMiddleware(g *zanzibar.Gateway, deps *module.Dependencies) Middleware {
+func NewMiddleware(deps *module.Dependencies) Middleware {
 	return Middleware {
 		Deps: deps,
 	}
 }
 
 // NewMiddlewareHandle calls back to the custom middleware to build a MiddlewareHandle
-func (m *Middleware) NewMiddlewareHandle(g *zanzibar.Gateway, o handle.Options) zanzibar.MiddlewareHandle {
-	return handle.NewMiddleware(g, m.Deps, o)
+func (m *Middleware) NewMiddlewareHandle(o handle.Options) zanzibar.MiddlewareHandle {
+	return handle.NewMiddleware(m.Deps, o)
 }
 
 

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -50,7 +50,7 @@ func InitializeDependencies(
 	tree.{{$className | title}} = initialized{{$className | pascal}}Dependencies
 
 	{{- range $idx, $dependency := $moduleInstances}}
-	initialized{{$className | pascal}}Dependencies.{{$dependency.PackageInfo.QualifiedInstanceName}} = {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportName}}(g, &{{$dependency.PackageInfo.ModulePackageAlias}}.Dependencies{
+	initialized{{$className | pascal}}Dependencies.{{$dependency.PackageInfo.QualifiedInstanceName}} = {{$dependency.PackageInfo.ImportPackageAlias}}.{{$dependency.PackageInfo.ExportName}}(&{{$dependency.PackageInfo.ModulePackageAlias}}.Dependencies{
 		Default: initializedDefaultDependencies,
 		{{- range $className, $moduleInstances := $dependency.ResolvedDependencies}}
 		{{$className | pascal}}: &{{$dependency.PackageInfo.ModulePackageAlias}}.{{$className | pascal}}Dependencies{

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -45,10 +45,7 @@ type Client interface {
 }
 
 // NewClient returns a new TChannel client for service {{$clientID}}.
-func {{$exportName}}(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func {{$exportName}}(deps *module.Dependencies) Client {
 	{{- /* this is the service discovery service name */}}
 	serviceName := deps.Default.Config.MustGetString("clients.{{$clientID}}.serviceName")
 	var routingKey string

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -24,10 +24,7 @@ import (
 {{$genCodePkg := .Method.GenCodePkgName -}}
 {{with .Method -}}
 // New{{$handlerName}} creates a handler to be registered with a thrift server.
-func New{{$handlerName}}(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *{{$handlerName}} {
+func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 	handler := &{{$handlerName}}{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/clients/bar.gogen
+++ b/codegen/test_data/clients/bar.gogen
@@ -200,10 +200,7 @@ type barClient struct {
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.bar.ip")
 	port := deps.Default.Config.MustGetInt("clients.bar.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -42,10 +42,7 @@ type BarArgNotStructHandler struct {
 }
 
 // NewBarArgNotStructHandler creates a handler
-func NewBarArgNotStructHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgNotStructHandler {
+func NewBarArgNotStructHandler(deps *module.Dependencies) *BarArgNotStructHandler {
 	handler := &BarArgNotStructHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -43,10 +43,7 @@ type BarArgWithHeadersHandler struct {
 }
 
 // NewBarArgWithHeadersHandler creates a handler
-func NewBarArgWithHeadersHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithHeadersHandler {
+func NewBarArgWithHeadersHandler(deps *module.Dependencies) *BarArgWithHeadersHandler {
 	handler := &BarArgWithHeadersHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -43,10 +43,7 @@ type BarArgWithManyQueryParamsHandler struct {
 }
 
 // NewBarArgWithManyQueryParamsHandler creates a handler
-func NewBarArgWithManyQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithManyQueryParamsHandler {
+func NewBarArgWithManyQueryParamsHandler(deps *module.Dependencies) *BarArgWithManyQueryParamsHandler {
 	handler := &BarArgWithManyQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -43,10 +43,7 @@ type BarArgWithNestedQueryParamsHandler struct {
 }
 
 // NewBarArgWithNestedQueryParamsHandler creates a handler
-func NewBarArgWithNestedQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithNestedQueryParamsHandler {
+func NewBarArgWithNestedQueryParamsHandler(deps *module.Dependencies) *BarArgWithNestedQueryParamsHandler {
 	handler := &BarArgWithNestedQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -42,10 +42,7 @@ type BarArgWithParamsHandler struct {
 }
 
 // NewBarArgWithParamsHandler creates a handler
-func NewBarArgWithParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithParamsHandler {
+func NewBarArgWithParamsHandler(deps *module.Dependencies) *BarArgWithParamsHandler {
 	handler := &BarArgWithParamsHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -43,10 +43,7 @@ type BarArgWithQueryHeaderHandler struct {
 }
 
 // NewBarArgWithQueryHeaderHandler creates a handler
-func NewBarArgWithQueryHeaderHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithQueryHeaderHandler {
+func NewBarArgWithQueryHeaderHandler(deps *module.Dependencies) *BarArgWithQueryHeaderHandler {
 	handler := &BarArgWithQueryHeaderHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -43,10 +43,7 @@ type BarArgWithQueryParamsHandler struct {
 }
 
 // NewBarArgWithQueryParamsHandler creates a handler
-func NewBarArgWithQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithQueryParamsHandler {
+func NewBarArgWithQueryParamsHandler(deps *module.Dependencies) *BarArgWithQueryParamsHandler {
 	handler := &BarArgWithQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
@@ -43,10 +43,7 @@ type BarHelloWorldHandler struct {
 }
 
 // NewBarHelloWorldHandler creates a handler
-func NewBarHelloWorldHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarHelloWorldHandler {
+func NewBarHelloWorldHandler(deps *module.Dependencies) *BarHelloWorldHandler {
 	handler := &BarHelloWorldHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -42,10 +42,7 @@ type BarMissingArgHandler struct {
 }
 
 // NewBarMissingArgHandler creates a handler
-func NewBarMissingArgHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarMissingArgHandler {
+func NewBarMissingArgHandler(deps *module.Dependencies) *BarMissingArgHandler {
 	handler := &BarMissingArgHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -42,10 +42,7 @@ type BarNoRequestHandler struct {
 }
 
 // NewBarNoRequestHandler creates a handler
-func NewBarNoRequestHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarNoRequestHandler {
+func NewBarNoRequestHandler(deps *module.Dependencies) *BarNoRequestHandler {
 	handler := &BarNoRequestHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -44,10 +44,7 @@ type BarNormalHandler struct {
 }
 
 // NewBarNormalHandler creates a handler
-func NewBarNormalHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarNormalHandler {
+func NewBarNormalHandler(deps *module.Dependencies) *BarNormalHandler {
 	handler := &BarNormalHandler{
 		Clients: deps.Client,
 	}
@@ -56,7 +53,6 @@ func NewBarNormalHandler(
 		"bar", "normal",
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{
 			deps.Middleware.Example.NewMiddlewareHandle(
-				g,
 				example.Options{
 					Baz: []string{"foo", "bar"},
 					Foo: "test",

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -45,10 +45,7 @@ type BarTooManyArgsHandler struct {
 }
 
 // NewBarTooManyArgsHandler creates a handler
-func NewBarTooManyArgsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarTooManyArgsHandler {
+func NewBarTooManyArgsHandler(deps *module.Dependencies) *BarTooManyArgsHandler {
 	handler := &BarTooManyArgsHandler{
 		Clients: deps.Client,
 	}

--- a/codegen/test_data/endpoints/endpoint.gogen
+++ b/codegen/test_data/endpoints/endpoint.gogen
@@ -35,20 +35,20 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		BarArgNotStructHandler:             NewBarArgNotStructHandler(g, deps),
-		BarArgWithHeadersHandler:           NewBarArgWithHeadersHandler(g, deps),
-		BarArgWithQueryParamsHandler:       NewBarArgWithQueryParamsHandler(g, deps),
-		BarArgWithNestedQueryParamsHandler: NewBarArgWithNestedQueryParamsHandler(g, deps),
-		BarArgWithQueryHeaderHandler:       NewBarArgWithQueryHeaderHandler(g, deps),
-		BarArgWithParamsHandler:            NewBarArgWithParamsHandler(g, deps),
-		BarArgWithManyQueryParamsHandler:   NewBarArgWithManyQueryParamsHandler(g, deps),
-		BarMissingArgHandler:               NewBarMissingArgHandler(g, deps),
-		BarNoRequestHandler:                NewBarNoRequestHandler(g, deps),
-		BarNormalHandler:                   NewBarNormalHandler(g, deps),
-		BarTooManyArgsHandler:              NewBarTooManyArgsHandler(g, deps),
-		BarHelloWorldHandler:               NewBarHelloWorldHandler(g, deps),
+		BarArgNotStructHandler:             NewBarArgNotStructHandler(deps),
+		BarArgWithHeadersHandler:           NewBarArgWithHeadersHandler(deps),
+		BarArgWithQueryParamsHandler:       NewBarArgWithQueryParamsHandler(deps),
+		BarArgWithNestedQueryParamsHandler: NewBarArgWithNestedQueryParamsHandler(deps),
+		BarArgWithQueryHeaderHandler:       NewBarArgWithQueryHeaderHandler(deps),
+		BarArgWithParamsHandler:            NewBarArgWithParamsHandler(deps),
+		BarArgWithManyQueryParamsHandler:   NewBarArgWithManyQueryParamsHandler(deps),
+		BarMissingArgHandler:               NewBarMissingArgHandler(deps),
+		BarNoRequestHandler:                NewBarNoRequestHandler(deps),
+		BarNormalHandler:                   NewBarNormalHandler(deps),
+		BarTooManyArgsHandler:              NewBarTooManyArgsHandler(deps),
+		BarHelloWorldHandler:               NewBarHelloWorldHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -200,10 +200,7 @@ type barClient struct {
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.bar.ip")
 	port := deps.Default.Config.MustGetInt("clients.bar.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -158,10 +158,7 @@ type Client interface {
 }
 
 // NewClient returns a new TChannel client for service baz.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	serviceName := deps.Default.Config.MustGetString("clients.baz.serviceName")
 	var routingKey string
 	if deps.Default.Config.ContainsKey("clients.baz.routingKey") {

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -55,10 +55,7 @@ type contactsClient struct {
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.contacts.ip")
 	port := deps.Default.Config.MustGetInt("clients.contacts.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -48,10 +48,7 @@ type Client interface {
 }
 
 // NewClient returns a new TChannel client for service corge.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	serviceName := deps.Default.Config.MustGetString("clients.corge.serviceName")
 	var routingKey string
 	if deps.Default.Config.ContainsKey("clients.corge.routingKey") {

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -55,10 +55,7 @@ type googleNowClient struct {
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.google-now.ip")
 	port := deps.Default.Config.MustGetInt("clients.google-now.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -53,10 +53,7 @@ type multiClient struct {
 }
 
 // NewClient returns a new http client.
-func NewClient(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) Client {
+func NewClient(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.multi.ip")
 	port := deps.Default.Config.MustGetInt("clients.multi.port")
 	baseURL := fmt.Sprintf("http://%s:%d", ip, port)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -42,10 +42,7 @@ type BarArgNotStructHandler struct {
 }
 
 // NewBarArgNotStructHandler creates a handler
-func NewBarArgNotStructHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgNotStructHandler {
+func NewBarArgNotStructHandler(deps *module.Dependencies) *BarArgNotStructHandler {
 	handler := &BarArgNotStructHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -43,10 +43,7 @@ type BarArgWithHeadersHandler struct {
 }
 
 // NewBarArgWithHeadersHandler creates a handler
-func NewBarArgWithHeadersHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithHeadersHandler {
+func NewBarArgWithHeadersHandler(deps *module.Dependencies) *BarArgWithHeadersHandler {
 	handler := &BarArgWithHeadersHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -43,10 +43,7 @@ type BarArgWithManyQueryParamsHandler struct {
 }
 
 // NewBarArgWithManyQueryParamsHandler creates a handler
-func NewBarArgWithManyQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithManyQueryParamsHandler {
+func NewBarArgWithManyQueryParamsHandler(deps *module.Dependencies) *BarArgWithManyQueryParamsHandler {
 	handler := &BarArgWithManyQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -43,10 +43,7 @@ type BarArgWithNestedQueryParamsHandler struct {
 }
 
 // NewBarArgWithNestedQueryParamsHandler creates a handler
-func NewBarArgWithNestedQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithNestedQueryParamsHandler {
+func NewBarArgWithNestedQueryParamsHandler(deps *module.Dependencies) *BarArgWithNestedQueryParamsHandler {
 	handler := &BarArgWithNestedQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -42,10 +42,7 @@ type BarArgWithParamsHandler struct {
 }
 
 // NewBarArgWithParamsHandler creates a handler
-func NewBarArgWithParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithParamsHandler {
+func NewBarArgWithParamsHandler(deps *module.Dependencies) *BarArgWithParamsHandler {
 	handler := &BarArgWithParamsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -43,10 +43,7 @@ type BarArgWithQueryHeaderHandler struct {
 }
 
 // NewBarArgWithQueryHeaderHandler creates a handler
-func NewBarArgWithQueryHeaderHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithQueryHeaderHandler {
+func NewBarArgWithQueryHeaderHandler(deps *module.Dependencies) *BarArgWithQueryHeaderHandler {
 	handler := &BarArgWithQueryHeaderHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -43,10 +43,7 @@ type BarArgWithQueryParamsHandler struct {
 }
 
 // NewBarArgWithQueryParamsHandler creates a handler
-func NewBarArgWithQueryParamsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarArgWithQueryParamsHandler {
+func NewBarArgWithQueryParamsHandler(deps *module.Dependencies) *BarArgWithQueryParamsHandler {
 	handler := &BarArgWithQueryParamsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -43,10 +43,7 @@ type BarHelloWorldHandler struct {
 }
 
 // NewBarHelloWorldHandler creates a handler
-func NewBarHelloWorldHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarHelloWorldHandler {
+func NewBarHelloWorldHandler(deps *module.Dependencies) *BarHelloWorldHandler {
 	handler := &BarHelloWorldHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -42,10 +42,7 @@ type BarMissingArgHandler struct {
 }
 
 // NewBarMissingArgHandler creates a handler
-func NewBarMissingArgHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarMissingArgHandler {
+func NewBarMissingArgHandler(deps *module.Dependencies) *BarMissingArgHandler {
 	handler := &BarMissingArgHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -42,10 +42,7 @@ type BarNoRequestHandler struct {
 }
 
 // NewBarNoRequestHandler creates a handler
-func NewBarNoRequestHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarNoRequestHandler {
+func NewBarNoRequestHandler(deps *module.Dependencies) *BarNoRequestHandler {
 	handler := &BarNoRequestHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -44,10 +44,7 @@ type BarNormalHandler struct {
 }
 
 // NewBarNormalHandler creates a handler
-func NewBarNormalHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarNormalHandler {
+func NewBarNormalHandler(deps *module.Dependencies) *BarNormalHandler {
 	handler := &BarNormalHandler{
 		Clients: deps.Client,
 	}
@@ -56,7 +53,6 @@ func NewBarNormalHandler(
 		"bar", "normal",
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{
 			deps.Middleware.Example.NewMiddlewareHandle(
-				g,
 				example.Options{
 					Baz: []string{"foo", "bar"},
 					Foo: "test",

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -45,10 +45,7 @@ type BarTooManyArgsHandler struct {
 }
 
 // NewBarTooManyArgsHandler creates a handler
-func NewBarTooManyArgsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *BarTooManyArgsHandler {
+func NewBarTooManyArgsHandler(deps *module.Dependencies) *BarTooManyArgsHandler {
 	handler := &BarTooManyArgsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/bar/endpoint.go
+++ b/examples/example-gateway/build/endpoints/bar/endpoint.go
@@ -35,20 +35,20 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		BarArgNotStructHandler:             NewBarArgNotStructHandler(g, deps),
-		BarArgWithHeadersHandler:           NewBarArgWithHeadersHandler(g, deps),
-		BarArgWithQueryParamsHandler:       NewBarArgWithQueryParamsHandler(g, deps),
-		BarArgWithNestedQueryParamsHandler: NewBarArgWithNestedQueryParamsHandler(g, deps),
-		BarArgWithQueryHeaderHandler:       NewBarArgWithQueryHeaderHandler(g, deps),
-		BarArgWithParamsHandler:            NewBarArgWithParamsHandler(g, deps),
-		BarArgWithManyQueryParamsHandler:   NewBarArgWithManyQueryParamsHandler(g, deps),
-		BarMissingArgHandler:               NewBarMissingArgHandler(g, deps),
-		BarNoRequestHandler:                NewBarNoRequestHandler(g, deps),
-		BarNormalHandler:                   NewBarNormalHandler(g, deps),
-		BarTooManyArgsHandler:              NewBarTooManyArgsHandler(g, deps),
-		BarHelloWorldHandler:               NewBarHelloWorldHandler(g, deps),
+		BarArgNotStructHandler:             NewBarArgNotStructHandler(deps),
+		BarArgWithHeadersHandler:           NewBarArgWithHeadersHandler(deps),
+		BarArgWithQueryParamsHandler:       NewBarArgWithQueryParamsHandler(deps),
+		BarArgWithNestedQueryParamsHandler: NewBarArgWithNestedQueryParamsHandler(deps),
+		BarArgWithQueryHeaderHandler:       NewBarArgWithQueryHeaderHandler(deps),
+		BarArgWithParamsHandler:            NewBarArgWithParamsHandler(deps),
+		BarArgWithManyQueryParamsHandler:   NewBarArgWithManyQueryParamsHandler(deps),
+		BarMissingArgHandler:               NewBarMissingArgHandler(deps),
+		BarNoRequestHandler:                NewBarNoRequestHandler(deps),
+		BarNormalHandler:                   NewBarNormalHandler(deps),
+		BarTooManyArgsHandler:              NewBarTooManyArgsHandler(deps),
+		BarHelloWorldHandler:               NewBarHelloWorldHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -42,10 +42,7 @@ type SimpleServiceCallHandler struct {
 }
 
 // NewSimpleServiceCallHandler creates a handler
-func NewSimpleServiceCallHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServiceCallHandler {
+func NewSimpleServiceCallHandler(deps *module.Dependencies) *SimpleServiceCallHandler {
 	handler := &SimpleServiceCallHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -43,10 +43,7 @@ type SimpleServiceCompareHandler struct {
 }
 
 // NewSimpleServiceCompareHandler creates a handler
-func NewSimpleServiceCompareHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServiceCompareHandler {
+func NewSimpleServiceCompareHandler(deps *module.Dependencies) *SimpleServiceCompareHandler {
 	handler := &SimpleServiceCompareHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -42,10 +42,7 @@ type SimpleServicePingHandler struct {
 }
 
 // NewSimpleServicePingHandler creates a handler
-func NewSimpleServicePingHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServicePingHandler {
+func NewSimpleServicePingHandler(deps *module.Dependencies) *SimpleServicePingHandler {
 	handler := &SimpleServicePingHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -43,10 +43,7 @@ type SimpleServiceSillyNoopHandler struct {
 }
 
 // NewSimpleServiceSillyNoopHandler creates a handler
-func NewSimpleServiceSillyNoopHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServiceSillyNoopHandler {
+func NewSimpleServiceSillyNoopHandler(deps *module.Dependencies) *SimpleServiceSillyNoopHandler {
 	handler := &SimpleServiceSillyNoopHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -43,10 +43,7 @@ type SimpleServiceTransHandler struct {
 }
 
 // NewSimpleServiceTransHandler creates a handler
-func NewSimpleServiceTransHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServiceTransHandler {
+func NewSimpleServiceTransHandler(deps *module.Dependencies) *SimpleServiceTransHandler {
 	handler := &SimpleServiceTransHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/baz/endpoint.go
+++ b/examples/example-gateway/build/endpoints/baz/endpoint.go
@@ -35,13 +35,13 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		SimpleServiceCallHandler:      NewSimpleServiceCallHandler(g, deps),
-		SimpleServiceCompareHandler:   NewSimpleServiceCompareHandler(g, deps),
-		SimpleServicePingHandler:      NewSimpleServicePingHandler(g, deps),
-		SimpleServiceSillyNoopHandler: NewSimpleServiceSillyNoopHandler(g, deps),
-		SimpleServiceTransHandler:     NewSimpleServiceTransHandler(g, deps),
+		SimpleServiceCallHandler:      NewSimpleServiceCallHandler(deps),
+		SimpleServiceCompareHandler:   NewSimpleServiceCompareHandler(deps),
+		SimpleServicePingHandler:      NewSimpleServicePingHandler(deps),
+		SimpleServiceSillyNoopHandler: NewSimpleServiceSillyNoopHandler(deps),
+		SimpleServiceTransHandler:     NewSimpleServiceTransHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -42,10 +42,7 @@ type ContactsSaveContactsHandler struct {
 }
 
 // NewContactsSaveContactsHandler creates a handler
-func NewContactsSaveContactsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *ContactsSaveContactsHandler {
+func NewContactsSaveContactsHandler(deps *module.Dependencies) *ContactsSaveContactsHandler {
 	handler := &ContactsSaveContactsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/contacts/endpoint.go
+++ b/examples/example-gateway/build/endpoints/contacts/endpoint.go
@@ -35,9 +35,9 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		ContactsSaveContactsHandler: NewContactsSaveContactsHandler(g, deps),
+		ContactsSaveContactsHandler: NewContactsSaveContactsHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/googlenow/endpoint.go
+++ b/examples/example-gateway/build/endpoints/googlenow/endpoint.go
@@ -35,10 +35,10 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		GoogleNowAddCredentialsHandler:   NewGoogleNowAddCredentialsHandler(g, deps),
-		GoogleNowCheckCredentialsHandler: NewGoogleNowCheckCredentialsHandler(g, deps),
+		GoogleNowAddCredentialsHandler:   NewGoogleNowAddCredentialsHandler(deps),
+		GoogleNowCheckCredentialsHandler: NewGoogleNowCheckCredentialsHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -42,10 +42,7 @@ type GoogleNowAddCredentialsHandler struct {
 }
 
 // NewGoogleNowAddCredentialsHandler creates a handler
-func NewGoogleNowAddCredentialsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *GoogleNowAddCredentialsHandler {
+func NewGoogleNowAddCredentialsHandler(deps *module.Dependencies) *GoogleNowAddCredentialsHandler {
 	handler := &GoogleNowAddCredentialsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -39,10 +39,7 @@ type GoogleNowCheckCredentialsHandler struct {
 }
 
 // NewGoogleNowCheckCredentialsHandler creates a handler
-func NewGoogleNowCheckCredentialsHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *GoogleNowCheckCredentialsHandler {
+func NewGoogleNowCheckCredentialsHandler(deps *module.Dependencies) *GoogleNowCheckCredentialsHandler {
 	handler := &GoogleNowCheckCredentialsHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/multi/endpoint.go
+++ b/examples/example-gateway/build/endpoints/multi/endpoint.go
@@ -35,10 +35,10 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		ServiceAFrontHelloHandler: NewServiceAFrontHelloHandler(g, deps),
-		ServiceBFrontHelloHandler: NewServiceBFrontHelloHandler(g, deps),
+		ServiceAFrontHelloHandler: NewServiceAFrontHelloHandler(deps),
+		ServiceBFrontHelloHandler: NewServiceBFrontHelloHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -40,10 +40,7 @@ type ServiceAFrontHelloHandler struct {
 }
 
 // NewServiceAFrontHelloHandler creates a handler
-func NewServiceAFrontHelloHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *ServiceAFrontHelloHandler {
+func NewServiceAFrontHelloHandler(deps *module.Dependencies) *ServiceAFrontHelloHandler {
 	handler := &ServiceAFrontHelloHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -40,10 +40,7 @@ type ServiceBFrontHelloHandler struct {
 }
 
 // NewServiceBFrontHelloHandler creates a handler
-func NewServiceBFrontHelloHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *ServiceBFrontHelloHandler {
+func NewServiceBFrontHelloHandler(deps *module.Dependencies) *ServiceBFrontHelloHandler {
 	handler := &ServiceBFrontHelloHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -37,10 +37,7 @@ import (
 )
 
 // NewSimpleServiceCallHandler creates a handler to be registered with a thrift server.
-func NewSimpleServiceCallHandler(
-	g *zanzibar.Gateway,
-	deps *module.Dependencies,
-) *SimpleServiceCallHandler {
+func NewSimpleServiceCallHandler(deps *module.Dependencies) *SimpleServiceCallHandler {
 	handler := &SimpleServiceCallHandler{
 		Clients: deps.Client,
 	}

--- a/examples/example-gateway/build/endpoints/tchannel/baz/endpoint.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/endpoint.go
@@ -35,9 +35,9 @@ type Endpoint interface {
 
 // NewEndpoint returns a collection of endpoints that can be registered on
 // a gateway
-func NewEndpoint(g *zanzibar.Gateway, deps *module.Dependencies) Endpoint {
+func NewEndpoint(deps *module.Dependencies) Endpoint {
 	return &EndpointHandlers{
-		SimpleServiceCallHandler: NewSimpleServiceCallHandler(g, deps),
+		SimpleServiceCallHandler: NewSimpleServiceCallHandler(deps),
 	}
 }
 

--- a/examples/example-gateway/build/middlewares/example/example.go
+++ b/examples/example-gateway/build/middlewares/example/example.go
@@ -35,13 +35,13 @@ type Middleware struct {
 }
 
 // NewMiddleware is a factory method for the struct
-func NewMiddleware(g *zanzibar.Gateway, deps *module.Dependencies) Middleware {
+func NewMiddleware(deps *module.Dependencies) Middleware {
 	return Middleware{
 		Deps: deps,
 	}
 }
 
 // NewMiddlewareHandle calls back to the custom middleware to build a MiddlewareHandle
-func (m *Middleware) NewMiddlewareHandle(g *zanzibar.Gateway, o handle.Options) zanzibar.MiddlewareHandle {
-	return handle.NewMiddleware(g, m.Deps, o)
+func (m *Middleware) NewMiddlewareHandle(o handle.Options) zanzibar.MiddlewareHandle {
+	return handle.NewMiddleware(m.Deps, o)
 }

--- a/examples/example-gateway/build/middlewares/example_reader/example_reader.go
+++ b/examples/example-gateway/build/middlewares/example_reader/example_reader.go
@@ -35,13 +35,13 @@ type Middleware struct {
 }
 
 // NewMiddleware is a factory method for the struct
-func NewMiddleware(g *zanzibar.Gateway, deps *module.Dependencies) Middleware {
+func NewMiddleware(deps *module.Dependencies) Middleware {
 	return Middleware{
 		Deps: deps,
 	}
 }
 
 // NewMiddlewareHandle calls back to the custom middleware to build a MiddlewareHandle
-func (m *Middleware) NewMiddlewareHandle(g *zanzibar.Gateway, o handle.Options) zanzibar.MiddlewareHandle {
-	return handle.NewMiddleware(g, m.Deps, o)
+func (m *Middleware) NewMiddlewareHandle(o handle.Options) zanzibar.MiddlewareHandle {
+	return handle.NewMiddleware(m.Deps, o)
 }

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -99,25 +99,25 @@ func InitializeDependencies(
 
 	initializedClientDependencies := &ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Bar = barClientGenerated.NewClient(g, &barClientModule.Dependencies{
+	initializedClientDependencies.Bar = barClientGenerated.NewClient(&barClientModule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Baz = bazClientGenerated.NewClient(g, &bazClientModule.Dependencies{
+	initializedClientDependencies.Baz = bazClientGenerated.NewClient(&bazClientModule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Contacts = contactsClientGenerated.NewClient(g, &contactsClientModule.Dependencies{
+	initializedClientDependencies.Contacts = contactsClientGenerated.NewClient(&contactsClientModule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.GoogleNow = googlenowClientGenerated.NewClient(g, &googlenowClientModule.Dependencies{
+	initializedClientDependencies.GoogleNow = googlenowClientGenerated.NewClient(&googlenowClientModule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Multi = multiClientGenerated.NewClient(g, &multiClientModule.Dependencies{
+	initializedClientDependencies.Multi = multiClientGenerated.NewClient(&multiClientModule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
 
 	initializedMiddlewareDependencies := &MiddlewareDependenciesNodes{}
 	tree.Middleware = initializedMiddlewareDependencies
-	initializedMiddlewareDependencies.Example = exampleMiddlewareGenerated.NewMiddleware(g, &exampleMiddlewareModule.Dependencies{
+	initializedMiddlewareDependencies.Example = exampleMiddlewareGenerated.NewMiddleware(&exampleMiddlewareModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &exampleMiddlewareModule.ClientDependencies{
 			Baz: initializedClientDependencies.Baz,
@@ -126,7 +126,7 @@ func InitializeDependencies(
 
 	initializedEndpointDependencies := &EndpointDependenciesNodes{}
 	tree.Endpoint = initializedEndpointDependencies
-	initializedEndpointDependencies.Bar = barEndpointGenerated.NewEndpoint(g, &barEndpointModule.Dependencies{
+	initializedEndpointDependencies.Bar = barEndpointGenerated.NewEndpoint(&barEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &barEndpointModule.ClientDependencies{
 			Bar: initializedClientDependencies.Bar,
@@ -135,31 +135,31 @@ func InitializeDependencies(
 			Example: initializedMiddlewareDependencies.Example,
 		},
 	})
-	initializedEndpointDependencies.Baz = bazEndpointGenerated.NewEndpoint(g, &bazEndpointModule.Dependencies{
+	initializedEndpointDependencies.Baz = bazEndpointGenerated.NewEndpoint(&bazEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &bazEndpointModule.ClientDependencies{
 			Baz: initializedClientDependencies.Baz,
 		},
 	})
-	initializedEndpointDependencies.BazTChannel = baztchannelEndpointGenerated.NewEndpoint(g, &baztchannelEndpointModule.Dependencies{
+	initializedEndpointDependencies.BazTChannel = baztchannelEndpointGenerated.NewEndpoint(&baztchannelEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &baztchannelEndpointModule.ClientDependencies{
 			Baz: initializedClientDependencies.Baz,
 		},
 	})
-	initializedEndpointDependencies.Contacts = contactsEndpointGenerated.NewEndpoint(g, &contactsEndpointModule.Dependencies{
+	initializedEndpointDependencies.Contacts = contactsEndpointGenerated.NewEndpoint(&contactsEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &contactsEndpointModule.ClientDependencies{
 			Contacts: initializedClientDependencies.Contacts,
 		},
 	})
-	initializedEndpointDependencies.Googlenow = googlenowEndpointGenerated.NewEndpoint(g, &googlenowEndpointModule.Dependencies{
+	initializedEndpointDependencies.Googlenow = googlenowEndpointGenerated.NewEndpoint(&googlenowEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &googlenowEndpointModule.ClientDependencies{
 			GoogleNow: initializedClientDependencies.GoogleNow,
 		},
 	})
-	initializedEndpointDependencies.Multi = multiEndpointGenerated.NewEndpoint(g, &multiEndpointModule.Dependencies{
+	initializedEndpointDependencies.Multi = multiEndpointGenerated.NewEndpoint(&multiEndpointModule.Dependencies{
 		Default: initializedDefaultDependencies,
 		Client: &multiEndpointModule.ClientDependencies{
 			Multi: initializedClientDependencies.Multi,

--- a/examples/example-gateway/middlewares/example/example.go
+++ b/examples/example-gateway/middlewares/example/example.go
@@ -49,7 +49,6 @@ type MiddlewareState struct {
 // NewMiddleware creates a new middleware that executes the next middleware
 // after performing it's operations.
 func NewMiddleware(
-	g *zanzibar.Gateway,
 	deps *module.Dependencies,
 	options Options,
 ) zanzibar.MiddlewareHandle {

--- a/examples/example-gateway/middlewares/example_reader/example_reader.go
+++ b/examples/example-gateway/middlewares/example_reader/example_reader.go
@@ -47,7 +47,6 @@ type MiddlewareState struct{}
 // NewMiddleware creates a new middleware that executes the next middleware
 // after performing it's operations.
 func NewMiddleware(
-	g *zanzibar.Gateway,
 	deps *module.Dependencies,
 	options Options,
 ) zanzibar.MiddlewareHandle {

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -38,7 +38,6 @@ import (
 // Ensures that a middleware stack can correctly return all of its handlers.
 func TestHandlers(t *testing.T) {
 	ex := example.NewMiddleware(
-		nil, // *zanzibar.Gateway
 		&module.Dependencies{
 			Default: &zanzibar.DefaultDependencies{},
 			Client:  &module.ClientDependencies{},
@@ -238,7 +237,6 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 // Ensures that a middleware can read state from a middeware earlier in the stack.
 func TestMiddlewareSharedStates(t *testing.T) {
 	ex := example.NewMiddleware(
-		nil, // *zanzibar.Gateway
 		nil,
 		example.Options{
 			Foo: "test_state",
@@ -246,7 +244,6 @@ func TestMiddlewareSharedStates(t *testing.T) {
 		},
 	)
 	exReader := exampleReader.NewMiddleware(
-		nil, // *zanzibar.Gateway
 		nil,
 		exampleReader.Options{
 			Foo: "foo",
@@ -295,7 +292,6 @@ func TestMiddlewareSharedStates(t *testing.T) {
 // Ensures that a middleware can read state from a middeware earlier in the stack.
 func TestMiddlewareSharedStateSet(t *testing.T) {
 	ex := example.NewMiddleware(
-		nil, // *zanzibar.Gateway
 		nil,
 		example.Options{
 			Foo: "test_state",
@@ -304,7 +300,6 @@ func TestMiddlewareSharedStateSet(t *testing.T) {
 	)
 
 	exReader := exampleReader.NewMiddleware(
-		nil, // *zanzibar.Gateway
 		nil,
 		exampleReader.Options{
 			Foo: "foo",


### PR DESCRIPTION
This PR remove the global gateway param `g` from client/endpoint/middware constructors, because: 
 *  it should not be needed as all dependencies for a module is passed in by the second param `deps`;
  * `g` is a God object that leaks access to almost everything;

The good thing is `g` is never passed to non-generated code, so this change should be safe and transparent.

@uber/zanzibar-team 