### PR TITLE
Defer server close in mockService stop call

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2011,9 +2011,13 @@ func (m *mockService) Start() {
 
 // Stop stops the mock server
 func (m *mockService) Stop() {
+	// m.ctrl.Finish() calls runtime.Goexit() on errors
+	// put it in defer so cleanup is always done
+	defer func(){
+		m.server.Close()
+		m.started = false
+	}()
 	m.ctrl.Finish()
-	m.server.Close()
-	m.started = false
 }
 
 // {{$mockType}} returns the mock nodes
@@ -2076,7 +2080,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 4041, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 4162, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -112,9 +112,13 @@ func (m *mockService) Start() {
 
 // Stop stops the mock server
 func (m *mockService) Stop() {
+	// m.ctrl.Finish() calls runtime.Goexit() on errors
+	// put it in defer so cleanup is always done
+	defer func(){
+		m.server.Close()
+		m.started = false
+	}()
 	m.ctrl.Finish()
-	m.server.Close()
-	m.started = false
 }
 
 // {{$mockType}} returns the mock nodes

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -130,9 +130,13 @@ func (m *mockService) Start() {
 
 // Stop stops the mock server
 func (m *mockService) Stop() {
+	// m.ctrl.Finish() calls runtime.Goexit() on errors
+	// put it in defer so cleanup is always done
+	defer func() {
+		m.server.Close()
+		m.started = false
+	}()
 	m.ctrl.Finish()
-	m.server.Close()
-	m.started = false
 }
 
 // MockClientNodes returns the mock nodes


### PR DESCRIPTION
`m.ctrl.Finish()` can potienally exit the program early, wrapping sever close in a defer gurantees server is always closed.