### PR TITLE
Swap deputy subchannel to scAlt at tchannel_client.go

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -547,6 +547,7 @@ func (g *TChannelClientGenerator) Generate(
 		ExposedMethods:   exposedMethods,
 		SidecarRouter:    clientSpec.SidecarRouter,
 		StagingReqHeader: g.packageHelper.StagingReqHeader(),
+		DeputyReqHeader:  g.packageHelper.DeputyReqHeader(),
 	}
 
 	client, err := g.templates.ExecTemplate(
@@ -909,7 +910,12 @@ func (g *EndpointGenerator) generateEndpointFile(
 		TransformTo: shk,
 		Field:       &compile.FieldSpec{Required: false},
 	}
-
+	shk = textproto.CanonicalMIMEHeaderKey(g.packageHelper.DeputyReqHeader())
+	reqHeaders[shk] = &TypedHeader{
+		Name:        shk,
+		TransformTo: shk,
+		Field:       &compile.FieldSpec{Required: false},
+	}
 	// TODO: http client needs to support multiple thrift services
 	meta := &EndpointMeta{
 		Instance:               instance,
@@ -1268,6 +1274,7 @@ type ClientMeta struct {
 	SidecarRouter    string
 	Fixture          *Fixture
 	StagingReqHeader string
+	DeputyReqHeader  string
 }
 
 func findMethod(

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -53,6 +53,8 @@ type PackageHelper struct {
 	middlewareSpecs map[string]*MiddlewareSpec
 	// Use staging client when this header is set as "true"
 	stagingReqHeader string
+	// Use deputy client when this header is set
+	deputyReqHeader string
 	// traceKey is the key for uniq trace id that identifies request / response pair
 	traceKey string
 }
@@ -68,6 +70,7 @@ func NewPackageHelper(
 	copyrightHeader string,
 	annotationPrefix string,
 	stagingReqHeader string,
+	deputyReqHeader string,
 	traceKey string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
@@ -96,6 +99,7 @@ func NewPackageHelper(
 		middlewareSpecs:    middlewareSpecs,
 		annotationPrefix:   annotationPrefix,
 		stagingReqHeader:   stagingReqHeader,
+		deputyReqHeader:    deputyReqHeader,
 		traceKey:           traceKey,
 	}
 	return p, nil
@@ -216,4 +220,10 @@ func (p PackageHelper) TypeFullName(typeSpec compile.TypeSpec) (string, error) {
 // if a request should go to the staging downstream client
 func (p PackageHelper) StagingReqHeader() string {
 	return p.stagingReqHeader
+}
+
+// DeputyReqHeader returns the header name that will be checked to determine
+// if a request should go to the deputy downstream client
+func (p PackageHelper) DeputyReqHeader() string {
+	return p.deputyReqHeader
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -73,6 +73,7 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"x-deputy-forwarded",
 		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -83,6 +83,11 @@ func main() {
 		stagingReqHeader = config.MustGetString("stagingReqHeader")
 	}
 
+	deputyReqHeader := "x-deputy-forwarded"
+	if config.ContainsKey("deputyReqHeader") {
+		deputyReqHeader = config.MustGetString("deputyReqHeader")
+	}
+
 	packageHelper, err := codegen.NewPackageHelper(
 		config.MustGetString("packageRoot"),
 		configRoot,
@@ -93,6 +98,7 @@ func main() {
 		string(copyright),
 		config.MustGetString("annotationPrefix"),
 		stagingReqHeader,
+		deputyReqHeader,
 		config.MustGetString("traceKey"),
 	)
 	checkError(

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2054,6 +2054,7 @@ import (
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
 {{- $stagingReqHeader := .StagingReqHeader}}
+{{- $deputyReqHeader := .DeputyReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -2179,9 +2180,13 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
+		if channelName, ok := reqHeaders["{{$deputyReqHeader}}"]; ok {
+			c.client.SetSubAltChannel(channelName)
+			caller = c.client.CallThruAltChannel
+		} else if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
 			caller = c.client.CallThruAltChannel
 		}
+
 		success, respHeaders, err := caller(
 			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 		)
@@ -2230,7 +2235,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6271, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6469, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -69,6 +69,7 @@ func TestGenerateBar(t *testing.T) {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"x-deputy-forwarded",
 		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -26,6 +26,7 @@ import (
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
 {{- $stagingReqHeader := .StagingReqHeader}}
+{{- $deputyReqHeader := .DeputyReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -151,9 +152,13 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
+		if channelName, ok := reqHeaders["{{$deputyReqHeader}}"]; ok {
+			c.client.SetSubAltChannel(channelName)
+			caller = c.client.CallThruAltChannel
+		} else if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
 			caller = c.client.CallThruAltChannel
 		}
+
 		success, respHeaders, err := caller(
 			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 		)

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -280,9 +280,13 @@ func (c *bazClient) EchoBinary(
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 	)
@@ -317,9 +321,13 @@ func (c *bazClient) EchoBool(
 	logger := c.client.Loggers["SecondService::echoBool"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 	)
@@ -354,9 +362,13 @@ func (c *bazClient) EchoDouble(
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 	)
@@ -391,9 +403,13 @@ func (c *bazClient) EchoEnum(
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 	)
@@ -428,9 +444,13 @@ func (c *bazClient) EchoI16(
 	logger := c.client.Loggers["SecondService::echoI16"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 	)
@@ -465,9 +485,13 @@ func (c *bazClient) EchoI32(
 	logger := c.client.Loggers["SecondService::echoI32"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 	)
@@ -502,9 +526,13 @@ func (c *bazClient) EchoI64(
 	logger := c.client.Loggers["SecondService::echoI64"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 	)
@@ -539,9 +567,13 @@ func (c *bazClient) EchoI8(
 	logger := c.client.Loggers["SecondService::echoI8"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 	)
@@ -576,9 +608,13 @@ func (c *bazClient) EchoString(
 	logger := c.client.Loggers["SecondService::echoString"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoString", reqHeaders, args, &result,
 	)
@@ -613,9 +649,13 @@ func (c *bazClient) EchoStringList(
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 	)
@@ -650,9 +690,13 @@ func (c *bazClient) EchoStringMap(
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 	)
@@ -687,9 +731,13 @@ func (c *bazClient) EchoStringSet(
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 	)
@@ -724,9 +772,13 @@ func (c *bazClient) EchoStructList(
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 	)
@@ -761,9 +813,13 @@ func (c *bazClient) EchoStructSet(
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 	)
@@ -798,9 +854,13 @@ func (c *bazClient) EchoTypedef(
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 	)
@@ -834,9 +894,13 @@ func (c *bazClient) Call(
 	logger := c.client.Loggers["SimpleService::call"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "call", reqHeaders, args, &result,
 	)
@@ -869,9 +933,13 @@ func (c *bazClient) Compare(
 	logger := c.client.Loggers["SimpleService::compare"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "compare", reqHeaders, args, &result,
 	)
@@ -910,9 +978,13 @@ func (c *bazClient) GetProfile(
 	logger := c.client.Loggers["SimpleService::getProfile"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 	)
@@ -949,9 +1021,13 @@ func (c *bazClient) HeaderSchema(
 	logger := c.client.Loggers["SimpleService::headerSchema"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 	)
@@ -990,9 +1066,13 @@ func (c *bazClient) Ping(
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "ping", reqHeaders, args, &result,
 	)
@@ -1026,9 +1106,13 @@ func (c *bazClient) DeliberateDiffNoop(
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 	)
@@ -1062,9 +1146,13 @@ func (c *bazClient) TestUUID(
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 	)
@@ -1095,9 +1183,13 @@ func (c *bazClient) Trans(
 	logger := c.client.Loggers["SimpleService::trans"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "trans", reqHeaders, args, &result,
 	)
@@ -1136,9 +1228,13 @@ func (c *bazClient) TransHeaders(
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 	)
@@ -1177,9 +1273,13 @@ func (c *bazClient) TransHeadersNoReq(
 	logger := c.client.Loggers["SimpleService::transHeadersNoReq"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 	)
@@ -1216,9 +1316,13 @@ func (c *bazClient) TransHeadersType(
 	logger := c.client.Loggers["SimpleService::transHeadersType"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 	)
@@ -1256,9 +1360,13 @@ func (c *bazClient) URLTest(
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 	)

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -126,9 +126,13 @@ func (c *corgeClient) EchoString(
 	logger := c.client.Loggers["Corge::echoString"]
 
 	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
+	if channelName, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		c.client.SetSubAltChannel(channelName)
+		caller = c.client.CallThruAltChannel
+	} else if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
 		caller = c.client.CallThruAltChannel
 	}
+
 	success, respHeaders, err := caller(
 		ctx, "Corge", "echoString", reqHeaders, args, &result,
 	)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -70,6 +70,10 @@ func (w barArgNotStructWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -70,6 +70,10 @@ func (w barArgWithHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["x-uuid"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -70,6 +70,10 @@ func (w barArgWithParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -70,6 +70,10 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["x-token"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -67,6 +67,10 @@ func (w barHelloWorldWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -67,6 +67,10 @@ func (w barMissingArgWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -67,6 +67,10 @@ func (w barNoRequestWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -70,6 +70,10 @@ func (w barNormalWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -73,6 +73,10 @@ func (w barTooManyArgsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -70,6 +70,10 @@ func (w simpleServiceCallWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -71,6 +71,10 @@ func (w simpleServiceCompareWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -70,6 +70,10 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -78,6 +78,10 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 	if ok {
 		clientHeaders["Content-Type"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -67,6 +67,10 @@ func (w simpleServicePingWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -68,6 +68,10 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -71,6 +71,10 @@ func (w simpleServiceTransWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -80,6 +80,10 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 	if ok {
 		clientHeaders["Uuid"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -82,6 +82,10 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 	if ok {
 		clientHeaders["S1"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -72,6 +72,10 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -70,6 +70,10 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -64,6 +64,10 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -64,6 +64,10 @@ func (w serviceAFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -64,6 +64,10 @@ func (w serviceBFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -132,6 +132,13 @@ func NewTChannelClient(
 	return client
 }
 
+// SetSubAltChannel set the client scAlt channel
+func (c *TChannelClient) SetSubAltChannel(AltSubchannelName string) {
+	if AltSubchannelName != "" {
+		c.scAlt = c.ch.GetSubChannel(AltSubchannelName)
+	}
+}
+
 // Call makes a RPC call to the given service.
 func (c *TChannelClient) Call(
 	ctx context.Context,


### PR DESCRIPTION
- The value of request header "x-deputy-forwarded" is sub-channel name. 

- If a coming request has header "x-deputy-forwarded", then swap scAlt with deputy sub-channel
at tchannel_client.go, then call scAlt channel instead of sc
