### PR TITLE
add error details for tchannel system error

### DIFF
--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -147,7 +147,7 @@ func (res *ClientHTTPResponse) finish() {
 			zap.Int("UnknownStatusCode", res.StatusCode),
 		)
 	} else {
-		res.req.metrics.Status[res.StatusCode].Inc(1)
+		res.req.metrics.Status.IncrStatus(res.StatusCode, 1)
 	}
 	if !known || res.StatusCode >= 400 && res.StatusCode < 600 {
 		res.req.metrics.Errors.Inc(1)

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -164,6 +164,7 @@ func CreateGateway(
 // Bootstrap func
 func (gateway *Gateway) Bootstrap() error {
 	// start HTTP server
+	gateway.PerHostScope.Counter("server.bootstrap").Inc(1)
 	_, err := gateway.localHTTPServer.JustListen()
 	if err != nil {
 		gateway.Logger.Error("Error listening on port", zap.Error(err))

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -91,7 +91,7 @@ func (res *ServerHTTPResponse) finish() {
 			zap.Int("UnknownStatusCode", res.StatusCode),
 		)
 	} else {
-		res.Request.metrics.Status[res.StatusCode].Inc(1)
+		res.Request.metrics.Status.IncrStatus(res.StatusCode, 1)
 	}
 	if !known || res.StatusCode >= 400 && res.StatusCode < 600 {
 		res.Request.metrics.Errors.Inc(1)

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -268,12 +268,7 @@ func (c *tchannelOutboundCall) finish(err error) {
 
 	// emit metrics
 	if err != nil {
-		tcause := tchannel.GetSystemErrorCode(errors.Cause(err))
-		if terr, ok := c.metrics.SystemErrors[byte(tcause)]; ok {
-			terr.Inc(1)
-		} else { // default system-error metrics without error detail tagging
-			c.metrics.SystemErrors[0x00].Inc(1)
-		}
+		c.metrics.SystemErrors.IncrErr(err, 1)
 	} else if !c.success {
 		c.metrics.AppErrors.Inc(1)
 	} else {

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -268,7 +268,12 @@ func (c *tchannelOutboundCall) finish(err error) {
 
 	// emit metrics
 	if err != nil {
-		c.metrics.SystemErrors.Inc(1)
+		tcause := tchannel.GetSystemErrorCode(errors.Cause(err))
+		if terr, ok := c.metrics.SystemErrors[byte(tcause)]; ok {
+			terr.Inc(1)
+		} else { // default system-error metrics without error detail tagging
+			c.metrics.SystemErrors[0x00].Inc(1)
+		}
 	} else if !c.success {
 		c.metrics.AppErrors.Inc(1)
 	} else {

--- a/runtime/tchannel_logger.go
+++ b/runtime/tchannel_logger.go
@@ -127,11 +127,19 @@ func (l TChannelLogger) WithFields(fields ...tchannel.LogField) tchannel.Logger 
 // https://github.com/uber/tchannel-node/blob/master/errors.js#L907-L930
 func LogErrorWarnTimeout(logger *zap.Logger, err error, msg string) {
 	if err != nil {
-		if errors.Cause(err) == context.Canceled || errors.Cause(err) == context.DeadlineExceeded ||
-			tchannel.GetSystemErrorCode(errors.Cause(err)) == tchannel.ErrCodeTimeout {
+		if IsTimeout(err) {
 			logger.Warn(msg, zap.Error(err))
 		} else {
 			logger.Error(msg, zap.Error(err))
 		}
 	}
+}
+
+// IsTimeout return true if error caused by timeout
+func IsTimeout(err error) bool {
+	cause := errors.Cause(err)
+	return cause == context.Canceled ||
+		cause == context.DeadlineExceeded ||
+		tchannel.GetSystemErrorCode(
+			errors.Cause(err)) == tchannel.ErrCodeTimeout
 }

--- a/runtime/tchannel_logger.go
+++ b/runtime/tchannel_logger.go
@@ -127,7 +127,7 @@ func (l TChannelLogger) WithFields(fields ...tchannel.LogField) tchannel.Logger 
 // https://github.com/uber/tchannel-node/blob/master/errors.js#L907-L930
 func LogErrorWarnTimeout(logger *zap.Logger, err error, msg string) {
 	if err != nil {
-		if IsTimeout(err) {
+		if isTimeout(err) {
 			logger.Warn(msg, zap.Error(err))
 		} else {
 			logger.Error(msg, zap.Error(err))
@@ -135,8 +135,9 @@ func LogErrorWarnTimeout(logger *zap.Logger, err error, msg string) {
 	}
 }
 
-// IsTimeout return true if error caused by timeout
-func IsTimeout(err error) bool {
+// isTimeout return true if error caused by timeout or context cancel
+// used by LogErrorWarnTimeout
+func isTimeout(err error) bool {
 	cause := errors.Cause(err)
 	return cause == context.Canceled ||
 		cause == context.DeadlineExceeded ||

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -234,7 +234,12 @@ func (c *tchannelInboundCall) finish(err error) {
 
 	// emit metrics
 	if err != nil {
-		c.endpoint.metrics.SystemErrors.Inc(1)
+		tcause := tchannel.GetSystemErrorCode(errors.Cause(err))
+		if terr, ok := c.endpoint.metrics.SystemErrors[byte(tcause)]; ok {
+			terr.Inc(1)
+		} else { // default system-error metrics without error detail tagging
+			c.endpoint.metrics.SystemErrors[0x00].Inc(1)
+		}
 	} else if !c.success {
 		c.endpoint.metrics.AppErrors.Inc(1)
 	} else {

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -234,12 +234,7 @@ func (c *tchannelInboundCall) finish(err error) {
 
 	// emit metrics
 	if err != nil {
-		tcause := tchannel.GetSystemErrorCode(errors.Cause(err))
-		if terr, ok := c.endpoint.metrics.SystemErrors[byte(tcause)]; ok {
-			terr.Inc(1)
-		} else { // default system-error metrics without error detail tagging
-			c.endpoint.metrics.SystemErrors[0x00].Inc(1)
-		}
+		c.endpoint.metrics.SystemErrors.IncrErr(err, 1)
 	} else if !c.success {
 		c.endpoint.metrics.AppErrors.Inc(1)
 	} else {

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -60,7 +60,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 13
+	numMetrics := 14
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -73,7 +73,7 @@ func TestCallMetrics(t *testing.T) {
 	headers["x-token"] = "token"
 	headers["x-uuid"] = "uuid"
 
-	numMetrics := 13
+	numMetrics := 14
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	_, err = gateway.MakeRequest(

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -72,7 +72,7 @@ func TestCallMetrics(t *testing.T) {
 		bazClient.NewSimpleServiceCallHandler(fakeCall),
 	)
 
-	numMetrics := 12
+	numMetrics := 13
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	ctx := context.Background()

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -112,7 +112,7 @@ func TestHealthMetrics(t *testing.T) {
 	defer gateway.Close()
 
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
-	numMetrics := 9
+	numMetrics := 10
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 
 	res, err := gateway.MakeRequest("GET", "/health", nil, nil)
@@ -211,12 +211,12 @@ func TestRuntimeMetrics(t *testing.T) {
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
 
 	// Expect 9 runtime metrics + 1 logged metric
-	numMetrics := 10
+	numMetrics := 11
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 	cgateway.MetricsWaitGroup.Wait()
 
 	metrics := cgateway.M3Service.GetMetrics()
-	assert.Equal(t, numMetrics, len(metrics), "expected 10 metrics")
+	assert.Equal(t, numMetrics, len(metrics), "expected 10TestCallMetrics metrics")
 	names := []string{
 		"test-gateway.test.per-worker.runtime.num-cpu",
 		"test-gateway.test.per-worker.runtime.gomaxprocs",


### PR DESCRIPTION
we want to capture error details for our client requests, tchannel and http, for better monitoring and debug-ability. Sample metrics we want to capture is request timeout

for http clients, we already emitting metrics for 418 and 504

for tchannel clients, error details are categorized as `systemError`  -> added some known type that we care about to emit extra metrics
- if tchannel error is either of such (like timeout), the `system-error` counter will be tagged with error metrics name. Such subscope is init-ed during the client initialization 



I'm also adding one liner for per host bootstrap since a spike of such metrics was used as indicator of massive instance crash 