### PR TITLE
fix nil response headers triggers NPE in zanzibar

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2403,8 +2403,10 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	resHeaders := map[string]string{}
-	for _, key := range wfResHeaders.Keys() {
-		resHeaders[key], _ = wfResHeaders.Get(key)
+	if wfResHeaders != nil {
+		for _, key := range wfResHeaders.Keys() {
+			resHeaders[key], _ = wfResHeaders.Get(key)
+		}
 	}
 
 	{{if eq (len .Exceptions) 0 -}}
@@ -2444,11 +2446,13 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	{{- if .ResHeaders}}
-	if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
-		return false, nil, nil, errors.Wrapf(
-			err, "%s.%s (%s) missing response headers",
-			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-		)
+	if wfResHeaders != nil {
+		if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
+			return false, nil, nil, errors.Wrapf(
+				err, "%s.%s (%s) missing response headers",
+				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+			)
+		}
 	}
 	{{- end}}
 
@@ -2492,7 +2496,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5355, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5422, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2447,7 +2447,11 @@ func (h *{{$handlerName}}) Handle(
 
 	{{- if .ResHeaders}}
 	if wfResHeaders == nil {
-		return false, nil, nil, errors.Errorf(
+		return false, nil, nil, errors.Wrapf(
+			errors.Errorf(
+				"Missing mandatory headers: %s",
+				strings.Join({{.ResHeaders | printf "%#v" }}, ", "),
+			),
 			"%s.%s (%s) missing response headers",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
 		)
@@ -2501,7 +2505,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5571, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5688, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2446,13 +2446,18 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	{{- if .ResHeaders}}
-	if wfResHeaders != nil {
-		if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
-			return false, nil, nil, errors.Wrapf(
-				err, "%s.%s (%s) missing response headers",
-				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-			)
-		}
+	if wfResHeaders == nil {
+		return false, nil, nil, errors.Errorf(
+			"%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
+	}
+
+	if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
+		return false, nil, nil, errors.Wrapf(
+			err, "%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
 	}
 	{{- end}}
 
@@ -2496,7 +2501,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5422, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 5571, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -93,8 +93,10 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	resHeaders := map[string]string{}
-	for _, key := range wfResHeaders.Keys() {
-		resHeaders[key], _ = wfResHeaders.Get(key)
+	if wfResHeaders != nil {
+		for _, key := range wfResHeaders.Keys() {
+			resHeaders[key], _ = wfResHeaders.Get(key)
+		}
 	}
 
 	{{if eq (len .Exceptions) 0 -}}
@@ -134,11 +136,13 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	{{- if .ResHeaders}}
-	if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
-		return false, nil, nil, errors.Wrapf(
-			err, "%s.%s (%s) missing response headers",
-			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-		)
+	if wfResHeaders != nil {
+		if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
+			return false, nil, nil, errors.Wrapf(
+				err, "%s.%s (%s) missing response headers",
+				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+			)
+		}
 	}
 	{{- end}}
 

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -137,7 +137,11 @@ func (h *{{$handlerName}}) Handle(
 
 	{{- if .ResHeaders}}
 	if wfResHeaders == nil {
-		return false, nil, nil, errors.Errorf(
+		return false, nil, nil, errors.Wrapf(
+			errors.Errorf(
+				"Missing mandatory headers: %s",
+				strings.Join({{.ResHeaders | printf "%#v" }}, ", "),
+			),
 			"%s.%s (%s) missing response headers",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
 		)

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -136,13 +136,18 @@ func (h *{{$handlerName}}) Handle(
 	{{end}}
 
 	{{- if .ResHeaders}}
-	if wfResHeaders != nil {
-		if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
-			return false, nil, nil, errors.Wrapf(
-				err, "%s.%s (%s) missing response headers",
-				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-			)
-		}
+	if wfResHeaders == nil {
+		return false, nil, nil, errors.Errorf(
+			"%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
+	}
+
+	if err := wfResHeaders.Ensure({{.ResHeaders | printf "%#v" }}, h.endpoint.Logger); err != nil {
+		return false, nil, nil, errors.Wrapf(
+			err, "%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
 	}
 	{{- end}}
 

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -25,6 +25,7 @@ package baztchannelendpoint
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
@@ -120,7 +121,11 @@ func (h *SimpleServiceCallHandler) Handle(
 		}
 	}
 	if wfResHeaders == nil {
-		return false, nil, nil, errors.Errorf(
+		return false, nil, nil, errors.Wrapf(
+			errors.Errorf(
+				"Missing mandatory headers: %s",
+				strings.Join([]string{"some-res-header"}, ", "),
+			),
 			"%s.%s (%s) missing response headers",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
 		)

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -91,8 +91,10 @@ func (h *SimpleServiceCallHandler) Handle(
 	wfResHeaders, err := workflow.Handle(ctx, wfReqHeaders, &req)
 
 	resHeaders := map[string]string{}
-	for _, key := range wfResHeaders.Keys() {
-		resHeaders[key], _ = wfResHeaders.Get(key)
+	if wfResHeaders != nil {
+		for _, key := range wfResHeaders.Keys() {
+			resHeaders[key], _ = wfResHeaders.Get(key)
+		}
 	}
 
 	if err != nil {
@@ -117,11 +119,13 @@ func (h *SimpleServiceCallHandler) Handle(
 			)
 		}
 	}
-	if err := wfResHeaders.Ensure([]string{"some-res-header"}, h.endpoint.Logger); err != nil {
-		return false, nil, nil, errors.Wrapf(
-			err, "%s.%s (%s) missing response headers",
-			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-		)
+	if wfResHeaders != nil {
+		if err := wfResHeaders.Ensure([]string{"some-res-header"}, h.endpoint.Logger); err != nil {
+			return false, nil, nil, errors.Wrapf(
+				err, "%s.%s (%s) missing response headers",
+				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+			)
+		}
 	}
 
 	return err == nil, &res, resHeaders, nil

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -119,13 +119,18 @@ func (h *SimpleServiceCallHandler) Handle(
 			)
 		}
 	}
-	if wfResHeaders != nil {
-		if err := wfResHeaders.Ensure([]string{"some-res-header"}, h.endpoint.Logger); err != nil {
-			return false, nil, nil, errors.Wrapf(
-				err, "%s.%s (%s) missing response headers",
-				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
-			)
-		}
+	if wfResHeaders == nil {
+		return false, nil, nil, errors.Errorf(
+			"%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
+	}
+
+	if err := wfResHeaders.Ensure([]string{"some-res-header"}, h.endpoint.Logger); err != nil {
+		return false, nil, nil, errors.Wrapf(
+			err, "%s.%s (%s) missing response headers",
+			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
+		)
 	}
 
 	return err == nil, &res, resHeaders, nil

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
@@ -81,5 +81,12 @@ func (w Workflow) Handle(
 			return respHeaders, err
 		}
 	}
+
+	if val, ok := clientReqHeaders["x-nil-response-header"]; ok {
+		if "true" == val {
+			return nil, nil
+		}
+	}
+
 	return respHeaders, nil
 }

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
@@ -18,8 +18,9 @@ func TestBazCall(t *testing.T) {
 
 	// fixtures
 	reqHeaders := map[string]string{
-		"x-token": "token",
-		"x-uuid":  "uuid",
+		"x-token":               "token",
+		"x-uuid":                "uuid",
+		"x-nil-response-header": "false",
 	}
 	args := &baz.SimpleService_Call_Args{
 		Arg: &baz.BazRequest{
@@ -45,4 +46,22 @@ func TestBazCall(t *testing.T) {
 	}
 	assert.True(t, success)
 	assert.Equal(t, expectedHeaders, resHeaders)
+
+	reqHeaders = map[string]string{
+		"x-token":               "token",
+		"x-uuid":                "uuid",
+		"x-nil-response-header": "true",
+	}
+
+	ms.MockClients().Baz.EXPECT().Call(gomock.Any(), reqHeaders, gomock.Any()).
+		Return(map[string]string{"some-res-header": "something"}, nil)
+
+	success, resHeaders, err = ms.MakeTChannelRequest(
+		ctx, "SimpleService", "Call", reqHeaders, args, &result,
+	)
+	if !assert.NoError(t, err, "got tchannel error") {
+		return
+	}
+	assert.True(t, success)
+	assert.Nil(t, resHeaders)
 }

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
@@ -59,9 +59,9 @@ func TestBazCall(t *testing.T) {
 	success, resHeaders, err = ms.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
-	if !assert.NoError(t, err, "got tchannel error") {
+	if !assert.Error(t, err, "got tchannel error") {
 		return
 	}
-	assert.True(t, success)
+	assert.False(t, success)
 	assert.Nil(t, resHeaders)
 }


### PR DESCRIPTION
Issue: 
Returning nil from an endpoint instead of zanzibar.Header (usually a map cast into zanzibar.TChannelHeaders) triggers a null pointer exception in zanzibar-generated code.

Fix:
add nil check for headers