### PR TITLE
Create sub-channel with dedicated hostport for deputy request

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2602,7 +2602,8 @@ func (h *{{$handlerName}}) redirectToDeputy(
 		"{{.ThriftService}}::{{.Name}}": "{{$methodName}}",
 	}
 
-	h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClient(
 		h.Deps.Default.Channel,
 		h.Deps.Default.Logger,
@@ -2617,7 +2618,8 @@ func (h *{{$handlerName}}) redirectToDeputy(
 		},
 	)
 
-	success, respHeaders, err := client.CallToHostPort(ctx, "{{.ThriftService}}", "{{$methodName}}", hostPort, reqHeaders, req, res, false)
+	success, respHeaders, err := client.Call(ctx, "{{.ThriftService}}", "{{$methodName}}", reqHeaders, req, res)
+	sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }
 {{end -}}
@@ -2659,7 +2661,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8167, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8204, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -218,7 +218,8 @@ func (h *{{$handlerName}}) redirectToDeputy(
 		"{{.ThriftService}}::{{.Name}}": "{{$methodName}}",
 	}
 
-	h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClient(
 		h.Deps.Default.Channel,
 		h.Deps.Default.Logger,
@@ -233,7 +234,8 @@ func (h *{{$handlerName}}) redirectToDeputy(
 		},
 	)
 
-	success, respHeaders, err := client.CallToHostPort(ctx, "{{.ThriftService}}", "{{$methodName}}", hostPort, reqHeaders, req, res, false)
+	success, respHeaders, err := client.Call(ctx, "{{.ThriftService}}", "{{$methodName}}", reqHeaders, req, res)
+	sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }
 {{end -}}

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -184,7 +184,8 @@ func (h *SimpleServiceCallHandler) redirectToDeputy(
 		"SimpleService::Call": "Call",
 	}
 
-	h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	sub.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClient(
 		h.Deps.Default.Channel,
 		h.Deps.Default.Logger,
@@ -199,7 +200,8 @@ func (h *SimpleServiceCallHandler) redirectToDeputy(
 		},
 	)
 
-	success, respHeaders, err := client.CallToHostPort(ctx, "SimpleService", "Call", hostPort, reqHeaders, req, res, false)
+	success, respHeaders, err := client.Call(ctx, "SimpleService", "Call", reqHeaders, req, res)
+	sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }
 

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -99,5 +99,5 @@ func (r *RawTChannelClient) Call(
 		call.metrics = r.tc.metrics[serviceMethod]
 	}
 
-	return r.tc.call(ctx, call, reqHeaders, req, resp, false, "")
+	return r.tc.call(ctx, call, reqHeaders, req, resp, false)
 }


### PR DESCRIPTION
- Create a subchannel with dedicated hostport per deputy request.
- Remove callToHostPort method from PR#408 at Tchannel_Client 