### PR TITLE
Add default header forward

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -891,7 +891,6 @@ func (g *EndpointGenerator) generateEndpointFile(
 	reqHeaders := make(map[string]*TypedHeader)
 	// forward default request headers
 	// header "src" from endpoint becomes header "target" in client
-	// "src" is matched case-insensitively, but "target" casing will be preserved
 	for src, target := range g.packageHelper.DefaultReqHeaderMap() {
 		reqHeaders[src] = &TypedHeader{
 			Name:        src,
@@ -914,7 +913,6 @@ func (g *EndpointGenerator) generateEndpointFile(
 	resHeaders := make(map[string]*TypedHeader)
 	// forward default response headers
 	// header "src" from client becomes header "target" to endpoint
-	// "src" is matched case-insensitively, but "target" casing will be preserved
 	for src, target := range g.packageHelper.DefaultResHeaderMap() {
 		// need to canonicalize to match library output
 		h := textproto.CanonicalMIMEHeaderKey(src)

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -888,16 +888,45 @@ func (g *EndpointGenerator) generateEndpointFile(
 		clientName = e.ClientSpec.ClientName
 	}
 
-	// allow configured header to pass down to switch downstream service dynmamic
-	reqHeaders := e.ReqHeaders
-	if reqHeaders == nil {
-		reqHeaders = make(map[string]*TypedHeader)
+	reqHeaders := make(map[string]*TypedHeader)
+	// forward default request headers
+	// header "src" from endpoint becomes header "target" in client
+	// "src" is matched case-insensitively, but "target" casing will be preserved
+	for src, target := range g.packageHelper.DefaultReqHeaderMap() {
+		reqHeaders[src] = &TypedHeader{
+			Name:        src,
+			TransformTo: target,
+			Field:       &compile.FieldSpec{Required: false},
+		}
 	}
-	shk := textproto.CanonicalMIMEHeaderKey(g.packageHelper.StagingReqHeader())
+	// forward endpoint-specific request headers
+	for k, v := range e.ReqHeaders {
+		reqHeaders[k] = v
+	}
+	// allow configured header to pass down to switch downstream service dynamically
+	shk := g.packageHelper.StagingReqHeader()
 	reqHeaders[shk] = &TypedHeader{
 		Name:        shk,
 		TransformTo: shk,
 		Field:       &compile.FieldSpec{Required: false},
+	}
+
+	resHeaders := make(map[string]*TypedHeader)
+	// forward default response headers
+	// header "src" from client becomes header "target" to endpoint
+	// "src" is matched case-insensitively, but "target" casing will be preserved
+	for src, target := range g.packageHelper.DefaultResHeaderMap() {
+		// need to canonicalize to match library output
+		h := textproto.CanonicalMIMEHeaderKey(src)
+		resHeaders[h] = &TypedHeader{
+			Name:        h,
+			TransformTo: target,
+			Field:       &compile.FieldSpec{Required: false},
+		}
+	}
+	// forward endpoint-specific response headers
+	for k, v := range e.ResHeaders {
+		resHeaders[k] = v
 	}
 
 	// TODO: http client needs to support multiple thrift services
@@ -910,9 +939,9 @@ func (g *EndpointGenerator) generateEndpointFile(
 		ReqHeaders:             reqHeaders,
 		ReqHeadersKeys:         sortedHeaders(reqHeaders, false),
 		ReqRequiredHeadersKeys: sortedHeaders(reqHeaders, true),
-		ResHeadersKeys:         sortedHeaders(e.ResHeaders, false),
-		ResRequiredHeadersKeys: sortedHeaders(e.ResHeaders, true),
-		ResHeaders:             e.ResHeaders,
+		ResHeadersKeys:         sortedHeaders(resHeaders, false),
+		ResRequiredHeadersKeys: sortedHeaders(resHeaders, true),
+		ResHeaders:             resHeaders,
 		ClientID:               clientID,
 		ClientName:             clientName,
 		ClientMethodName:       e.ClientMethod,

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -57,6 +57,10 @@ type PackageHelper struct {
 	stagingReqHeader string
 	// traceKey is the key for uniq trace id that identifies request / response pair
 	traceKey string
+	// A map of default headers that all endpoints will forward to their clients
+	defaultReqHeaderMap map[string]string
+	// A map of default headers that all clients will forward back to their endpoints
+	defaultResHeaderMap map[string]string
 }
 
 // NewPackageHelper creates a package helper.
@@ -72,6 +76,8 @@ func NewPackageHelper(
 	annotationPrefix string,
 	stagingReqHeader string,
 	traceKey string,
+	defaultReqHeaderMap map[string]string,
+	defaultResHeaderMap map[string]string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
 	if err != nil {
@@ -101,6 +107,8 @@ func NewPackageHelper(
 		annotationPrefix:    annotationPrefix,
 		stagingReqHeader:    stagingReqHeader,
 		traceKey:            traceKey,
+		defaultReqHeaderMap: defaultReqHeaderMap,
+		defaultResHeaderMap: defaultResHeaderMap,
 	}
 	return p, nil
 }
@@ -220,4 +228,16 @@ func (p PackageHelper) TypeFullName(typeSpec compile.TypeSpec) (string, error) {
 // if a request should go to the staging downstream client
 func (p PackageHelper) StagingReqHeader() string {
 	return p.stagingReqHeader
+}
+
+// DefaultReqHeaderMap returns a map of default headers to be forwarded
+// from the endpoint to client
+func (p PackageHelper) DefaultReqHeaderMap() map[string]string {
+	return p.defaultReqHeaderMap
+}
+
+// DefaultResHeaderMap returns a map of default headers to be forwarded
+// from client to endpoint
+func (p PackageHelper) DefaultResHeaderMap() map[string]string {
+	return p.defaultResHeaderMap
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -75,6 +75,8 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
 		"trace-key",
+		nil,
+		nil,
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {
 		return nil

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -82,6 +82,14 @@ func main() {
 	if config.ContainsKey("stagingReqHeader") {
 		stagingReqHeader = config.MustGetString("stagingReqHeader")
 	}
+	defaultReqHeaderMap := make(map[string]string)
+	defaultResHeaderMap := make(map[string]string)
+	if config.ContainsKey("defaultReqHeaderMap") {
+		config.MustGetStruct("defaultReqHeaderMap", &defaultReqHeaderMap)
+	}
+	if config.ContainsKey("defaultResHeaderMap") {
+		config.MustGetStruct("defaultResHeaderMap", &defaultResHeaderMap)
+	}
 
 	packageHelper, err := codegen.NewPackageHelper(
 		config.MustGetString("packageRoot"),
@@ -95,6 +103,8 @@ func main() {
 		config.MustGetString("annotationPrefix"),
 		stagingReqHeader,
 		config.MustGetString("traceKey"),
+		defaultReqHeaderMap,
+		defaultResHeaderMap,
 	)
 	checkError(
 		err, fmt.Sprintf("Can't build package helper %s", configRoot),

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -71,6 +71,8 @@ func TestGenerateBar(t *testing.T) {
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
 		"trace-key",
+		nil,
+		nil,
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {
 		return

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -74,8 +74,12 @@ func (w barArgNotStructWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	_, err := w.Clients.Bar.ArgNotStruct(
+	cliRespHeaders, err := w.Clients.Bar.ArgNotStruct(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -107,6 +111,8 @@ func (w barArgNotStructWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	return resHeaders, nil
 }

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -78,8 +78,12 @@ func (w barArgWithHeadersWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithHeaders(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -103,6 +107,8 @@ func (w barArgWithHeadersWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithHeadersClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -74,8 +74,12 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithManyQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -99,6 +103,8 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithManyQueryParamsClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -74,8 +74,12 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithNestedQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -99,6 +103,8 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithNestedQueryParamsClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -74,8 +74,12 @@ func (w barArgWithParamsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithParams(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -99,6 +103,8 @@ func (w barArgWithParamsWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithParamsClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -74,8 +74,12 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithQueryHeader(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -99,6 +103,8 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithQueryHeaderClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -82,8 +82,12 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -107,6 +111,8 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarArgWithQueryParamsClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -71,8 +71,12 @@ func (w barHelloWorldWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.Hello(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.Hello(
 		ctx, clientHeaders,
 	)
 
@@ -104,6 +108,8 @@ func (w barHelloWorldWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarHelloWorldClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -71,8 +71,12 @@ func (w barMissingArgWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.MissingArg(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.MissingArg(
 		ctx, clientHeaders,
 	)
 
@@ -104,6 +108,8 @@ func (w barMissingArgWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarMissingArgClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -71,8 +71,12 @@ func (w barNoRequestWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.NoRequest(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.NoRequest(
 		ctx, clientHeaders,
 	)
 
@@ -104,6 +108,8 @@ func (w barNoRequestWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarNoRequestClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -74,8 +74,12 @@ func (w barNormalWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Bar.Normal(
+	clientRespBody, cliRespHeaders, err := w.Clients.Bar.Normal(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -107,6 +111,8 @@ func (w barNormalWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertBarNormalClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -85,6 +85,10 @@ func (w barTooManyArgsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
 	clientRespBody, cliRespHeaders, err := w.Clients.Bar.TooManyArgs(
 		ctx, clientHeaders, clientRequest,
@@ -128,6 +132,7 @@ func (w barTooManyArgsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	resHeaders.Set("X-Token", cliRespHeaders["X-Token"])
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 	resHeaders.Set("X-Uuid", cliRespHeaders["X-Uuid"])
 
 	response := convertBarTooManyArgsClientResponse(clientRespBody)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype_test.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype_test.go
@@ -79,10 +79,6 @@ func TestTransHeadersTypeSuccessfulRequestOKResponse(t *testing.T) {
 	)
 
 	headers := map[string]string{}
-	headers["x-boolean"] = "true"
-	headers["x-float"] = "3.14"
-	headers["x-int"] = "3"
-	headers["x-string"] = "2a629c1a-262a-43f0-8623-869b0256a321"
 
 	endpointRequest := []byte(`{"req":{}}`)
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -82,6 +82,10 @@ func (w simpleServiceCallWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
 	cliRespHeaders, err := w.Clients.Baz.Call(
 		ctx, clientHeaders, clientRequest,
@@ -117,6 +121,7 @@ func (w simpleServiceCallWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	resHeaders.Set("Some-Res-Header", cliRespHeaders["Some-Res-Header"])
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	return resHeaders, nil
 }

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -75,8 +75,12 @@ func (w simpleServiceCompareWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.Compare(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.Compare(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -116,6 +120,8 @@ func (w simpleServiceCompareWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServiceCompareClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -90,8 +90,12 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.HeaderSchema(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.HeaderSchema(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -131,6 +135,8 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServiceHeaderSchemaClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -71,8 +71,12 @@ func (w simpleServicePingWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.Ping(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.Ping(
 		ctx, clientHeaders,
 	)
 
@@ -96,6 +100,8 @@ func (w simpleServicePingWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServicePingClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -72,8 +72,12 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	_, err := w.Clients.Baz.DeliberateDiffNoop(ctx, clientHeaders)
+	cliRespHeaders, err := w.Clients.Baz.DeliberateDiffNoop(ctx, clientHeaders)
 
 	if err != nil {
 		switch errValue := err.(type) {
@@ -111,6 +115,8 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	return resHeaders, nil
 }

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -75,8 +75,12 @@ func (w simpleServiceTransWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.Trans(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.Trans(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -116,6 +120,8 @@ func (w simpleServiceTransWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServiceTransClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -85,8 +85,12 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.TransHeaders(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.TransHeaders(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -126,6 +130,8 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServiceTransHeadersClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -77,8 +77,12 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Baz.TransHeadersType(
+	clientRespBody, cliRespHeaders, err := w.Clients.Baz.TransHeadersType(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -118,6 +122,8 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertSimpleServiceTransHeadersTypeClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -82,6 +82,10 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.AddCredentials(
 		ctx, clientHeaders, clientRequest,
@@ -108,6 +112,7 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 	resHeaders.Set("X-Uuid", cliRespHeaders["X-Uuid"])
 
 	return resHeaders, nil

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -76,6 +76,10 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
 	cliRespHeaders, err := w.Clients.GoogleNow.CheckCredentials(ctx, clientHeaders)
 
@@ -100,6 +104,7 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 	resHeaders.Set("X-Uuid", cliRespHeaders["X-Uuid"])
 
 	return resHeaders, nil

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -68,8 +68,12 @@ func (w serviceAFrontHelloWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Multi.HelloA(
+	clientRespBody, cliRespHeaders, err := w.Clients.Multi.HelloA(
 		ctx, clientHeaders,
 	)
 
@@ -93,6 +97,8 @@ func (w serviceAFrontHelloWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertServiceABackHelloClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -68,8 +68,12 @@ func (w serviceBFrontHelloWorkflow) Handle(
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h
 	}
+	h, ok = reqHeaders.Get("x-trace-id")
+	if ok {
+		clientHeaders["x-trace-id"] = h
+	}
 
-	clientRespBody, _, err := w.Clients.Multi.HelloB(
+	clientRespBody, cliRespHeaders, err := w.Clients.Multi.HelloB(
 		ctx, clientHeaders,
 	)
 
@@ -93,6 +97,8 @@ func (w serviceBFrontHelloWorkflow) Handle(
 
 	// TODO: Add support for TChannel Headers with a switch here
 	resHeaders := zanzibar.ServerHTTPHeader{}
+
+	resHeaders.Set("x-trace-id", cliRespHeaders["X-Trace-Id"])
 
 	response := convertServiceBBackHelloClientResponse(clientRespBody)
 	return response, resHeaders, nil

--- a/examples/example-gateway/gateway.json
+++ b/examples/example-gateway/gateway.json
@@ -13,5 +13,12 @@
 
 	"annotationPrefix": "zanzibar",
 	"traceKey": "x-trace-id",
-	"genMock": true
+	"genMock": true,
+
+	"defaultReqHeaderMap": {
+		"x-trace-id": "x-trace-id"
+	},
+	"defaultResHeaderMap": {
+		"x-trace-id": "x-trace-id"
+	}
 }


### PR DESCRIPTION
Add
`
"defaultReqHeaderMap": {
	"x-trace-id": "x-trace-id"
},
"defaultResHeaderMap": {
	"x-trace-id": "x-trace-id"
}
`
field to gateway.json, similar to `reqHeaderMap` and `resHeaderMap` in endpoint configs
