### PR TITLE
expose transform middleware in repository API

### DIFF
--- a/backend/repository/config.go
+++ b/backend/repository/config.go
@@ -378,9 +378,30 @@ func (r *Repository) endpointConfigs(thriftRootDir string, gatewaySpec *codegen.
 func (r *Repository) middlewareConfigs(
 	gatewaySpec *codegen.GatewaySpec,
 ) (map[string]interface{}, map[string]*RawMiddlewareConfig, error) {
-	middlewareSpecs := gatewaySpec.MiddlewareModules
+	orgMiddlewareSpecs := gatewaySpec.MiddlewareModules
 	schemasByName := make(map[string]interface{})
 	middlewareConfigs := make(map[string]*RawMiddlewareConfig)
+
+	// manually add transform request response since they are features of the zanzibar platform
+	//  Note:  the schema files must be available in the middlewares directory
+	tq := &codegen.MiddlewareSpec{
+		Name:              "transformRequest",
+		OptionsSchemaFile: "./middlewares/transform-request/transform_request_schema.json",
+		ImportPath:        "github.com/uber/zanzibar/codegen",
+	}
+
+	ts := &codegen.MiddlewareSpec{
+		Name:              "transformResponse",
+		OptionsSchemaFile: "./middlewares/transform-response/transform_response_schema.json",
+		ImportPath:        "github.com/uber/zanzibar/codegen",
+	}
+
+	middlewareSpecs := make(map[string]*codegen.MiddlewareSpec)
+	for k, v := range orgMiddlewareSpecs {
+		middlewareSpecs[k] = v
+	}
+	middlewareSpecs[tq.Name] = tq
+	middlewareSpecs[ts.Name] = ts
 
 	for _, spec := range middlewareSpecs {
 		schemaFile := spec.OptionsSchemaFile

--- a/backend/repository/data/gateway_config_expected.json
+++ b/backend/repository/data/gateway_config_expected.json
@@ -988,6 +988,52 @@
 				"Foo"
 			],
 			"type": "object"
+		},
+		"transformRequest": {
+			"$schema": "http://json-schema.org/schema#",
+			"properties": {
+				"transforms": {
+					"items": {
+						"properties": {
+							"from": {
+								"type": "string"
+							},
+							"override": {
+								"type": "boolean"
+							},
+							"to": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
+		},
+		"transformResponse": {
+			"$schema": "http://json-schema.org/schema#",
+			"properties": {
+				"transforms": {
+					"items": {
+						"properties": {
+							"from": {
+								"type": "string"
+							},
+							"override": {
+								"type": "boolean"
+							},
+							"to": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"type": "array"
+				}
+			},
+			"type": "object"
 		}
 	},
 	"RawMiddlewares": {
@@ -1000,6 +1046,16 @@
 			"name": "example_reader",
 			"importPath": "github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader",
 			"schema": "./middlewares/example_reader/example_reader_schema.json"
+		},
+		"transformRequest": {
+			"name": "transformRequest",
+			"importPath": "github.com/uber/zanzibar/codegen",
+			"schema": "./middlewares/transform-request/transform_request_schema.json"
+		},
+		"transformResponse": {
+			"name": "transformResponse",
+			"importPath": "github.com/uber/zanzibar/codegen",
+			"schema": "./middlewares/transform-response/transform_response_schema.json"
 		}
 	}
 }

--- a/backend/repository/data/handler/test_cases.json
+++ b/backend/repository/data/handler/test_cases.json
@@ -269,6 +269,52 @@
 						"Foo"
 					],
 					"type": "object"
+				},
+				"transformRequest": {
+					"$schema": "http://json-schema.org/schema#",
+					"properties": {
+						"transforms": {
+							"items": {
+								"properties": {
+									"from": {
+										"type": "string"
+									},
+									"override": {
+										"type": "boolean"
+									},
+									"to": {
+										"type": "string"
+									}
+								},
+								"type": "object"
+							},
+							"type": "array"
+						}
+					},
+					"type": "object"
+				},
+				"transformResponse": {
+					"$schema": "http://json-schema.org/schema#",
+					"properties": {
+						"transforms": {
+							"items": {
+								"properties": {
+									"from": {
+										"type": "string"
+									},
+									"override": {
+										"type": "boolean"
+									},
+									"to": {
+										"type": "string"
+									}
+								},
+								"type": "object"
+							},
+							"type": "array"
+						}
+					},
+					"type": "object"
 				}
 			}
 		}
@@ -3144,6 +3190,52 @@
 								"Foo"
 							],
 							"type": "object"
