### PR TITLE
support annotation prefix config

### DIFF
--- a/backend/repository/config.go
+++ b/backend/repository/config.go
@@ -210,6 +210,7 @@ func (r *Repository) newGatewayConfig() (configuration *Config, cfgErr error) {
 		EndpointConfigDir:   cfg.MustGetString("endpointConfig"),
 		MiddlewareConfigDir: cfg.MustGetString("middlewareConfig"),
 	}
+	annotationPrefix := cfg.MustGetString("annotationPrefix")
 	pkgHelper, err := codegen.NewPackageHelper(
 		config.PackageRoot,
 		config.ManagedThriftFolder,
@@ -219,6 +220,7 @@ func (r *Repository) newGatewayConfig() (configuration *Config, cfgErr error) {
 		config.GenCodePackage,
 		config.TargetGenDir,
 		"",
+		annotationPrefix,
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create package helper")

--- a/backend/repository/manager.go
+++ b/backend/repository/manager.go
@@ -46,7 +46,7 @@ type Manager struct {
 	// IDL-registry repository.
 	IDLRegistry IDLRegistry
 
-	// TODO: Add a Middleware schema repository
+	annoPrefix string
 }
 
 // NewManager creates a manager for remote git repositories.
@@ -54,11 +54,13 @@ func NewManager(
 	repoMap map[string]*Repository,
 	localRoot string,
 	idlRegistry IDLRegistry,
+	annoPrefix string,
 ) *Manager {
 	manager := &Manager{
 		RepoMap:      repoMap,
 		localRootDir: localRoot,
 		IDLRegistry:  idlRegistry,
+		annoPrefix:   annoPrefix,
 	}
 	return manager
 }
@@ -93,6 +95,7 @@ func (m *Manager) IDLThriftService(path string) (map[string]*ThriftService, erro
 		"idl-registry/gen-code", // genCodePackage
 		"./build",               // targetGenDir
 		"",                      // copyrightHeader
+		m.annoPrefix,
 	)
 	if err != nil {
 		return nil, err
@@ -295,6 +298,7 @@ func (m *Manager) Validate(r *Repository, req *UpdateRequest) error {
 		cfg.GenCodePackage,
 		"./build",
 		"",
+		m.annoPrefix,
 	)
 	if err != nil {
 		return err

--- a/backend/repository/manager_test.go
+++ b/backend/repository/manager_test.go
@@ -258,7 +258,7 @@ func NewTestManager() *Manager {
 	repoMap := map[string]*Repository{
 		gatewayID: r,
 	}
-	manager, err := NewManager(repoMap, "", idlRegistor), nil
+	manager, err := NewManager(repoMap, "", idlRegistor, "zanzibar"), nil
 	if err != nil {
 		log.Fatalf("Failed to create test manager: %v\n", err)
 	}

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -49,6 +49,8 @@ type PackageHelper struct {
 	testConfigsRootDir string
 	// String containing copyright header to add to generated code.
 	copyrightHeader string
+	// annotation prefix to parse for thrift schema
+	annotationPrefix string
 	// The middlewares available for the endpoints
 	middlewareSpecs map[string]*MiddlewareSpec
 }
@@ -63,6 +65,7 @@ func NewPackageHelper(
 	genCodePackage string,
 	relTargetGenDir string,
 	copyrightHeader string,
+	annotationPrefix string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
 	if err != nil {
@@ -89,6 +92,7 @@ func NewPackageHelper(
 		targetGenDir:        filepath.Join(absConfigRoot, relTargetGenDir),
 		copyrightHeader:     copyrightHeader,
 		middlewareSpecs:     middlewareSpecs,
+		annotationPrefix:    annotationPrefix,
 	}
 	return p, nil
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -72,6 +72,7 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
 		tmpDir,
 		testCopyrightHeader,
+		"zanzibar",
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {
 		return nil

--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -11,14 +11,19 @@ if [ -z "$2" ]; then
 	echo "config dir argument (\$2) is missing"
 	exit 1
 fi
+if [ -z "$3" ]; then
+	echo "annotation prefix argument (\$3) is missing"
+	exit 1
+fi
 
 BUILD_DIR="$1"
 CONFIG_DIR="$2"
+ANNOPREFIX="$3"
 
-if [ -z "$3" ]; then
+if [ -z "$4" ]; then
 	THRIFTRW_SRCS="$(find "$CONFIG_DIR/idl" -name '*.thrift')"
 else
-	THRIFTRW_SRCS="$3"
+	THRIFTRW_SRCS="$4"
 fi
 THRIFTRW_SRCS="$(echo "$THRIFTRW_SRCS" | xargs -n1 | sort | uniq)"
 
@@ -95,7 +100,7 @@ for config_file in ${config_files}; do
 
 		thrift_file="$CONFIG_DIR/idl/$thrift_file"
 		gen_code_dir=$(
-		"$RESOLVE_THRIFT_BINARY" "$thrift_file" | \
+		"$RESOLVE_THRIFT_BINARY" "$thrift_file" "$ANNOPREFIX" | \
 			sed "s|$ABS_IDL_DIR\/\(.*\)\/.*.thrift|$ABS_GENCODE_DIR/\1|" | \
 			sort | uniq | xargs
 		)

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -89,6 +89,7 @@ func main() {
 		config.MustGetString("genCodePackage"),
 		config.MustGetString("targetGenDir"),
 		string(copyright),
+		config.MustGetString("annotationPrefix"),
 	)
 	checkError(
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -68,6 +68,7 @@ func TestGenerateBar(t *testing.T) {
 		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
 		tmpDir,
 		testCopyrightHeader,
+		"zanzibar",
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {
 		return

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -9,5 +9,7 @@
 	"clientConfig": "./clients",
 	"endpointConfig": "./endpoints",
 	"middlewareConfig": "./middlewares",
-	"copyrightHeader": "./copyright_header.txt"
+	"copyrightHeader": "./copyright_header.txt",
+
+	"annotationPrefix": "zanzibar"
 }

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,8 +2,9 @@
 set -e
 
 PREFIX=examples/example-gateway
+ANNOPREFIX=${1:-zanzibar}
 
-bash ./codegen/runner/pre-steps.sh "$PREFIX/build" "$PREFIX"
+bash ./codegen/runner/pre-steps.sh "$PREFIX/build" "$PREFIX" "$ANNOPREFIX"
 
 start=$(cat .TMP_ZANZIBAR_TIMESTAMP_FILE.txt)
 go run codegen/runner/runner.go -config="$PREFIX/gateway.json"

--- a/scripts/resolve_thrift/main.go
+++ b/scripts/resolve_thrift/main.go
@@ -43,7 +43,7 @@ func main() {
 	thisThriftPath := module.ThriftPath
 	fmt.Println(thisThriftPath)
 
-	var unwrapAnnot = codegen.AntHTTPReqDefBoxed
+	var unwrapAnnot = fmt.Sprintf(codegen.AntHTTPReqDefBoxed, os.Args[2])
 
 	for _, service := range module.Services {
 		for _, method := range service.Functions {


### PR DESCRIPTION
this PR allows annotation prefix to be specified in project config instead hardcode in zanzibar lib
it helps project migration (if they have to keep original annotations), and schema used by different services

@uber/zanzibar-team 