### PR TITLE
Disable request and response body logging.

### DIFF
--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -125,8 +125,8 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 		// Temporarily log during the development cycle
 		// TODO: Add a gateway level configurable body unmarshaller
 		// to extract only non-PII info.
-		zap.ByteString("Request Body", req.rawBody),
-		zap.ByteString("Response Body", res.pendingBodyBytes),
+		// zap.ByteString("Request Body", req.rawBody),
+		// zap.ByteString("Response Body", res.pendingBodyBytes),
 	}
 
 	if res.err != nil {


### PR DESCRIPTION
Disable logging the full request and response bodies on every request.