### PR TITLE
Add deputy hostport to tchanel client

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -547,6 +547,7 @@ func (g *TChannelClientGenerator) Generate(
 		ExposedMethods:   exposedMethods,
 		SidecarRouter:    clientSpec.SidecarRouter,
 		StagingReqHeader: g.packageHelper.StagingReqHeader(),
+		DeputyReqHeader:  g.packageHelper.DeputyReqHeader(),
 	}
 
 	client, err := g.templates.ExecTemplate(
@@ -909,7 +910,12 @@ func (g *EndpointGenerator) generateEndpointFile(
 		TransformTo: shk,
 		Field:       &compile.FieldSpec{Required: false},
 	}
-
+	shk = textproto.CanonicalMIMEHeaderKey(g.packageHelper.DeputyReqHeader())
+	reqHeaders[shk] = &TypedHeader{
+		Name:        shk,
+		TransformTo: shk,
+		Field:       &compile.FieldSpec{Required: false},
+	}
 	// TODO: http client needs to support multiple thrift services
 	meta := &EndpointMeta{
 		Instance:               instance,
@@ -1268,6 +1274,7 @@ type ClientMeta struct {
 	SidecarRouter    string
 	Fixture          *Fixture
 	StagingReqHeader string
+	DeputyReqHeader  string
 }
 
 func findMethod(

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -53,6 +53,8 @@ type PackageHelper struct {
 	middlewareSpecs map[string]*MiddlewareSpec
 	// Use staging client when this header is set as "true"
 	stagingReqHeader string
+	// Use deputy client when this header is set
+	deputyReqHeader string
 	// traceKey is the key for uniq trace id that identifies request / response pair
 	traceKey string
 }
@@ -68,6 +70,7 @@ func NewPackageHelper(
 	copyrightHeader string,
 	annotationPrefix string,
 	stagingReqHeader string,
+	deputyReqHeader string,
 	traceKey string,
 ) (*PackageHelper, error) {
 	absConfigRoot, err := filepath.Abs(configRoot)
@@ -96,6 +99,7 @@ func NewPackageHelper(
 		middlewareSpecs:    middlewareSpecs,
 		annotationPrefix:   annotationPrefix,
 		stagingReqHeader:   stagingReqHeader,
+		deputyReqHeader:    deputyReqHeader,
 		traceKey:           traceKey,
 	}
 	return p, nil
@@ -216,4 +220,10 @@ func (p PackageHelper) TypeFullName(typeSpec compile.TypeSpec) (string, error) {
 // if a request should go to the staging downstream client
 func (p PackageHelper) StagingReqHeader() string {
 	return p.stagingReqHeader
+}
+
+// DeputyReqHeader returns the header name that will be checked to determine
+// if a request should go to the deputy downstream client
+func (p PackageHelper) DeputyReqHeader() string {
+	return p.deputyReqHeader
 }

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -73,6 +73,7 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"x-deputy-forwarded",
 		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -83,6 +83,11 @@ func main() {
 		stagingReqHeader = config.MustGetString("stagingReqHeader")
 	}
 
+	deputyReqHeader := "x-deputy-forwarded"
+	if config.ContainsKey("deputyReqHeader") {
+		deputyReqHeader = config.MustGetString("deputyReqHeader")
+	}
+
 	packageHelper, err := codegen.NewPackageHelper(
 		config.MustGetString("packageRoot"),
 		configRoot,
@@ -93,6 +98,7 @@ func main() {
 		string(copyright),
 		config.MustGetString("annotationPrefix"),
 		stagingReqHeader,
+		deputyReqHeader,
 		config.MustGetString("traceKey"),
 	)
 	checkError(

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2054,6 +2054,7 @@ import (
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
 {{- $stagingReqHeader := .StagingReqHeader}}
+{{- $deputyReqHeader := .DeputyReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -2178,13 +2179,25 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
-		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
-			caller = c.client.CallThruAltChannel
+		var success bool
+		var respHeaders map[string]string
+		var err error
+		useAltChannel := strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true")
+		if hostPort, ok := reqHeaders["{{$deputyReqHeader}}"]; ok {
+			caller := c.client.CallToHostPort
+			success, respHeaders, err = caller(
+				ctx, "{{$svc.Name}}", "{{.Name}}", hostPort, reqHeaders, args, &result, useAltChannel,
+			)
+		} else {
+			caller := c.client.Call
+			if useAltChannel {
+				caller = c.client.CallThruAltChannel
+			}
+
+			success, respHeaders, err = caller(
+				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
+			)
 		}
-		success, respHeaders, err := caller(
-			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
-		)
 
 		if err == nil && !success {
 			switch {
@@ -2230,7 +2243,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6271, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6674, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -69,6 +69,7 @@ func TestGenerateBar(t *testing.T) {
 		testCopyrightHeader,
 		"zanzibar",
 		"X-Zanzibar-Use-Staging",
+		"x-deputy-forwarded",
 		"trace-key",
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -26,6 +26,7 @@ import (
 {{- $exportName := .ExportName}}
 {{- $sidecarRouter := .SidecarRouter}}
 {{- $stagingReqHeader := .StagingReqHeader}}
+{{- $deputyReqHeader := .DeputyReqHeader}}
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -150,13 +151,25 @@ type {{$clientName}} struct {
 			args := &{{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Args{}
 		{{end -}}
 
-		caller := c.client.Call
-		if strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true") {
-			caller = c.client.CallThruAltChannel
+		var success bool
+		var respHeaders map[string]string
+		var err error
+		useAltChannel := strings.EqualFold(reqHeaders["{{$stagingReqHeader}}"], "true")
+		if hostPort, ok := reqHeaders["{{$deputyReqHeader}}"]; ok {
+			caller := c.client.CallToHostPort
+			success, respHeaders, err = caller(
+				ctx, "{{$svc.Name}}", "{{.Name}}", hostPort, reqHeaders, args, &result, useAltChannel,
+			)
+		} else {
+			caller := c.client.Call
+			if useAltChannel {
+				caller = c.client.CallThruAltChannel
+			}
+
+			success, respHeaders, err = caller(
+				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
+			)
 		}
-		success, respHeaders, err := caller(
-			ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
-		)
 
 		if err == nil && !success {
 			switch {

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -279,13 +279,25 @@ func (c *bazClient) EchoBinary(
 
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoBinary", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -316,13 +328,25 @@ func (c *bazClient) EchoBool(
 
 	logger := c.client.Loggers["SecondService::echoBool"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoBool", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoBool", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoBool", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -353,13 +377,25 @@ func (c *bazClient) EchoDouble(
 
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoDouble", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -390,13 +426,25 @@ func (c *bazClient) EchoEnum(
 
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoEnum", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -427,13 +475,25 @@ func (c *bazClient) EchoI16(
 
 	logger := c.client.Loggers["SecondService::echoI16"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI16", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI16", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoI16", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -464,13 +524,25 @@ func (c *bazClient) EchoI32(
 
 	logger := c.client.Loggers["SecondService::echoI32"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI32", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI32", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoI32", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -501,13 +573,25 @@ func (c *bazClient) EchoI64(
 
 	logger := c.client.Loggers["SecondService::echoI64"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI64", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI64", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoI64", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -538,13 +622,25 @@ func (c *bazClient) EchoI8(
 
 	logger := c.client.Loggers["SecondService::echoI8"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI8", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoI8", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoI8", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -575,13 +671,25 @@ func (c *bazClient) EchoString(
 
 	logger := c.client.Loggers["SecondService::echoString"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoString", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoString", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoString", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -612,13 +720,25 @@ func (c *bazClient) EchoStringList(
 
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringList", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -649,13 +769,25 @@ func (c *bazClient) EchoStringMap(
 
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringMap", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -686,13 +818,25 @@ func (c *bazClient) EchoStringSet(
 
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringSet", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -723,13 +867,25 @@ func (c *bazClient) EchoStructList(
 
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStructList", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -760,13 +916,25 @@ func (c *bazClient) EchoStructSet(
 
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStructSet", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -797,13 +965,25 @@ func (c *bazClient) EchoTypedef(
 
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoTypedef", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -833,13 +1013,25 @@ func (c *bazClient) Call(
 
 	logger := c.client.Loggers["SimpleService::call"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "call", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "call", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "call", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -868,13 +1060,25 @@ func (c *bazClient) Compare(
 
 	logger := c.client.Loggers["SimpleService::compare"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "compare", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "compare", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "compare", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -909,13 +1113,25 @@ func (c *bazClient) GetProfile(
 
 	logger := c.client.Loggers["SimpleService::getProfile"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "getProfile", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -948,13 +1164,25 @@ func (c *bazClient) HeaderSchema(
 
 	logger := c.client.Loggers["SimpleService::headerSchema"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "headerSchema", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -989,13 +1217,25 @@ func (c *bazClient) Ping(
 	logger := c.client.Loggers["SimpleService::ping"]
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "ping", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "ping", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "ping", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1025,13 +1265,25 @@ func (c *bazClient) DeliberateDiffNoop(
 	logger := c.client.Loggers["SimpleService::sillyNoop"]
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "sillyNoop", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1061,13 +1313,25 @@ func (c *bazClient) TestUUID(
 	logger := c.client.Loggers["SimpleService::testUuid"]
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "testUuid", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1094,13 +1358,25 @@ func (c *bazClient) Trans(
 
 	logger := c.client.Loggers["SimpleService::trans"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "trans", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "trans", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "trans", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1135,13 +1411,25 @@ func (c *bazClient) TransHeaders(
 
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeaders", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1176,13 +1464,25 @@ func (c *bazClient) TransHeadersNoReq(
 
 	logger := c.client.Loggers["SimpleService::transHeadersNoReq"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeadersNoReq", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1215,13 +1515,25 @@ func (c *bazClient) TransHeadersType(
 
 	logger := c.client.Loggers["SimpleService::transHeadersType"]
 
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeadersType", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {
@@ -1255,13 +1567,25 @@ func (c *bazClient) URLTest(
 	logger := c.client.Loggers["SimpleService::urlTest"]
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
-	caller := c.client.Call
-	if strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true") {
-		caller = c.client.CallThruAltChannel
+	var success bool
+	var respHeaders map[string]string
+	var err error
+	useAltChannel := strings.EqualFold(reqHeaders["X-Zanzibar-Use-Staging"], "true")
+	if hostPort, ok := reqHeaders["x-deputy-forwarded"]; ok {
+		caller := c.client.CallToHostPort
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "urlTest", hostPort, reqHeaders, args, &result, useAltChannel,
+		)
+	} else {
+		caller := c.client.Call
+		if useAltChannel {
+			caller = c.client.CallThruAltChannel
+		}
+
+		success, respHeaders, err = caller(
+			ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
+		)
 	}
-	success, respHeaders, err := caller(
-		ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
-	)
 
 	if err == nil && !success {
 		switch {

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -70,6 +70,10 @@ func (w barArgNotStructWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -70,6 +70,10 @@ func (w barArgWithHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Uuid")
 	if ok {
 		clientHeaders["x-uuid"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -70,6 +70,10 @@ func (w barArgWithParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -70,6 +70,10 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -70,6 +70,10 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["x-token"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -67,6 +67,10 @@ func (w barHelloWorldWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -67,6 +67,10 @@ func (w barMissingArgWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -67,6 +67,10 @@ func (w barNoRequestWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -70,6 +70,10 @@ func (w barNormalWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -73,6 +73,10 @@ func (w barTooManyArgsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -70,6 +70,10 @@ func (w simpleServiceCallWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -71,6 +71,10 @@ func (w simpleServiceCompareWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -70,6 +70,10 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -78,6 +78,10 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 	if ok {
 		clientHeaders["Content-Type"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -67,6 +67,10 @@ func (w simpleServicePingWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -68,6 +68,10 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -71,6 +71,10 @@ func (w simpleServiceTransWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -80,6 +80,10 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 	if ok {
 		clientHeaders["Uuid"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -82,6 +82,10 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 	if ok {
 		clientHeaders["S1"] = h
 	}
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -72,6 +72,10 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -70,6 +70,10 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -64,6 +64,10 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Token")
 	if ok {
 		clientHeaders["X-Token"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -64,6 +64,10 @@ func (w serviceAFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -64,6 +64,10 @@ func (w serviceBFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
+	if ok {
+		clientHeaders["X-Deputy-Forwarded"] = h
+	}
 	h, ok = reqHeaders.Get("X-Zanzibar-Use-Staging")
 	if ok {
 		clientHeaders["X-Zanzibar-Use-Staging"] = h

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -99,5 +99,5 @@ func (r *RawTChannelClient) Call(
 		call.metrics = r.tc.metrics[serviceMethod]
 	}
 
-	return r.tc.call(ctx, call, reqHeaders, req, resp, false)
+	return r.tc.call(ctx, call, reqHeaders, req, resp, false, "")
 }


### PR DESCRIPTION
This commits will send a request to a dedicated hostport. If inbound request had header of **x-deputy-forwarded**, tchannel client would get hostport from it, then add it to peer list at the outbound tchannel, the inbound request with header of **x-deputy-forwarded** would go to the dedicated peer destination. This is thread safe commits since production request and deputy request would go to their hostports separately .