+						},
+						"transformRequest": {
+							"$schema": "http://json-schema.org/schema#",
+							"properties": {
+								"transforms": {
+									"items": {
+										"properties": {
+											"from": {
+												"type": "string"
+											},
+											"override": {
+												"type": "boolean"
+											},
+											"to": {
+												"type": "string"
+											}
+										},
+										"type": "object"
+									},
+									"type": "array"
+								}
+							},
+							"type": "object"
+						},
+						"transformResponse": {
+							"$schema": "http://json-schema.org/schema#",
+							"properties": {
+								"transforms": {
+									"items": {
+										"properties": {
+											"from": {
+												"type": "string"
+											},
+											"override": {
+												"type": "boolean"
+											},
+											"to": {
+												"type": "string"
+											}
+										},
+										"type": "object"
+									},
+									"type": "array"
+								}
+							},
+							"type": "object"
 						}
 					},
 					"PackageRoot": "github.com/uber/zanzibar/examples/example-gateway",
@@ -3157,6 +3249,16 @@
 							"importPath": "github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader",
 							"name": "example_reader",
 							"schema": "./middlewares/example_reader/example_reader_schema.json"
+						},
+						"transformRequest": {
+							"importPath": "github.com/uber/zanzibar/codegen",
+							"name": "transformRequest",
+							"schema": "./middlewares/transform-request/transform_request_schema.json"
+						},
+						"transformResponse": {
+							"importPath": "github.com/uber/zanzibar/codegen",
+							"name": "transformResponse",
+							"schema": "./middlewares/transform-response/transform_response_schema.json"
 						}
 					},
 					"Repository": "example-gateway",
@@ -4173,6 +4275,52 @@
 							"Foo"
 						],
 						"type": "object"
+					},
+					"transformRequest": {
+						"$schema": "http://json-schema.org/schema#",
+						"properties": {
+							"transforms": {
+								"items": {
+									"properties": {
+										"from": {
+											"type": "string"
+										},
+										"override": {
+											"type": "boolean"
+										},
+										"to": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"type": "array"
+							}
+						},
+						"type": "object"
+					},
+					"transformResponse": {
+						"$schema": "http://json-schema.org/schema#",
+						"properties": {
+							"transforms": {
+								"items": {
+									"properties": {
+										"from": {
+											"type": "string"
+										},
+										"override": {
+											"type": "boolean"
+										},
+										"to": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"type": "array"
+							}
+						},
+						"type": "object"
 					}
 				},
 				"PackageRoot": "github.com/uber/zanzibar/examples/example-gateway",
@@ -4186,6 +4334,16 @@
 						"importPath": "github.com/uber/zanzibar/examples/example-gateway/middlewares/example_reader",
 						"name": "example_reader",
 						"schema": "./middlewares/example_reader/example_reader_schema.json"
+					},
+					"transformRequest": {
+						"importPath": "github.com/uber/zanzibar/codegen",
+						"name": "transformRequest",
+						"schema": "./middlewares/transform-request/transform_request_schema.json"
+					},
+					"transformResponse": {
+						"importPath": "github.com/uber/zanzibar/codegen",
+						"name": "transformResponse",
+						"schema": "./middlewares/transform-response/transform_response_schema.json"
 					}
 				},
 				"Repository": "example-gateway",

--- a/examples/example-gateway/middlewares/transform-request/_middleware-config.json
+++ b/examples/example-gateway/middlewares/transform-request/_middleware-config.json
@@ -1,0 +1,9 @@
+{
+	"name": "transform_request",
+	"type": "default",
+	"dependencies": {},
+	"config": {
+		"schema": "./middlewares/transform-request/transform_request_schema.json",
+		"path": "github.com/uber/zanzibar/codegen"
+	}
+}

--- a/examples/example-gateway/middlewares/transform-request/transform_request_schema.json
+++ b/examples/example-gateway/middlewares/transform-request/transform_request_schema.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"type": "object",
+	"properties": {
+		"transforms": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"override": {
+						"type": "boolean"
+					}
+				}
+			}
+		}
+	}
+}

--- a/examples/example-gateway/middlewares/transform-response/_middleware-config.json
+++ b/examples/example-gateway/middlewares/transform-response/_middleware-config.json
@@ -1,0 +1,9 @@
+{
+	"name": "transform_response",
+	"type": "default",
+	"dependencies": {},
+	"config": {
+		"schema": "./middlewares/transform-response/transform_response_schema.json",
+		"path": "github.com/uber/zanzibar/codegen"
+	}
+}

--- a/examples/example-gateway/middlewares/transform-response/transform_response_schema.json
+++ b/examples/example-gateway/middlewares/transform-response/transform_response_schema.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "http://json-schema.org/schema#",
+	"type": "object",
+	"properties": {
+		"transforms": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"override": {
+						"type": "boolean"
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
tranform features are not technically a middleware module as defined by
the module system.  the endpoint middleware stack codegen braches on
transforms to use the type converter.  However transform middlewares
config schema still need to be exposed in the repository API for orchestration
so thats what this accomplishes. 