### PR TITLE
Cache method mocks and better method name to get mock clients

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -78,6 +78,12 @@ import (
 type MockClientWithFixture struct {
 	*MockClient
 	fixture *ClientFixture
+
+	{{range $method := $methods}}
+	{{$methodName := $method.Name -}}
+	{{$methodMockType := printf "%sMock" $methodName -}}
+	{{camel $methodMockType}} *{{$methodMockType}}
+	{{- end}}
 }
 
 // New creates a new mock instance
@@ -98,6 +104,7 @@ func (m *MockClientWithFixture) EXPECT() {
 {{range $method := $methods}}
 {{$methodName := $method.Name -}}
 {{$methodMockType := printf "%sMock" $methodName -}}
+{{$methodMockField := camel $methodMockType -}}
 {{$methodScenarios := index $scenarios $methodName -}}
 // {{$methodMockType}} mocks the {{$methodName}} method
 type {{$methodMockType}} struct {
@@ -107,10 +114,13 @@ type {{$methodMockType}} struct {
 {{$methodMockMethod := printf "Expect%s" $methodName -}}
 // {{$methodMockMethod}} returns an object that allows the caller to choose expected scenario for {{$methodName}}
 func (m *MockClientWithFixture) {{$methodMockMethod}}() *{{$methodMockType}} {
-	return &{{$methodMockType}}{
-		scenarios:  m.fixture.{{$methodName}},
-		mockClient: m.MockClient,
+	if m.{{$methodMockField}} == nil {
+		m.{{$methodMockField}} = &{{$methodMockType}}{
+			scenarios:  m.fixture.{{$methodName}},
+			mockClient: m.MockClient,
+		}
 	}
+	return m.{{$methodMockField}}
 }
 
 {{- range $scenario := $methodScenarios -}}
@@ -148,7 +158,7 @@ func augmented_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "augmented_mock.tmpl", size: 2171, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "augmented_mock.tmpl", size: 2491, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1910,6 +1910,7 @@ func serviceTmpl() (*asset, error) {
 var _service_mockTmpl = []byte(`{{- $instance := . -}}
 {{- $leafClass := index .DependencyOrder 0 -}}
 {{- $mockType := printf "Mock%sNodes" (title $leafClass) -}}
+{{- $mock := printf "Mock%ss" (title $leafClass) -}}
 
 package {{$instance.PackageInfo.GeneratedPackageAlias}}mock
 
@@ -1946,7 +1947,7 @@ type MockService interface {
 		headers map[string]string,
 		req, resp zanzibar.RWTStruct,
 	) (bool, map[string]string, error)
-	{{$mockType}}() *{{$mockType}}
+	{{$mock}}() *{{$mockType}}
 	Start()
 	Stop()
 }
@@ -1955,7 +1956,7 @@ type mockService struct {
 	started        bool
 	server         *zanzibar.Gateway
 	ctrl           *gomock.Controller
-	{{camel $mockType}}    *{{$mockType}}
+	{{camel $mock}}    *{{$mockType}}
 	httpClient     *http.Client
 	tChannelClient zanzibar.TChannelCaller
 }
@@ -2005,7 +2006,7 @@ func MustCreateTestService(t *testing.T) MockService {
 	return &mockService{
 		server:         		server,
 		ctrl:                   ctrl,
-		{{camel $mockType}}:    mockNodes,
+		{{camel $mock}}:        mockNodes,
 		httpClient:     		httpClient,
 		tChannelClient: 		tchannelClient,
 	}
@@ -2030,9 +2031,9 @@ func (m *mockService) Stop() {
 	m.ctrl.Finish()
 }
 
-// {{$mockType}} returns the mock nodes
-func (m *mockService) {{$mockType}}() *{{$mockType}} {
-	return m.{{camel $mockType}}
+// {{$mock}} returns the mock {{$leafClass}}s
+func (m *mockService) {{$mock}}() *{{$mockType}} {
+	return m.{{camel $mock}}
 }
 
 // MakeHTTPRequest makes a HTTP request to the mock server
@@ -2090,7 +2091,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 4162, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 4205, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/augmented_mock.tmpl
+++ b/codegen/templates/augmented_mock.tmpl
@@ -12,6 +12,12 @@ import (
 type MockClientWithFixture struct {
 	*MockClient
 	fixture *ClientFixture
+
+	{{range $method := $methods}}
+	{{$methodName := $method.Name -}}
+	{{$methodMockType := printf "%sMock" $methodName -}}
+	{{camel $methodMockType}} *{{$methodMockType}}
+	{{- end}}
 }
 
 // New creates a new mock instance
@@ -32,6 +38,7 @@ func (m *MockClientWithFixture) EXPECT() {
 {{range $method := $methods}}
 {{$methodName := $method.Name -}}
 {{$methodMockType := printf "%sMock" $methodName -}}
+{{$methodMockField := camel $methodMockType -}}
 {{$methodScenarios := index $scenarios $methodName -}}
 // {{$methodMockType}} mocks the {{$methodName}} method
 type {{$methodMockType}} struct {
@@ -41,10 +48,13 @@ type {{$methodMockType}} struct {
 {{$methodMockMethod := printf "Expect%s" $methodName -}}
 // {{$methodMockMethod}} returns an object that allows the caller to choose expected scenario for {{$methodName}}
 func (m *MockClientWithFixture) {{$methodMockMethod}}() *{{$methodMockType}} {
-	return &{{$methodMockType}}{
-		scenarios:  m.fixture.{{$methodName}},
-		mockClient: m.MockClient,
+	if m.{{$methodMockField}} == nil {
+		m.{{$methodMockField}} = &{{$methodMockType}}{
+			scenarios:  m.fixture.{{$methodName}},
+			mockClient: m.MockClient,
+		}
 	}
+	return m.{{$methodMockField}}
 }
 
 {{- range $scenario := $methodScenarios -}}

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -1,6 +1,7 @@
 {{- $instance := . -}}
 {{- $leafClass := index .DependencyOrder 0 -}}
 {{- $mockType := printf "Mock%sNodes" (title $leafClass) -}}
+{{- $mock := printf "Mock%ss" (title $leafClass) -}}
 
 package {{$instance.PackageInfo.GeneratedPackageAlias}}mock
 
@@ -37,7 +38,7 @@ type MockService interface {
 		headers map[string]string,
 		req, resp zanzibar.RWTStruct,
 	) (bool, map[string]string, error)
-	{{$mockType}}() *{{$mockType}}
+	{{$mock}}() *{{$mockType}}
 	Start()
 	Stop()
 }
@@ -46,7 +47,7 @@ type mockService struct {
 	started        bool
 	server         *zanzibar.Gateway
 	ctrl           *gomock.Controller
-	{{camel $mockType}}    *{{$mockType}}
+	{{camel $mock}}    *{{$mockType}}
 	httpClient     *http.Client
 	tChannelClient zanzibar.TChannelCaller
 }
@@ -96,7 +97,7 @@ func MustCreateTestService(t *testing.T) MockService {
 	return &mockService{
 		server:         		server,
 		ctrl:                   ctrl,
-		{{camel $mockType}}:    mockNodes,
+		{{camel $mock}}:        mockNodes,
 		httpClient:     		httpClient,
 		tChannelClient: 		tchannelClient,
 	}
@@ -121,9 +122,9 @@ func (m *mockService) Stop() {
 	m.ctrl.Finish()
 }
 
-// {{$mockType}} returns the mock nodes
-func (m *mockService) {{$mockType}}() *{{$mockType}} {
-	return m.{{camel $mockType}}
+// {{$mock}} returns the mock {{$leafClass}}s
+func (m *mockService) {{$mock}}() *{{$mockType}} {
+	return m.{{camel $mock}}
 }
 
 // MakeHTTPRequest makes a HTTP request to the mock server

--- a/examples/example-gateway/build/clients/contacts/mock-client/mock_client_with_fixture.go
+++ b/examples/example-gateway/build/clients/contacts/mock-client/mock_client_with_fixture.go
@@ -31,6 +31,8 @@ import (
 type MockClientWithFixture struct {
 	*MockClient
 	fixture *ClientFixture
+
+	saveContactsMock *SaveContactsMock
 }
 
 // New creates a new mock instance
@@ -55,10 +57,13 @@ type SaveContactsMock struct {
 
 // ExpectSaveContacts returns an object that allows the caller to choose expected scenario for SaveContacts
 func (m *MockClientWithFixture) ExpectSaveContacts() *SaveContactsMock {
-	return &SaveContactsMock{
-		scenarios:  m.fixture.SaveContacts,
-		mockClient: m.MockClient,
+	if m.saveContactsMock == nil {
+		m.saveContactsMock = &SaveContactsMock{
+			scenarios:  m.fixture.SaveContacts,
+			mockClient: m.MockClient,
+		}
 	}
+	return m.saveContactsMock
 }
 
 // Success sets the expected scenario as defined in the concrete fixture package

--- a/examples/example-gateway/build/clients/quux/mock-client/mock_client_with_fixture.go
+++ b/examples/example-gateway/build/clients/quux/mock-client/mock_client_with_fixture.go
@@ -31,6 +31,9 @@ import (
 type MockClientWithFixture struct {
 	*MockClient
 	fixture *ClientFixture
+
+	echoMessageMock *EchoMessageMock
+	echoStringMock  *EchoStringMock
 }
 
 // New creates a new mock instance
@@ -47,6 +50,39 @@ func (m *MockClientWithFixture) EXPECT() {
 	panic("should not call EXPECT directly.")
 }
 
+// EchoMessageMock mocks the EchoMessage method
+type EchoMessageMock struct {
+	scenarios  *EchoMessageScenarios
+	mockClient *MockClient
+}
+
+// ExpectEchoMessage returns an object that allows the caller to choose expected scenario for EchoMessage
+func (m *MockClientWithFixture) ExpectEchoMessage() *EchoMessageMock {
+	if m.echoMessageMock == nil {
+		m.echoMessageMock = &EchoMessageMock{
+			scenarios:  m.fixture.EchoMessage,
+			mockClient: m.MockClient,
+		}
+	}
+	return m.echoMessageMock
+}
+
+// Success sets the expected scenario as defined in the concrete fixture package
+// github.com/uber/zanzibar/examples/example-gateway/clients/quux/fixture
+func (s *EchoMessageMock) Success() {
+	f := s.scenarios.Success
+
+	var arg0 interface{}
+	arg0 = f.Arg0
+	if f.Arg0Any {
+		arg0 = gomock.Any()
+	}
+
+	ret0 := f.Ret0
+
+	s.mockClient.EXPECT().EchoMessage(arg0).Return(ret0)
+}
+
 // EchoStringMock mocks the EchoString method
 type EchoStringMock struct {
 	scenarios  *EchoStringScenarios
@@ -55,10 +91,13 @@ type EchoStringMock struct {
 
 // ExpectEchoString returns an object that allows the caller to choose expected scenario for EchoString
 func (m *MockClientWithFixture) ExpectEchoString() *EchoStringMock {
-	return &EchoStringMock{
-		scenarios:  m.fixture.EchoString,
-		mockClient: m.MockClient,
+	if m.echoStringMock == nil {
+		m.echoStringMock = &EchoStringMock{
+			scenarios:  m.fixture.EchoString,
+			mockClient: m.MockClient,
+		}
 	}
+	return m.echoStringMock
 }
 
 // Success sets the expected scenario as defined in the concrete fixture package

--- a/examples/example-gateway/build/clients/quux/mock-client/types.go
+++ b/examples/example-gateway/build/clients/quux/mock-client/types.go
@@ -23,14 +23,34 @@
 
 package clientmock
 
+import (
+	base "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/foo/base/base"
+)
+
 // ClientFixture defines the client fixture type
 type ClientFixture struct {
-	EchoString *EchoStringScenarios
+	EchoMessage *EchoMessageScenarios
+	EchoString  *EchoStringScenarios
+}
+
+// EchoMessageScenarios defines all fixture scenarios for EchoMessage
+type EchoMessageScenarios struct {
+	Success *EchoMessageFixture `scenario:"success"`
 }
 
 // EchoStringScenarios defines all fixture scenarios for EchoString
 type EchoStringScenarios struct {
 	Success *EchoStringFixture `scenario:"success"`
+}
+
+// EchoMessageFixture defines the fixture type for EchoMessage
+type EchoMessageFixture struct {
+	Arg0 *base.Message
+
+	// Arg{n}Any indicates the nth argument could be gomock.Any
+	Arg0Any bool
+
+	Ret0 *base.Message
 }
 
 // EchoStringFixture defines the fixture type for EchoString

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -55,18 +55,18 @@ type MockService interface {
 		headers map[string]string,
 		req, resp zanzibar.RWTStruct,
 	) (bool, map[string]string, error)
-	MockClientNodes() *MockClientNodes
+	MockClients() *MockClientNodes
 	Start()
 	Stop()
 }
 
 type mockService struct {
-	started         bool
-	server          *zanzibar.Gateway
-	ctrl            *gomock.Controller
-	mockClientNodes *MockClientNodes
-	httpClient      *http.Client
-	tChannelClient  zanzibar.TChannelCaller
+	started        bool
+	server         *zanzibar.Gateway
+	ctrl           *gomock.Controller
+	mockClients    *MockClientNodes
+	httpClient     *http.Client
+	tChannelClient zanzibar.TChannelCaller
 }
 
 // MustCreateTestService creates a new MockService, panics if it fails doing so.
@@ -112,11 +112,11 @@ func MustCreateTestService(t *testing.T) MockService {
 	)
 
 	return &mockService{
-		server:          server,
-		ctrl:            ctrl,
-		mockClientNodes: mockNodes,
-		httpClient:      httpClient,
-		tChannelClient:  tchannelClient,
+		server:         server,
+		ctrl:           ctrl,
+		mockClients:    mockNodes,
+		httpClient:     httpClient,
+		tChannelClient: tchannelClient,
 	}
 }
 
@@ -139,9 +139,9 @@ func (m *mockService) Stop() {
 	m.ctrl.Finish()
 }
 
-// MockClientNodes returns the mock nodes
-func (m *mockService) MockClientNodes() *MockClientNodes {
-	return m.mockClientNodes
+// MockClients returns the mock clients
+func (m *mockService) MockClients() *MockClientNodes {
+	return m.mockClients
 }
 
 // MakeHTTPRequest makes a HTTP request to the mock server

--- a/examples/example-gateway/clients/quux/client-config.json
+++ b/examples/example-gateway/clients/quux/client-config.json
@@ -8,6 +8,9 @@
 			"scenarios": {
 				"EchoString":[
 					"success"
+				],
+				"EchoMessage":[
+					"success"
 				]
 			}
 		}

--- a/examples/example-gateway/clients/quux/fixture/fixure.go
+++ b/examples/example-gateway/clients/quux/fixture/fixure.go
@@ -2,7 +2,10 @@ package fixture
 
 import (
 	mc "github.com/uber/zanzibar/examples/example-gateway/build/clients/quux/mock-client"
+	"github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients/foo/base/base"
 )
+
+var message = &base.Message{Body: "hola"}
 
 // Fixture ...
 var Fixture = &mc.ClientFixture{
@@ -10,6 +13,12 @@ var Fixture = &mc.ClientFixture{
 		Success: &mc.EchoStringFixture{
 			Arg0: "echo",
 			Ret0: "echo",
+		},
+	},
+	EchoMessage: &mc.EchoMessageScenarios{
+		Success: &mc.EchoMessageFixture{
+			Arg0: message,
+			Ret0: message,
 		},
 	},
 }

--- a/examples/example-gateway/endpoints/contacts/save_contacts_test.go
+++ b/examples/example-gateway/endpoints/contacts/save_contacts_test.go
@@ -15,7 +15,7 @@ func TestSaveContactsCall(t *testing.T) {
 	ms.Start()
 	defer ms.Stop()
 
-	ms.MockClientNodes().Contacts.ExpectSaveContacts().Success()
+	ms.MockClients().Contacts.ExpectSaveContacts().Success()
 
 	endpointReqeust := &endpointContacts.SaveContactsRequest{
 		Contacts: []*endpointContacts.Contact{},

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
@@ -34,7 +34,7 @@ func TestBazCall(t *testing.T) {
 
 	ctx := context.Background()
 	var result baz.SimpleService_Call_Result
-	ms.MockClientNodes().Baz.EXPECT().Call(gomock.Any(), reqHeaders, gomock.Any()).
+	ms.MockClients().Baz.EXPECT().Call(gomock.Any(), reqHeaders, gomock.Any()).
 		Return(map[string]string{"some-res-header": "something"}, nil)
 
 	success, resHeaders, err := ms.MakeTChannelRequest(


### PR DESCRIPTION
This PR:
- caches the method mocks so that subsequent calls do not create new wrapper objects;
- Renames MockClientNodes() to MockClients() on mockService for better ergonomic;