### PR TITLE
add trace key to response

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint: check-licence eclint-check
 	@echo "Checking vet..."
 	@$(foreach dir,$(PKG_FILES),go tool vet $(VET_RULES) $(dir) 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
 	@echo "Checking lint..."
-	@go get github.com/golang/lint/golint
+	@go get golang.org/x/lint/golint
 	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
 	@echo "Checking errcheck..."
 	@go get github.com/kisielk/errcheck

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -48,6 +48,7 @@ type EndpointMeta struct {
 	ResHeaders             map[string]*TypedHeader
 	ResHeadersKeys         []string
 	ResRequiredHeadersKeys []string
+	TraceKey               string
 }
 
 // EndpointCollectionMeta saves information used to generate an initializer
@@ -916,6 +917,7 @@ func (g *EndpointGenerator) generateEndpointFile(
 		ClientName:             clientName,
 		ClientMethodName:       e.ClientMethod,
 		WorkflowPkg:            workflowPkg,
+		TraceKey:               g.packageHelper.traceKey,
 	}
 
 	var endpoint []byte

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -55,6 +55,8 @@ type PackageHelper struct {
 	middlewareSpecs map[string]*MiddlewareSpec
 	// Use staging client when this header is set as "true"
 	stagingReqHeader string
+	// traceKey is the key for uniq trace id that identifies request / response pair
+	traceKey string
 }
 
 // NewPackageHelper creates a package helper.
@@ -69,6 +71,7 @@ func NewPackageHelper(
 	copyrightHeader string,
 	annotationPrefix string,
 	stagingReqHeader string,
+	traceKey string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
 	if err != nil {
@@ -97,6 +100,7 @@ func NewPackageHelper(
 		middlewareSpecs:     middlewareSpecs,
 		annotationPrefix:    annotationPrefix,
 		stagingReqHeader:    stagingReqHeader,
+		traceKey:            traceKey,
 	}
 	return p, nil
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -74,6 +74,7 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {
 		return nil

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -94,7 +94,7 @@ func main() {
 		string(copyright),
 		config.MustGetString("annotationPrefix"),
 		stagingReqHeader,
-		config.MustGetString("trace-key"),
+		config.MustGetString("traceKey"),
 	)
 	checkError(
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -94,6 +94,7 @@ func main() {
 		string(copyright),
 		config.MustGetString("annotationPrefix"),
 		stagingReqHeader,
+		config.MustGetString("trace-key"),
 	)
 	checkError(
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -232,6 +232,7 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $middlewares := .Spec.Middlewares }}
 {{- $workflowPkg := .WorkflowPkg }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
+{{- $traceKey := .TraceKey }}
 
 import (
 	"context"
@@ -391,6 +392,9 @@ func (h *{{$handlerName}}) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("{{$traceKey}}"); ok {
+			zfields = append(zfields, zap.String("{{$traceKey}}", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 
@@ -450,7 +454,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 6373, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 6534, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -70,6 +70,7 @@ func TestGenerateBar(t *testing.T) {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {
 		return

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -17,6 +17,7 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $middlewares := .Spec.Middlewares }}
 {{- $workflowPkg := .WorkflowPkg }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
+{{- $traceKey := .TraceKey }}
 
 import (
 	"context"
@@ -175,6 +176,9 @@ func (h *{{$handlerName}}) HandleRequest(
 			if val, ok := cliRespHeaders.Get(k); ok {
 				zfields = append(zfields, zap.String(k, val))
 			}
+		}
+		if traceKey, ok := req.Header.Get("{{$traceKey}}"); ok {
+			zfields = append(zfields, zap.String("{{$traceKey}}", traceKey))
 		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}

--- a/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithheaders.gogen
@@ -122,6 +122,9 @@ func (h *BarArgWithHeadersHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithmanyqueryparams.gogen
@@ -244,6 +244,9 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithnestedqueryparams.gogen
@@ -188,6 +188,9 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithparams.gogen
@@ -119,6 +119,9 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryheader.gogen
@@ -116,6 +116,9 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_argwithqueryparams.gogen
@@ -130,6 +130,9 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_normal.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_normal.gogen
@@ -122,6 +122,9 @@ func (h *BarNormalHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
+++ b/codegen/test_data/endpoints/bar_bar_method_toomanyargs.gogen
@@ -114,6 +114,9 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("trace-key"); ok {
+			zfields = append(zfields, zap.String("trace-key", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -122,6 +122,9 @@ func (h *BarArgWithHeadersHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -244,6 +244,9 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -188,6 +188,9 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -119,6 +119,9 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -116,6 +116,9 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -130,6 +130,9 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -122,6 +122,9 @@ func (h *BarNormalHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -114,6 +114,9 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -113,6 +113,9 @@ func (h *SimpleServiceCompareHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
@@ -116,6 +116,9 @@ func (h *SimpleServiceHeaderSchemaHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -113,6 +113,9 @@ func (h *SimpleServiceTransHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -113,6 +113,9 @@ func (h *SimpleServiceTransHeadersHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
@@ -113,6 +113,9 @@ func (h *SimpleServiceTransHeadersTypeHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -115,6 +115,9 @@ func (h *ContactsSaveContactsHandler) HandleRequest(
 				zfields = append(zfields, zap.String(k, val))
 			}
 		}
+		if traceKey, ok := req.Header.Get("x-trace-id"); ok {
+			zfields = append(zfields, zap.String("x-trace-id", traceKey))
+		}
 		req.Logger.Debug("downstream service response", zfields...)
 	}
 

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -12,6 +12,6 @@
 	"copyrightHeader": "./copyright_header.txt",
 
 	"annotationPrefix": "zanzibar",
-
+	"trace-key": "x-trace-id",
 	"genMock": true
 }

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -12,6 +12,6 @@
 	"copyrightHeader": "./copyright_header.txt",
 
 	"annotationPrefix": "zanzibar",
-	"trace-key": "x-trace-id",
+	"traceKey": "x-trace-id",
 	"genMock": true
 }


### PR DESCRIPTION
propagate trace id from request to response header

so that we'll be able to track endpoint request -> client request -> client response -> endpoint response in our log with uniq trace key