### PR TITLE
Make mock generation as an configurable option

### DIFF
--- a/codegen/mockgen.go
+++ b/codegen/mockgen.go
@@ -22,7 +22,6 @@ package codegen
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -120,40 +119,4 @@ func (m MockgenBin) GenMock(instance *ModuleInstance, dest, pkg, intf string) er
 	}
 
 	return nil
-}
-
-// ClientMockGenHook returns a PostGenHook to generate client mocks
-func ClientMockGenHook(h *PackageHelper) (PostGenHook, error) {
-	bin, err := NewMockgenBin(h.PackageRoot())
-	if err != nil {
-		return nil, errors.Wrap(err, "error building mockgen binary")
-	}
-
-	return func(instances map[string][]*ModuleInstance) error {
-		fmt.Println("Generating client mocks:")
-		mockCount := len(instances["client"])
-		for i, instance := range instances["client"] {
-			if err := bin.GenMock(
-				instance,
-				"mock-client/mock_client.go",
-				"clientmock",
-				"Client",
-			); err != nil {
-				return errors.Wrapf(
-					err,
-					"error generating mocks for client %q",
-					instance.InstanceName,
-				)
-			}
-			fmt.Printf(
-				"Generating %12s %12s %-20s in %-40s %d/%d\n",
-				"mock",
-				instance.ClassName,
-				instance.InstanceName,
-				path.Join(path.Base(h.CodeGenTargetPath()), instance.Directory),
-				i+1, mockCount,
-			)
-		}
-		return nil
-	}, nil
 }

