### PR TITLE
parse method names from thrift code

### DIFF
--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2069,6 +2069,37 @@
 		}
 	},
 	{
+		"name": "get the list of methods for a given parse thrift definitions - empty request body",
+		"request": {
+			"method": "POST",
+			"url": "/thrift-method-parsed",
+			"body": {
+			}
+		},
+		"response": {
+			"code": 400,
+			"body": {
+				"error": "Raw code is empty."
+			}
+		}
+	},
+	{
+		"name": "get the list of methods for a given parse thrift definitions - valid json without rawCode field",
+		"request": {
+			"method": "POST",
+			"url": "/thrift-method-parsed",
+			"body": {
+				"rawCode": "test"
+			}
+		},
+		"response": {
+			"code": 400,
+			"body": {
+				"error": "Raw code failed thrift compilation.: failed to parse thrift program: parse error\n  line 1: syntax error: unexpected IDENTIFIER\n"
+			}
+		}
+	},
+	{
 		"name": "get the list of all files in IDL registry",
 		"request": {
 			"method": "GET",

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2079,7 +2079,7 @@
 		"response": {
 			"code": 400,
 			"body": {
-				"error": "Raw code is empty."
+				"error": "raw code is empty"
 			}
 		}
 	},
@@ -2095,7 +2095,7 @@
 		"response": {
 			"code": 400,
 			"body": {
-				"error": "Raw code failed thrift compilation.: failed to parse thrift program: parse error\n  line 1: syntax error: unexpected IDENTIFIER\n"
+				"error": "raw code failed thrift compilation: failed to parse thrift program: parse error\n  line 1: syntax error: unexpected IDENTIFIER\n"
 			}
 		}
 	},

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2032,25 +2032,38 @@
 		}
 	},
 	{
-		"name": "get the list of methods for a given thrift path",
+		"name": "get the list of methods for a given parse thrift definitions",
 		"request": {
-			"method": "GET",
-			"url": "/thrift-method-parsed/endpoints/baz/baz.thrift",
-			"header": {
-				"gateway-id": "example-gateway"
+			"method": "POST",
+			"url": "/thrift-method-parsed",
+			"body": {
+				"rawCode": "namespace java com.uber.zanzibar.clients.baz\n\ninclude \"base.thrift\"\n\nconst string MyTestString = mts\n\nenum Fruit {\n\tAPPLE = 0,\n\tBANANA = 1\n}\n\ntypedef string StringTypedefTest\n\nstruct BazRequest {\n\t1: required bool b1\n\t2: required string s2\n\t3: required i32 i3\n}\n\nexception AuthErr {\n\t1: required string message\n}\n\nexception OtherAuthErr {\n\t1: required string message\n}\n\nservice SimpleService {\n\tvoid call (\n\t\t1: required BazRequest arg\n\t) throws (\n\t\t1: AuthErr authErr\n\t) (\n\t\tzanzibar.http.reqHeaders = \"x-uuid,x-token\"\n\t\tzanzibar.http.resHeaders = \"some-res-header\"\n\t)\n\n\tbase.BazResponse compare (\n\t\t1: required BazRequest arg1\n\t\t2: required BazRequest arg2\n\t) throws (\n\t\t1: AuthErr authErr\n\t\t2: OtherAuthErr otherAuthErr\n\t)\n\n\tbase.BazResponse ping ()\n\n\tvoid sillyNoop () throws (\n\t\t1: AuthErr authErr\n\t\t2: base.ServerErr serverErr\n\t)\n}\n\nservice SecondService {\n\tbinary echoBinary (\n\t\t1: required binary arg\n\t)\n\n\tbool echoBool (\n\t\t1: required bool arg\n\t)\n\n\tdouble echoDouble (\n\t\t1: required double arg\n\t)\n\n\tFruit echoEnum (\n\t\t1: optional Fruit arg = Fruit.APPLE\n\t)\n\n\ti16 echoI16 (\n\t\t1: required i16 arg\n\t)\n\n\ti32 echoI32 (\n\t\t1: required i32 arg\n\t)\n\n\ti64 echoI64 (\n\t\t1: required i64 arg\n\t)\n\n\tbyte echoI8 (\n\t\t1: required byte arg\n\t)\n\n\tstring echoString (\n\t\t1: required string arg\n\t)\n\n\tlist\u003cstring\u003e echoStringList (\n\t\t1: required list\u003cstring\u003e arg\n\t)\n\n\tmap\u003cstring, base.BazResponse\u003e echoStringMap (\n\t\t1: required map\u003cstring, base.BazResponse\u003e arg\n\t)\n\n\tset\u003cstring\u003e echoStringSet (\n\t\t1: required set\u003cstring\u003e arg\n\t)\n\n\tlist\u003cbase.BazResponse\u003e echoStructList (\n\t\t1: required list\u003cbase.BazResponse\u003e arg\n\t)\n\n\tmap\u003cbase.BazResponse, string\u003e echoStructMap (\n\t\t1: required map\u003cbase.BazResponse, string\u003e arg\n\t)\n\n\tset\u003cbase.BazResponse\u003e echoStructSet (\n\t\t1: required set\u003cbase.BazResponse\u003e arg\n\t)\n\n\tbase.UUID echoTypedef (\n\t\t1: required base.UUID arg\n\t)\n}\n\n"
 			}
 		},
 		"response": {
 			"code": 200,
 			"body": {
 				"functions": [
+					"SecondService::echoBinary",
+					"SecondService::echoBool",
+					"SecondService::echoDouble",
+					"SecondService::echoEnum",
+					"SecondService::echoI16",
+					"SecondService::echoI32",
+					"SecondService::echoI64",
+					"SecondService::echoI8",
+					"SecondService::echoString",
+					"SecondService::echoStringList",
+					"SecondService::echoStringMap",
+					"SecondService::echoStringSet",
+					"SecondService::echoStructList",
+					"SecondService::echoStructMap",
+					"SecondService::echoStructSet",
+					"SecondService::echoTypedef",
 					"SimpleService::call",
 					"SimpleService::compare",
 					"SimpleService::ping",
-					"SimpleService::sillyNoop",
-					"SimpleService::testUuid",
-					"SimpleService::trans",
-					"SimpleService::urlTest"
+					"SimpleService::sillyNoop"
 				]
 			}
 		}

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2044,12 +2044,12 @@
 			"code": 200,
 			"body": {
 				"functions": [
-					"SimpleService::compare",
 					"SimpleService::call",
+					"SimpleService::compare",
 					"SimpleService::ping",
-					"SimpleService::trans",
 					"SimpleService::sillyNoop",
 					"SimpleService::testUuid",
+					"SimpleService::trans",
 					"SimpleService::urlTest"
 				]
 			}

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -2032,6 +2032,30 @@
 		}
 	},
 	{
+		"name": "get the list of methods for a given thrift path",
+		"request": {
+			"method": "GET",
+			"url": "/thrift-method-parsed/endpoints/baz/baz.thrift",
+			"header": {
+				"gateway-id": "example-gateway"
+			}
+		},
+		"response": {
+			"code": 200,
+			"body": {
+				"functions": [
+					"SimpleService::compare",
+					"SimpleService::call",
+					"SimpleService::ping",
+					"SimpleService::trans",
+					"SimpleService::sillyNoop",
+					"SimpleService::testUuid",
+					"SimpleService::urlTest"
+				]
+			}
+		}
+	},
+	{
 		"name": "get the list of all files in IDL registry",
 		"request": {
 			"method": "GET",

--- a/backend/repository/handler.go
+++ b/backend/repository/handler.go
@@ -402,13 +402,17 @@ func (h *Handler) ThriftCodeToMethods(w http.ResponseWriter, r *http.Request, _ 
 
 	_, err := UnmarshalJSONBody(r, req)
 	if err != nil {
-		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Failed to unmarshal request body for converting to a list of methods"))
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Raw code failed unmarshalling."))
+		return
+	}
+	if req.RawCode == "" {
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Errorf("Raw code is empty."))
 		return
 	}
 
 	module, err := h.Manager.CompileThriftCode(req.RawCode)
 	if err != nil {
-		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Failed to unmarshal bytes to thrift for converting to a list of methods"))
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Raw code failed thrift compilation."))
 		return
 	}
 

--- a/backend/repository/handler.go
+++ b/backend/repository/handler.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -332,6 +333,7 @@ func (h *Handler) MethodFromThriftCode(w http.ResponseWriter, r *http.Request, p
 			functionNames = append(functionNames, serviceSpec.Name+"::"+functionSpec.Name)
 		}
 	}
+	sort.Strings(functionNames)
 	h.WriteJSON(w, http.StatusOK, &methodFromThriftCodeResponse{Functions: functionNames})
 }
 

