### PR TITLE
Serialize module tree in build folder

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -43,6 +43,8 @@ const (
 	SingleModule moduleClassType = iota
 	// MultiModule defines a module class type with multiple nested directories
 	MultiModule moduleClassType = iota
+
+	serializedModuleTreePath = "zanzibar.tree"
 )
 
 const configSuffix = "-config.json"
@@ -866,6 +868,15 @@ func (system *ModuleSystem) GenerateBuild(
 
 	if err != nil {
 		return nil, err
+	}
+
+	serializedModules, err := json.Marshal(resolvedModules)
+	if err != nil {
+		return nil, errors.Wrap(err, "error serializing module tree")
+	}
+	err = writeFile(filepath.Join(targetGenDir, serializedModuleTreePath), serializedModules)
+	if err != nil {
+		return nil, errors.Wrap(err, "error writing serialized module tree")
 	}
 
 	moduleCount := 0

--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -167,6 +169,13 @@ func TestExampleService(t *testing.T) {
 
 	currentDir := getTestDirName()
 	testServiceDir := path.Join(currentDir, "test-service")
+
+	defer func() {
+		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
+		if err != nil {
+			panic(errors.Wrap(err, "error removing serialized module tree"))
+		}
+	}()
 
 	// TODO: this should return a collection of errors if they occur
 	instances, err := moduleSystem.GenerateBuild(

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+function cleanup {
+	rm -f $PREFIX/build/zanzibar.tree
+}
+trap cleanup EXIT
+
 PREFIX=examples/example-gateway
 ANNOPREFIX=${1:-zanzibar}
 


### PR DESCRIPTION
Many of the build steps require as input the module tree. For example, to build the module struct we must know the direct dependencies. 

Currently the dependency tree is resolved once at the beginning of the build process and passed to the generators in memory either as a side-effect (through the `ResolvedDependencies` and `RecursiveDependencies` properties). As a prerequisite of incremental builds we need to be able to execute the entire build process for a single module instance, but by passing the dependency tree only through memory we would need to re-resolve the tree each time. 

This diff stores the module tree onto disk during the build process so we can resolve it once, read it from disk in the individual build steps, and remove it once the build is done. 