### PR TITLE
Use Make for running thriftrw-go

### DIFF
--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -52,18 +52,7 @@ fi
 start=$(date +%s)
 echo "$start" > .TMP_ZANZIBAR_TIMESTAMP_FILE.txt
 
-go build -o "$THRIFTRW_BINARY" "$THRIFTRW_MAIN_FILE"
-end=$(date +%s)
-runtime=$((end-start))
-echo "Compiled thriftrw : +$runtime"
-
 echo "Generating Go code from Thrift files"
-mkdir -p "$BUILD_DIR/gen-code"
-for tfile in ${THRIFTRW_SRCS}; do
-	"$THRIFTRW_BINARY" --out="$BUILD_DIR/gen-code" \
-		--no-embed-idl \
-		--thrift-root="$CONFIG_DIR/idl" "$tfile"
-done
 gofmt -w "$BUILD_DIR/gen-code/"
 
 end=$(date +%s)


### PR DESCRIPTION
Removes code in pre-steps.sh for invoking thriftrw-go and instead rely on Make to determine when to run thriftrw-go. 

Test: Delete build folder and re-run make generate and verify no missing files. 