--- a/backend/repository/handler.go
+++ b/backend/repository/handler.go
@@ -312,6 +312,10 @@ func (h *Handler) CompiledThrift(w http.ResponseWriter, r *http.Request, ps http
 	h.WriteJSON(w, http.StatusOK, module)
 }
 
+type methodFromThriftCodeResponse struct {
+	Functions []string `json:"functions"`
+}
+
 // MethodFromThriftCode returns a list of method names for a given thrift file path
 func (h *Handler) MethodFromThriftCode(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := r.Header.Get(h.gatewayHeader)
@@ -328,7 +332,7 @@ func (h *Handler) MethodFromThriftCode(w http.ResponseWriter, r *http.Request, p
 			functionNames = append(functionNames, serviceSpec.Name+"::"+functionSpec.Name)
 		}
 	}
-	h.WriteJSON(w, http.StatusOK, functionNames)
+	h.WriteJSON(w, http.StatusOK, &methodFromThriftCodeResponse{Functions: functionNames})
 }
 
 type rawCodeRequest struct {

--- a/backend/repository/handler.go
+++ b/backend/repository/handler.go
@@ -402,17 +402,17 @@ func (h *Handler) ThriftCodeToMethods(w http.ResponseWriter, r *http.Request, _ 
 
 	_, err := UnmarshalJSONBody(r, req)
 	if err != nil {
-		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Raw code failed unmarshalling."))
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "raw code failed unmarshalling"))
 		return
 	}
 	if req.RawCode == "" {
-		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Errorf("Raw code is empty."))
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Errorf("raw code is empty"))
 		return
 	}
 
 	module, err := h.Manager.CompileThriftCode(req.RawCode)
 	if err != nil {
-		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "Raw code failed thrift compilation."))
+		h.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrap(err, "raw code failed thrift compilation"))
 		return
 	}
 

--- a/backend/repository/manager.go
+++ b/backend/repository/manager.go
@@ -179,6 +179,11 @@ func (m *Manager) CompileThriftFile(gateway, path string) (*Module, error) {
 	return CompileThriftFile(absPath, prefix)
 }
 
+// CompileThriftCode parses raw bytes in to compiled thrift.
+func (m *Manager) CompileThriftCode(rawCode string) (*Module, error) {
+	return CompileThriftCode([]byte(rawCode), "", "")
+}
+
 // CodeThriftFile returns the content and meta data of a file in a gateway.
 func (m *Manager) CodeThriftFile(rawCode, gateway, path string) (*Module, error) {
 	repo, ok := m.RepoMap[gateway]


### PR DESCRIPTION
Frontent requires an list of method names given thrift code.
thrift compilation creates a struct with service and method names which
isn't necessarily ordered but converting that to a list for the frontend
assumes ordering which may break tests hence always sort the list before
returning.