### PR TITLE
Add option to override tchannel client

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -524,6 +524,7 @@ func (g *TChannelClientGenerator) Generate(
 		ClientID:         clientSpec.ClientID,
 		ExposedMethods:   exposedMethods,
 		SidecarRouter:    clientSpec.SidecarRouter,
+		StagingReqHeader: g.packageHelper.StagingReqHeader(),
 	}
 
 	client, err := g.templates.ExecTemplate(
@@ -874,6 +875,13 @@ func (g *EndpointGenerator) generateEndpointFile(
 		clientName = e.ClientSpec.ClientName
 	}
 
+	reqHeaderMap := make(map[string]string)
+	for k, v := range e.ReqHeaderMap {
+		reqHeaderMap[k] = v
+	}
+	reqHeaderMap[g.packageHelper.StagingReqHeader()] = g.packageHelper.StagingReqHeader()
+	reqHeaderMapKeys := append(e.ReqHeaderMapKeys, g.packageHelper.StagingReqHeader())
+
 	// TODO: http client needs to support multiple thrift services
 	meta := &EndpointMeta{
 		Instance:           instance,
@@ -881,8 +889,8 @@ func (g *EndpointGenerator) generateEndpointFile(
 		GatewayPackageName: g.packageHelper.GoGatewayPackageName(),
 		IncludedPackages:   includedPackages,
 		Method:             method,
-		ReqHeaderMap:       e.ReqHeaderMap,
-		ReqHeaderMapKeys:   e.ReqHeaderMapKeys,
+		ReqHeaderMap:       reqHeaderMap,
+		ReqHeaderMapKeys:   reqHeaderMapKeys,
 		ResHeaderMap:       e.ResHeaderMap,
 		ResHeaderMapKeys:   e.ResHeaderMapKeys,
 		ClientID:           clientID,
@@ -1214,6 +1222,7 @@ type ClientMeta struct {
 	ExposedMethods   map[string]string
 	SidecarRouter    string
 	Fixture          *Fixture
+	StagingReqHeader string
 }
 
 func findMethod(

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -53,6 +53,8 @@ type PackageHelper struct {
 	annotationPrefix string
 	// The middlewares available for the endpoints
 	middlewareSpecs map[string]*MiddlewareSpec
+	// Use staging client when this header is set as "true"
+	stagingReqHeader string
 }
 
 // NewPackageHelper creates a package helper.
@@ -66,6 +68,7 @@ func NewPackageHelper(
 	relTargetGenDir string,
 	copyrightHeader string,
 	annotationPrefix string,
+	stagingReqHeader string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
 	if err != nil {
@@ -93,6 +96,7 @@ func NewPackageHelper(
 		copyrightHeader:     copyrightHeader,
 		middlewareSpecs:     middlewareSpecs,
 		annotationPrefix:    annotationPrefix,
+		stagingReqHeader:    stagingReqHeader,
 	}
 	return p, nil
 }
@@ -206,4 +210,10 @@ func (p PackageHelper) TypeFullName(typeSpec compile.TypeSpec) (string, error) {
 		return "", nil
 	}
 	return GoType(p, typeSpec)
+}
+
+// StagingReqHeader returns the header name that will be checked to determine
+// if a request should go to the staging downstream client
+func (p PackageHelper) StagingReqHeader() string {
+	return p.stagingReqHeader
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -73,6 +73,7 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		tmpDir,
 		testCopyrightHeader,
 		"zanzibar",
+		"X-Zanzibar-Use-Staging",
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {
 		return nil

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -78,6 +78,11 @@ func main() {
 		copyright = []byte("")
 	}
 
+	stagingReqHeader := "X-Zanzibar-Use-Staging"
+	if config.ContainsKey("stagingReqHeader") {
+		stagingReqHeader = config.MustGetString("stagingReqHeader")
+	}
+
 	packageHelper, err := codegen.NewPackageHelper(
 		config.MustGetString("packageRoot"),
 		config.MustGetString("managedThriftFolder"),
@@ -88,6 +93,7 @@ func main() {
 		config.MustGetString("targetGenDir"),
 		string(copyright),
 		config.MustGetString("annotationPrefix"),
+		stagingReqHeader,
 	)
 	checkError(
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2207,10 +2207,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
-	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
-		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
-		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
-		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
+	} else if deps.Default.Config.ContainsKey("clients.staging.all.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.staging.all.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.staging.all.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.staging.all.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -464,18 +464,16 @@ func (w {{$workflow}}) Handle(
 	clientRequest = propagateHeaders{{title .Name}}ClientRequests(clientRequest, reqHeaders)
 	{{end}}
 	clientHeaders := map[string]string{}
+	{{if (ne (len $reqHeaderMapKeys) 0) }}
 	var ok bool
 	var h string
+	{{- end -}}
 	{{range $i, $k := $reqHeaderMapKeys}}
 	h, ok = reqHeaders.Get("{{$k}}")
 	if ok {
 		clientHeaders["{{index $reqHeaderMap $k}}"] = h
 	}
 	{{- end}}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
-	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
-	}
 	{{if and (eq $clientReqType "") (eq $clientResType "")}}
 		{{if (eq (len $resHeaderMap) 0) -}}
 		_, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(ctx, clientHeaders)
@@ -610,7 +608,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 10973, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 10916, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2161,6 +2159,7 @@ import (
 {{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
+{{- $stagingReqHeader := .StagingReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -2286,7 +2285,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
 			caller = c.client.CallThruAltChannel
 		}
 		success, respHeaders, err := caller(
@@ -2337,7 +2336,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6228, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6271, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2201,11 +2201,13 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
+		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
+		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
-		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
 	}
 
 	{{/* TODO: (lu) maybe set these at per method level */ -}}
@@ -2328,7 +2330,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5588, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5765, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2201,10 +2201,17 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
-		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
-		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
+	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.{{$clientID}}.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.{{$clientID}}.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.{{$clientID}}.staging.port")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
+	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
@@ -2330,7 +2337,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 5765, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6228, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -69,6 +69,7 @@ func TestGenerateBar(t *testing.T) {
 		tmpDir,
 		testCopyrightHeader,
 		"zanzibar",
+		"X-Zanzibar-Use-Staging",
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {
 		return

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -252,16 +252,18 @@ func (w {{$workflow}}) Handle(
 	clientRequest = propagateHeaders{{title .Name}}ClientRequests(clientRequest, reqHeaders)
 	{{end}}
 	clientHeaders := map[string]string{}
-	{{if (ne (len $reqHeaderMapKeys) 0) }}
 	var ok bool
 	var h string
-	{{- end -}}
 	{{range $i, $k := $reqHeaderMapKeys}}
 	h, ok = reqHeaders.Get("{{$k}}")
 	if ok {
 		clientHeaders["{{index $reqHeaderMap $k}}"] = h
 	}
 	{{- end}}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 	{{if and (eq $clientReqType "") (eq $clientResType "")}}
 		{{if (eq (len $resHeaderMap) 0) -}}
 		_, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(ctx, clientHeaders)

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -252,18 +252,16 @@ func (w {{$workflow}}) Handle(
 	clientRequest = propagateHeaders{{title .Name}}ClientRequests(clientRequest, reqHeaders)
 	{{end}}
 	clientHeaders := map[string]string{}
+	{{if (ne (len $reqHeaderMapKeys) 0) }}
 	var ok bool
 	var h string
+	{{- end -}}
 	{{range $i, $k := $reqHeaderMapKeys}}
 	h, ok = reqHeaders.Get("{{$k}}")
 	if ok {
 		clientHeaders["{{index $reqHeaderMap $k}}"] = h
 	}
 	{{- end}}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
-	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
-	}
 	{{if and (eq $clientReqType "") (eq $clientResType "")}}
 		{{if (eq (len $resHeaderMap) 0) -}}
 		_, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(ctx, clientHeaders)

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -25,6 +25,7 @@ import (
 {{- $clientName := printf "%sClient" (camel $clientID) }}
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
+{{- $stagingReqHeader := .StagingReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -150,7 +151,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
 			caller = c.client.CallThruAltChannel
 		}
 		success, respHeaders, err := caller(

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -140,9 +140,12 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
-		useAltSc := strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true")
-		success, respHeaders, err := c.client.Call(
-			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result, useAltSc,
+		caller := c.client.Call
+		if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+			caller = c.client.CallThruAltChannel
+		}
+		success, respHeaders, err := caller(
+			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 		)
 
 		if err == nil && !success {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -63,6 +64,14 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	{{end -}}
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
+	var scAltName string
+	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	}
+
 	{{/* TODO: (lu) maybe set these at per method level */ -}}
 	timeout := time.Millisecond * time.Duration(
 		deps.Default.Config.MustGetInt("clients.{{$clientID}}.timeout"),
@@ -94,6 +103,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			Timeout:           timeout,
 			TimeoutPerAttempt: timeoutPerAttempt,
 			RoutingKey:        &routingKey,
+			AltSubchannelName: scAltName,
 		},
 	)
 
@@ -130,8 +140,9 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
+		useAltSc := strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true")
 		success, respHeaders, err := c.client.Call(
-			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
+			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result, useAltSc,
 		)
 
 		if err == nil && !success {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -65,11 +65,13 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
+		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
+		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
-		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
 	}
 
 	{{/* TODO: (lu) maybe set these at per method level */ -}}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -65,10 +65,17 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
-		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
-		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
+	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.{{$clientID}}.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.{{$clientID}}.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.{{$clientID}}.staging.port")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
+	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -73,10 +73,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
-	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
-		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
-		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
-		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
+	} else if deps.Default.Config.ContainsKey("clients.staging.all.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.staging.all.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.staging.all.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.staging.all.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -128,6 +128,13 @@ func (w BarArgNotStructEndpoint) Handle(
 	clientRequest := convertToArgNotStructClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	_, err := w.Clients.Bar.ArgNotStruct(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argnotstruct.gogen
@@ -84,6 +84,12 @@ func (h *BarArgNotStructHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgNotStructEndpoint{
@@ -128,12 +134,12 @@ func (w BarArgNotStructEndpoint) Handle(
 	clientRequest := convertToArgNotStructClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	_, err := w.Clients.Bar.ArgNotStruct(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -134,12 +134,16 @@ func (w BarArgWithHeadersEndpoint) Handle(
 	clientRequest := convertToArgWithHeadersClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -99,6 +99,10 @@ func (h *BarArgWithHeadersHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithHeadersEndpoint{
@@ -134,16 +138,16 @@ func (w BarArgWithHeadersEndpoint) Handle(
 	clientRequest := convertToArgWithHeadersClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -250,6 +250,13 @@ func (w BarArgWithManyQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithManyQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -215,6 +215,12 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithManyQueryParamsEndpoint{
@@ -250,12 +256,12 @@ func (w BarArgWithManyQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithManyQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -194,6 +194,13 @@ func (w BarArgWithNestedQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithNestedQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -159,6 +159,12 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithNestedQueryParamsEndpoint{
@@ -194,12 +200,12 @@ func (w BarArgWithNestedQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithNestedQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -90,6 +90,12 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithParamsEndpoint{
@@ -125,12 +131,12 @@ func (w BarArgWithParamsEndpoint) Handle(
 	clientRequest := convertToArgWithParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithParams(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -125,6 +125,13 @@ func (w BarArgWithParamsEndpoint) Handle(
 	clientRequest := convertToArgWithParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithParams(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -87,6 +87,12 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithQueryHeaderEndpoint{
@@ -122,12 +128,12 @@ func (w BarArgWithQueryHeaderEndpoint) Handle(
 	clientRequest := convertToArgWithQueryHeaderClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -122,6 +122,13 @@ func (w BarArgWithQueryHeaderEndpoint) Handle(
 	clientRequest := convertToArgWithQueryHeaderClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -146,9 +146,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -156,6 +156,10 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -111,6 +111,10 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithQueryParamsEndpoint{
@@ -146,9 +150,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -157,9 +161,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(

--- a/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
@@ -126,6 +126,13 @@ func (w BarHelloWorldEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.Hello(
 		ctx, clientHeaders,

--- a/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_helloworld.gogen
@@ -79,6 +79,12 @@ func (h *BarHelloWorldHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarHelloWorldEndpoint{
@@ -126,12 +132,12 @@ func (w BarHelloWorldEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.Hello(

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -77,6 +77,12 @@ func (h *BarMissingArgHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarMissingArgEndpoint{
@@ -120,12 +126,12 @@ func (w BarMissingArgEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.MissingArg(

--- a/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_missingarg.gogen
@@ -120,6 +120,13 @@ func (w BarMissingArgEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.MissingArg(
 		ctx, clientHeaders,

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -77,6 +77,12 @@ func (h *BarNoRequestHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarNoRequestEndpoint{
@@ -120,12 +126,12 @@ func (w BarNoRequestEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.NoRequest(

--- a/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_norequest.gogen
@@ -120,6 +120,13 @@ func (w BarNoRequestEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.NoRequest(
 		ctx, clientHeaders,

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -93,6 +93,12 @@ func (h *BarNormalHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarNormalEndpoint{
@@ -138,12 +144,12 @@ func (w BarNormalEndpoint) Handle(
 	clientRequest := convertToNormalClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.Normal(

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -138,6 +138,13 @@ func (w BarNormalEndpoint) Handle(
 	clientRequest := convertToNormalClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.Normal(
 		ctx, clientHeaders, clientRequest,

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -152,9 +152,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	clientRequest := convertToTooManyArgsClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -162,6 +162,10 @@ func (w BarTooManyArgsEndpoint) Handle(
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, cliRespHeaders, err := w.Clients.Bar.TooManyArgs(

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -100,6 +100,10 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarTooManyArgsEndpoint{
@@ -152,9 +156,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	clientRequest := convertToTooManyArgsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -163,9 +167,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, cliRespHeaders, err := w.Clients.Bar.TooManyArgs(

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -170,10 +170,17 @@ func NewClient(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
-		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
-		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
+	if deps.Default.Config.ContainsKey("clients.baz.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.baz.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.baz.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.baz.staging.port")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
+	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -170,11 +170,13 @@ func NewClient(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
+		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
+		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
-		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
 	}
 
 	timeout := time.Millisecond * time.Duration(

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -256,7 +256,7 @@ func (c *bazClient) EchoBinary(
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -293,7 +293,7 @@ func (c *bazClient) EchoBool(
 	logger := c.client.Loggers["SecondService::echoBool"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -330,7 +330,7 @@ func (c *bazClient) EchoDouble(
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -367,7 +367,7 @@ func (c *bazClient) EchoEnum(
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -404,7 +404,7 @@ func (c *bazClient) EchoI16(
 	logger := c.client.Loggers["SecondService::echoI16"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -441,7 +441,7 @@ func (c *bazClient) EchoI32(
 	logger := c.client.Loggers["SecondService::echoI32"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -478,7 +478,7 @@ func (c *bazClient) EchoI64(
 	logger := c.client.Loggers["SecondService::echoI64"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -515,7 +515,7 @@ func (c *bazClient) EchoI8(
 	logger := c.client.Loggers["SecondService::echoI8"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -552,7 +552,7 @@ func (c *bazClient) EchoString(
 	logger := c.client.Loggers["SecondService::echoString"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -589,7 +589,7 @@ func (c *bazClient) EchoStringList(
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -626,7 +626,7 @@ func (c *bazClient) EchoStringMap(
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -663,7 +663,7 @@ func (c *bazClient) EchoStringSet(
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -700,7 +700,7 @@ func (c *bazClient) EchoStructList(
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -737,7 +737,7 @@ func (c *bazClient) EchoStructSet(
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -774,7 +774,7 @@ func (c *bazClient) EchoTypedef(
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -810,7 +810,7 @@ func (c *bazClient) Call(
 	logger := c.client.Loggers["SimpleService::call"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -845,7 +845,7 @@ func (c *bazClient) Compare(
 	logger := c.client.Loggers["SimpleService::compare"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -886,7 +886,7 @@ func (c *bazClient) Ping(
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -922,7 +922,7 @@ func (c *bazClient) DeliberateDiffNoop(
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -958,7 +958,7 @@ func (c *bazClient) TestUUID(
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -991,7 +991,7 @@ func (c *bazClient) Trans(
 	logger := c.client.Loggers["SimpleService::trans"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -1032,7 +1032,7 @@ func (c *bazClient) TransHeaders(
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(
@@ -1072,7 +1072,7 @@ func (c *bazClient) URLTest(
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -177,10 +177,10 @@ func NewClient(deps *module.Dependencies) Client {
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
-	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
-		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
-		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
-		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
+	} else if deps.Default.Config.ContainsKey("clients.staging.all.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.staging.all.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.staging.all.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.staging.all.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -168,6 +169,14 @@ func NewClient(deps *module.Dependencies) Client {
 	port := deps.Default.Config.MustGetInt("clients.baz.port")
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
+	var scAltName string
+	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	}
+
 	timeout := time.Millisecond * time.Duration(
 		deps.Default.Config.MustGetInt("clients.baz.timeout"),
 	)
@@ -212,6 +221,7 @@ func NewClient(deps *module.Dependencies) Client {
 			Timeout:           timeout,
 			TimeoutPerAttempt: timeoutPerAttempt,
 			RoutingKey:        &routingKey,
+			AltSubchannelName: scAltName,
 		},
 	)
 
@@ -236,7 +246,11 @@ func (c *bazClient) EchoBinary(
 
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 	)
 
@@ -269,7 +283,11 @@ func (c *bazClient) EchoBool(
 
 	logger := c.client.Loggers["SecondService::echoBool"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 	)
 
@@ -302,7 +320,11 @@ func (c *bazClient) EchoDouble(
 
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 	)
 
@@ -335,7 +357,11 @@ func (c *bazClient) EchoEnum(
 
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 	)
 
@@ -368,7 +394,11 @@ func (c *bazClient) EchoI16(
 
 	logger := c.client.Loggers["SecondService::echoI16"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 	)
 
@@ -401,7 +431,11 @@ func (c *bazClient) EchoI32(
 
 	logger := c.client.Loggers["SecondService::echoI32"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 	)
 
@@ -434,7 +468,11 @@ func (c *bazClient) EchoI64(
 
 	logger := c.client.Loggers["SecondService::echoI64"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 	)
 
@@ -467,7 +505,11 @@ func (c *bazClient) EchoI8(
 
 	logger := c.client.Loggers["SecondService::echoI8"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 	)
 
@@ -500,7 +542,11 @@ func (c *bazClient) EchoString(
 
 	logger := c.client.Loggers["SecondService::echoString"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoString", reqHeaders, args, &result,
 	)
 
@@ -533,7 +579,11 @@ func (c *bazClient) EchoStringList(
 
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 	)
 
@@ -566,7 +616,11 @@ func (c *bazClient) EchoStringMap(
 
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 	)
 
@@ -599,7 +653,11 @@ func (c *bazClient) EchoStringSet(
 
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 	)
 
@@ -632,7 +690,11 @@ func (c *bazClient) EchoStructList(
 
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 	)
 
@@ -665,7 +727,11 @@ func (c *bazClient) EchoStructSet(
 
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 	)
 
@@ -698,7 +764,11 @@ func (c *bazClient) EchoTypedef(
 
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 	)
 
@@ -730,7 +800,11 @@ func (c *bazClient) Call(
 
 	logger := c.client.Loggers["SimpleService::call"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "call", reqHeaders, args, &result,
 	)
 
@@ -761,7 +835,11 @@ func (c *bazClient) Compare(
 
 	logger := c.client.Loggers["SimpleService::compare"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "compare", reqHeaders, args, &result,
 	)
 
@@ -798,7 +876,11 @@ func (c *bazClient) Ping(
 	logger := c.client.Loggers["SimpleService::ping"]
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "ping", reqHeaders, args, &result,
 	)
 
@@ -830,7 +912,11 @@ func (c *bazClient) DeliberateDiffNoop(
 	logger := c.client.Loggers["SimpleService::sillyNoop"]
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 	)
 
@@ -862,7 +948,11 @@ func (c *bazClient) TestUUID(
 	logger := c.client.Loggers["SimpleService::testUuid"]
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 	)
 
@@ -891,7 +981,11 @@ func (c *bazClient) Trans(
 
 	logger := c.client.Loggers["SimpleService::trans"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "trans", reqHeaders, args, &result,
 	)
 
@@ -928,7 +1022,11 @@ func (c *bazClient) TransHeaders(
 
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 	)
 
@@ -964,7 +1062,11 @@ func (c *bazClient) URLTest(
 	logger := c.client.Loggers["SimpleService::urlTest"]
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
-	success, respHeaders, err := c.client.Call(
+	caller := c.client.Call
+	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+		caller = c.client.CallThruAltChannel
+	}
+	success, respHeaders, err := caller(
 		ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 	)
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -62,10 +62,17 @@ func NewClient(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
-		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
-		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
+	if deps.Default.Config.ContainsKey("clients.corge.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.corge.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.corge.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.corge.staging.port")
+
+		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
+	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -62,11 +62,13 @@ func NewClient(deps *module.Dependencies) Client {
 	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	var scAltName string
-	if deps.Default.Config.ContainsKey("test.clients.overrideService") {
-		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService")
+	if deps.Default.Config.ContainsKey("test.clients.overrideService.name") {
+		scAltName = deps.Default.Config.MustGetString("test.clients.overrideService.name")
+		ipAlt := deps.Default.Config.MustGetString("test.clients.overrideService.ip")
+		portAlt := deps.Default.Config.MustGetInt("test.clients.overrideService.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
-		scAlt.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
 	}
 
 	timeout := time.Millisecond * time.Duration(

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -69,10 +69,10 @@ func NewClient(deps *module.Dependencies) Client {
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))
-	} else if deps.Default.Config.ContainsKey("clients.all.staging.serviceName") {
-		scAltName = deps.Default.Config.MustGetString("clients.all.staging.serviceName")
-		ipAlt := deps.Default.Config.MustGetString("clients.all.staging.ip")
-		portAlt := deps.Default.Config.MustGetInt("clients.all.staging.port")
+	} else if deps.Default.Config.ContainsKey("clients.staging.all.serviceName") {
+		scAltName = deps.Default.Config.MustGetString("clients.staging.all.serviceName")
+		ipAlt := deps.Default.Config.MustGetString("clients.staging.all.ip")
+		portAlt := deps.Default.Config.MustGetInt("clients.staging.all.port")
 
 		scAlt := deps.Default.Channel.GetSubChannel(scAltName, tchannel.Isolated)
 		scAlt.Peers().Add(ipAlt + ":" + strconv.Itoa(int(portAlt)))

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -126,7 +126,7 @@ func (c *corgeClient) EchoString(
 	logger := c.client.Loggers["Corge::echoString"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Test-Override-Service"], "true") {
+	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
 	success, respHeaders, err := caller(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -128,6 +128,13 @@ func (w BarArgNotStructEndpoint) Handle(
 	clientRequest := convertToArgNotStructClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	_, err := w.Clients.Bar.ArgNotStruct(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -84,6 +84,12 @@ func (h *BarArgNotStructHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgNotStructEndpoint{
@@ -128,12 +134,12 @@ func (w BarArgNotStructEndpoint) Handle(
 	clientRequest := convertToArgNotStructClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	_, err := w.Clients.Bar.ArgNotStruct(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -134,12 +134,16 @@ func (w BarArgWithHeadersEndpoint) Handle(
 	clientRequest := convertToArgWithHeadersClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -99,6 +99,10 @@ func (h *BarArgWithHeadersHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithHeadersEndpoint{
@@ -134,16 +138,16 @@ func (w BarArgWithHeadersEndpoint) Handle(
 	clientRequest := convertToArgWithHeadersClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -250,6 +250,13 @@ func (w BarArgWithManyQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithManyQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -215,6 +215,12 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithManyQueryParamsEndpoint{
@@ -250,12 +256,12 @@ func (w BarArgWithManyQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithManyQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -194,6 +194,13 @@ func (w BarArgWithNestedQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithNestedQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -159,6 +159,12 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithNestedQueryParamsEndpoint{
@@ -194,12 +200,12 @@ func (w BarArgWithNestedQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithNestedQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -90,6 +90,12 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithParamsEndpoint{
@@ -125,12 +131,12 @@ func (w BarArgWithParamsEndpoint) Handle(
 	clientRequest := convertToArgWithParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithParams(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -125,6 +125,13 @@ func (w BarArgWithParamsEndpoint) Handle(
 	clientRequest := convertToArgWithParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithParams(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -87,6 +87,12 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithQueryHeaderEndpoint{
@@ -122,12 +128,12 @@ func (w BarArgWithQueryHeaderEndpoint) Handle(
 	clientRequest := convertToArgWithQueryHeaderClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -122,6 +122,13 @@ func (w BarArgWithQueryHeaderEndpoint) Handle(
 	clientRequest := convertToArgWithQueryHeaderClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -146,9 +146,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -156,6 +156,10 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -111,6 +111,10 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarArgWithQueryParamsEndpoint{
@@ -146,9 +150,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	clientRequest := convertToArgWithQueryParamsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -157,9 +161,9 @@ func (w BarArgWithQueryParamsEndpoint) Handle(
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -126,6 +126,13 @@ func (w BarHelloWorldEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.Hello(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -79,6 +79,12 @@ func (h *BarHelloWorldHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarHelloWorldEndpoint{
@@ -126,12 +132,12 @@ func (w BarHelloWorldEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.Hello(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -77,6 +77,12 @@ func (h *BarMissingArgHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarMissingArgEndpoint{
@@ -120,12 +126,12 @@ func (w BarMissingArgEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.MissingArg(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -120,6 +120,13 @@ func (w BarMissingArgEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.MissingArg(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -77,6 +77,12 @@ func (h *BarNoRequestHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarNoRequestEndpoint{
@@ -120,12 +126,12 @@ func (w BarNoRequestEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.NoRequest(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -120,6 +120,13 @@ func (w BarNoRequestEndpoint) Handle(
 ) (*endpointsBarBar.BarResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.NoRequest(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -93,6 +93,12 @@ func (h *BarNormalHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarNormalEndpoint{
@@ -138,12 +144,12 @@ func (w BarNormalEndpoint) Handle(
 	clientRequest := convertToNormalClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Bar.Normal(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -138,6 +138,13 @@ func (w BarNormalEndpoint) Handle(
 	clientRequest := convertToNormalClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Bar.Normal(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -152,9 +152,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	clientRequest := convertToTooManyArgsClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -162,6 +162,10 @@ func (w BarTooManyArgsEndpoint) Handle(
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	clientRespBody, cliRespHeaders, err := w.Clients.Bar.TooManyArgs(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -100,6 +100,10 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := BarTooManyArgsEndpoint{
@@ -152,9 +156,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	clientRequest := convertToTooManyArgsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -163,9 +167,9 @@ func (w BarTooManyArgsEndpoint) Handle(
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, cliRespHeaders, err := w.Clients.Bar.TooManyArgs(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -112,6 +112,10 @@ func (h *SimpleServiceCallHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServiceCallEndpoint{
@@ -157,9 +161,9 @@ func (w SimpleServiceCallEndpoint) Handle(
 	clientRequest := convertToCallClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -168,9 +172,9 @@ func (w SimpleServiceCallEndpoint) Handle(
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.Baz.Call(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -157,9 +157,9 @@ func (w SimpleServiceCallEndpoint) Handle(
 	clientRequest := convertToCallClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h
@@ -167,6 +167,10 @@ func (w SimpleServiceCallEndpoint) Handle(
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.Baz.Call(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -135,6 +135,13 @@ func (w SimpleServiceCompareEndpoint) Handle(
 	clientRequest := convertToCompareClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Baz.Compare(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -85,6 +85,12 @@ func (h *SimpleServiceCompareHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServiceCompareEndpoint{
@@ -135,12 +141,12 @@ func (w SimpleServiceCompareEndpoint) Handle(
 	clientRequest := convertToCompareClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Baz.Compare(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -77,6 +77,12 @@ func (h *SimpleServicePingHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServicePingEndpoint{
@@ -109,12 +115,12 @@ func (w SimpleServicePingEndpoint) Handle(
 ) (*endpointsBazBaz.BazResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Baz.Ping(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -109,6 +109,13 @@ func (w SimpleServicePingEndpoint) Handle(
 ) (*endpointsBazBaz.BazResponse, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Baz.Ping(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -78,6 +78,12 @@ func (h *SimpleServiceSillyNoopHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServiceSillyNoopEndpoint{
@@ -126,12 +132,12 @@ func (w SimpleServiceSillyNoopEndpoint) Handle(
 ) (zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	_, err := w.Clients.Baz.DeliberateDiffNoop(ctx, clientHeaders)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -126,6 +126,13 @@ func (w SimpleServiceSillyNoopEndpoint) Handle(
 ) (zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	_, err := w.Clients.Baz.DeliberateDiffNoop(ctx, clientHeaders)
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -135,6 +135,13 @@ func (w SimpleServiceTransEndpoint) Handle(
 	clientRequest := convertToTransClientRequest(r)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Baz.Trans(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -85,6 +85,12 @@ func (h *SimpleServiceTransHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServiceTransEndpoint{
@@ -135,12 +141,12 @@ func (w SimpleServiceTransEndpoint) Handle(
 	clientRequest := convertToTransClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Baz.Trans(

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -140,6 +140,13 @@ func (w SimpleServiceTransHeadersEndpoint) Handle(
 	clientRequest = propagateHeadersTransHeadersClientRequests(clientRequest, reqHeaders)
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Baz.TransHeaders(
 		ctx, clientHeaders, clientRequest,

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -88,6 +88,12 @@ func (h *SimpleServiceTransHeadersHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := SimpleServiceTransHeadersEndpoint{
@@ -140,12 +146,12 @@ func (w SimpleServiceTransHeadersEndpoint) Handle(
 	clientRequest = propagateHeadersTransHeadersClientRequests(clientRequest, reqHeaders)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Baz.TransHeaders(

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -86,6 +86,12 @@ func (h *ContactsSaveContactsHandler) HandleRequest(
 
 	// TODO: potential perf issue, use zap.Object lazy serialization
 	zfields = append(zfields, zap.String("body", fmt.Sprintf("%#v", requestBody)))
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := customContacts.SaveContactsEndpoint{

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -128,12 +128,16 @@ func (w GoogleNowAddCredentialsEndpoint) Handle(
 	clientRequest := convertToAddCredentialsClientRequest(r)
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.AddCredentials(

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -93,6 +93,10 @@ func (h *GoogleNowAddCredentialsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := GoogleNowAddCredentialsEndpoint{
@@ -128,16 +132,16 @@ func (w GoogleNowAddCredentialsEndpoint) Handle(
 	clientRequest := convertToAddCredentialsClientRequest(r)
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.AddCredentials(

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -83,6 +83,10 @@ func (h *GoogleNowCheckCredentialsHandler) HandleRequest(
 	if headerOk {
 		zfields = append(zfields, zap.String("X-Uuid", headerValue))
 	}
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := GoogleNowCheckCredentialsEndpoint{
@@ -116,16 +120,16 @@ func (w GoogleNowCheckCredentialsEndpoint) Handle(
 ) (zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
 	}
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.CheckCredentials(ctx, clientHeaders)

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -116,12 +116,16 @@ func (w GoogleNowCheckCredentialsEndpoint) Handle(
 ) (zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
-
 	var ok bool
 	var h string
+
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["X-Uuid"] = h
+	}
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
 	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.CheckCredentials(ctx, clientHeaders)

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -76,6 +76,12 @@ func (h *ServiceAFrontHelloHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := ServiceAFrontHelloEndpoint{
@@ -113,12 +119,12 @@ func (w ServiceAFrontHelloEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Multi.HelloA(

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -113,6 +113,13 @@ func (w ServiceAFrontHelloEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Multi.HelloA(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -113,6 +113,13 @@ func (w ServiceBFrontHelloEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+	var ok bool
+	var h string
+
+	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	if ok {
+		clientHeaders["X-Test-Override-Service"] = h
+	}
 
 	clientRespBody, _, err := w.Clients.Multi.HelloB(
 		ctx, clientHeaders,

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -76,6 +76,12 @@ func (h *ServiceBFrontHelloHandler) HandleRequest(
 		zap.String("endpoint", h.endpoint.EndpointName),
 	}
 
+	var headerOk bool
+	var headerValue string
+	headerValue, headerOk = req.Header.Get("X-Zanzibar-Use-Staging")
+	if headerOk {
+		zfields = append(zfields, zap.String("X-Zanzibar-Use-Staging", headerValue))
+	}
 	req.Logger.Debug("Endpoint request to downstream", zfields...)
 
 	workflow := ServiceBFrontHelloEndpoint{
@@ -113,12 +119,12 @@ func (w ServiceBFrontHelloEndpoint) Handle(
 ) (string, zanzibar.Header, error) {
 
 	clientHeaders := map[string]string{}
+
 	var ok bool
 	var h string
-
-	h, ok = reqHeaders.Get("X-Test-Override-Service")
+	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
-		clientHeaders["X-Test-Override-Service"] = h
+		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
 
 	clientRespBody, _, err := w.Clients.Multi.HelloB(

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -50,7 +50,7 @@ type TChannelClientOption struct {
 	MethodNames map[string]string
 
 	// An alternate subchannel that can optionally be used to make a TChannel call
-	// instead; allows the service name to be overridden when a "X-Test-Override-Service"
+	// instead; e.g. can allow the service to be overridden when a "X-Zanzibar-Use-Staging"
 	// header is present
 	AltSubchannelName string
 }

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -138,7 +138,6 @@ func (c *TChannelClient) Call(
 	thriftService, methodName string,
 	reqHeaders map[string]string,
 	req, resp RWTStruct,
-	useAltSubchannel bool,
 ) (success bool, resHeaders map[string]string, err error) {
 	serviceMethod := thriftService + "::" + methodName
 
@@ -151,7 +150,28 @@ func (c *TChannelClient) Call(
 		metrics:       c.metrics[serviceMethod],
 	}
 
-	return c.call(ctx, call, reqHeaders, req, resp, useAltSubchannel)
+	return c.call(ctx, call, reqHeaders, req, resp, false)
+}
+
+// CallThruAltChannel makes a RPC call using a configured alternate channel
+func (c *TChannelClient) CallThruAltChannel(
+	ctx context.Context,
+	thriftService, methodName string,
+	reqHeaders map[string]string,
+	req, resp RWTStruct,
+) (success bool, resHeaders map[string]string, err error) {
+	serviceMethod := thriftService + "::" + methodName
+
+	call := &tchannelOutboundCall{
+		client:        c,
+		methodName:    c.methodNames[serviceMethod],
+		serviceMethod: serviceMethod,
+		reqHeaders:    reqHeaders,
+		logger:        c.Loggers[serviceMethod],
+		metrics:       c.metrics[serviceMethod],
+	}
+
+	return c.call(ctx, call, reqHeaders, req, resp, true)
 }
 
 func (c *TChannelClient) call(

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -99,5 +99,5 @@ func (r *RawTChannelClient) Call(
 		call.metrics = r.tc.metrics[serviceMethod]
 	}
 
-	return r.tc.call(ctx, call, reqHeaders, req, resp)
+	return r.tc.call(ctx, call, reqHeaders, req, resp, false)
 }


### PR DESCRIPTION
Add config option `"clients.{{client}}.staging.name .ip .port: someservice, ip, port"` and `"clients.staging.all.name .ip .port: someservice, ip, port"`so that when requests have a `"X-Zanzibar-Use-Staging: true"` header (default; configurable in gateway.json), they will go to `someservice` instead of the original downstream service (for tchannel clients only)