--- a/codegen/module.go
+++ b/codegen/module.go
@@ -888,7 +888,7 @@ func (system *ModuleSystem) GenerateBuild(
 				classInstance.Directory,
 			)
 			fmt.Printf(
-				"Generating %12s %12s %-20s in %-40s %d/%d\n",
+				"Generating %12s %12s %-30s in %-50s %d/%d\n",
 				classInstance.ClassType,
 				classInstance.ClassName,
 				classInstance.InstanceName,

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package codegen
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/pkg/errors"
+	"path/filepath"
+)
+
+// ClientMockGenHook returns a PostGenHook to generate client mocks
+func ClientMockGenHook(h *PackageHelper) (PostGenHook, error) {
+	bin, err := NewMockgenBin(h.PackageRoot())
+	if err != nil {
+		return nil, errors.Wrap(err, "error building mockgen binary")
+	}
+
+	return func(instances map[string][]*ModuleInstance) error {
+		fmt.Println("Generating client mocks:")
+		mockCount := len(instances["client"])
+		for i, instance := range instances["client"] {
+			if err := bin.GenMock(
+				instance,
+				"mock-client/mock_client.go",
+				"clientmock",
+				"Client",
+			); err != nil {
+				return errors.Wrapf(
+					err,
+					"error generating mocks for client %q",
+					instance.InstanceName,
+				)
+			}
+			fmt.Printf(
+				"Generating %12s %12s %-30s in %-50s %d/%d\n",
+				"mock",
+				instance.ClassName,
+				instance.InstanceName,
+				path.Join(path.Base(h.CodeGenTargetPath()), instance.Directory, "mock-client"),
+				i+1, mockCount,
+			)
+		}
+		return nil
+	}, nil
+}
+
+// ServiceMockGenHook returns a PostGenHook to generate server mocks
+func ServiceMockGenHook(h *PackageHelper, t *Template) PostGenHook {
+	return func(instances map[string][]*ModuleInstance) error {
+		fmt.Println("Generating service mocks:")
+		mockCount := len(instances["service"])
+		for i, instance := range instances["service"] {
+			mockInit, err := generateMockInitializer(instance, h, t)
+			if err != nil {
+				return errors.Wrapf(
+					err,
+					"Error generating service mock_init.go for %s",
+					instance.InstanceName,
+				)
+			}
+			mockService, err := t.ExecTemplate("service_mock.tmpl", instance, h)
+			if err != nil {
+				return errors.Wrapf(
+					err,
+					"Error generating service mock_service.go for %s",
+					instance.InstanceName,
+				)
+			}
+
+			buildPath := filepath.Join(h.CodeGenTargetPath(), instance.Directory)
+			mockInitPath := filepath.Join(buildPath, "mock-service/mock_init.go")
+			mockServicePath := filepath.Join(buildPath, "mock-service/mock_Service.go")
+
+			for _, s := range []struct {
+				path    string
+				content []byte
+			}{
+				{mockInitPath, mockInit},
+				{mockServicePath, mockService},
+			} {
+				if err := writeFile(s.path, s.content); err != nil {
+					return errors.Wrapf(
+						err,
+						"Error writing to file %q",
+						s.path,
+					)
+				}
+				if err := FormatGoFile(s.path); err != nil {
+					return err
+				}
+
+			}
+
+			fmt.Printf(
+				"Generating %12s %12s %-30s in %-50s %d/%d\n",
+				"mock",
+				instance.ClassName,
+				instance.InstanceName,
+				path.Join(path.Base(h.CodeGenTargetPath()), instance.Directory, "mock-service"),
+				i+1, mockCount,
+			)
+		}
+		return nil
+	}
+}
+
+// generateMockInitializer generates code to initialize modules with leaf nodes being mocks
+func generateMockInitializer(instance *ModuleInstance, h *PackageHelper, t *Template) ([]byte, error) {
+	leafWithFixture := map[string]string{}
+	for _, leaf := range instance.RecursiveDependencies["client"] {
+		spec, ok := leaf.genSpec.(*ClientSpec)
+		if ok && spec.Fixture != nil {
+			leafWithFixture[leaf.InstanceName] = spec.Fixture.ImportPath
+		}
+	}
+	data := map[string]interface{}{
+		"Instance":        instance,
+		"LeafWithFixture": leafWithFixture,
+	}
+	return t.ExecTemplate("module_mock_initializer.tmpl", data, h)
+}

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -89,7 +89,7 @@ func ServiceMockGenHook(h *PackageHelper, t *Template) PostGenHook {
 
 			buildPath := filepath.Join(h.CodeGenTargetPath(), instance.Directory)
 			mockInitPath := filepath.Join(buildPath, "mock-service/mock_init.go")
-			mockServicePath := filepath.Join(buildPath, "mock-service/mock_Service.go")
+			mockServicePath := filepath.Join(buildPath, "mock-service/mock_service.go")
 
 			for _, s := range []struct {
 				path    string

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -32,8 +32,6 @@ import (
 	"github.com/uber/zanzibar/runtime"
 )
 
-const templateDir = "./codegen/templates/*.tmpl"
-
 type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
@@ -95,7 +93,16 @@ func main() {
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),
 	)
 
-	moduleSystem, err := codegen.NewDefaultModuleSystem(packageHelper)
+	genMock := config.ContainsKey("genMock")
+	if genMock {
+		genMock = config.MustGetBoolean("genMock")
+	}
+	var moduleSystem *codegen.ModuleSystem
+	if genMock {
+		moduleSystem, err = codegen.NewDefaultModuleSystemWithMockHook(packageHelper)
+	} else {
+		moduleSystem, err = codegen.NewDefaultModuleSystem(packageHelper)
+	}
 	checkError(
 		err, fmt.Sprintf("Error creating module system %s", configRoot),
 	)

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -11,5 +11,7 @@
 	"middlewareConfig": "./middlewares",
 	"copyrightHeader": "./copyright_header.txt",
 
-	"annotationPrefix": "zanzibar"
+	"annotationPrefix": "zanzibar",
+
+	"genMock": true
 }


### PR DESCRIPTION
This PR:
- moves mock service generation to a post gen hook
- makes mock client and service generation as an option

I will move fixture generation to post gen hook in a future PR together with fixture generation for custom clients.