### PR TITLE
bump go version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: true
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
 go_import_path: github.com/uber/zanzibar
 env:
   global:


### PR DESCRIPTION
remove support for 1.8 since some new data structure introduced in 1.9 only (syncMap)