### PR TITLE
Add ability to attach env vars to root scope

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -2,6 +2,8 @@
 	"service.env.config": {},
 
 	"env": "production",
+	"env-vars-to-tag-in-root-scope": [],
+
 	"useDatacenter": false,
 
 	"jaeger.disabled": false,

--- a/config/production.json
+++ b/config/production.json
@@ -2,7 +2,7 @@
 	"service.env.config": {},
 
 	"env": "production",
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 
 	"useDatacenter": false,
 

--- a/config/production.json
+++ b/config/production.json
@@ -2,7 +2,7 @@
 	"service.env.config": {},
 
 	"env": "production",
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 
 	"useDatacenter": false,
 

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -68,6 +68,8 @@ var _productionJson = []byte(`{
 	"service.env.config": {},
 
 	"env": "production",
+	"env-vars-to-add-to-metrics-root-scope": [],
+
 	"useDatacenter": false,
 
 	"jaeger.disabled": false,
@@ -104,7 +106,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 713, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 760, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -106,7 +106,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 744, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 746, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -68,7 +68,7 @@ var _productionJson = []byte(`{
 	"service.env.config": {},
 
 	"env": "production",
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 
 	"useDatacenter": false,
 

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -68,7 +68,7 @@ var _productionJson = []byte(`{
 	"service.env.config": {},
 
 	"env": "production",
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 
 	"useDatacenter": false,
 
@@ -106,7 +106,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 752, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 744, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/production.json.go
+++ b/config/production.json.go
@@ -68,7 +68,7 @@ var _productionJson = []byte(`{
 	"service.env.config": {},
 
 	"env": "production",
-	"env-vars-to-add-to-metrics-root-scope": [],
+	"env-vars-to-tag-in-root-scope": [],
 
 	"useDatacenter": false,
 
@@ -106,7 +106,7 @@ func productionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "production.json", size: 760, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "production.json", size: 752, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/config/test.json
+++ b/config/test.json
@@ -14,7 +14,7 @@
 	},
 
 	"env": "test",
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 	"useDatacenter": false,
 
 	"jaeger.disabled": false,

--- a/config/test.json
+++ b/config/test.json
@@ -14,6 +14,7 @@
 	},
 
 	"env": "test",
+	"env-vars-to-tag-in-root-scope": [],
 	"useDatacenter": false,
 
 	"jaeger.disabled": false,

--- a/config/test.json
+++ b/config/test.json
@@ -14,7 +14,7 @@
 	},
 
 	"env": "test",
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 	"useDatacenter": false,
 
 	"jaeger.disabled": false,

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/uber/zanzibar/runtime"
 
 	service "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
-	"github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
+	module "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
 )
 
 var configFiles *string

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -34,7 +34,7 @@ import (
 	"github.com/uber/zanzibar/runtime"
 
 	service "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
-	module "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
+	"github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
 )
 
 var configFiles *string

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -27,7 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 	"http.port": 7783,
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -27,7 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 	"http.port": 7783,
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -27,6 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
+	"env-vars-to-tag-in-root-scope": [],
 	"http.port": 7783,
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",

--- a/examples/example-gateway/config/test.json
+++ b/examples/example-gateway/config/test.json
@@ -27,7 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 	"http.port": 0,
 	"logger.fileName": "/tmp/example-gateway.log",
 	"logger.output": "disk",

--- a/examples/example-gateway/config/test.json
+++ b/examples/example-gateway/config/test.json
@@ -27,6 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
+	"env-vars-to-tag-in-root-scope": [],
 	"http.port": 0,
 	"logger.fileName": "/tmp/example-gateway.log",
 	"logger.output": "disk",

--- a/examples/example-gateway/config/test.json
+++ b/examples/example-gateway/config/test.json
@@ -27,7 +27,7 @@
 	"clients.multi.ip": "127.0.0.1",
 	"clients.multi.port": 4003,
 	"clients.multi.timeout": 10000,
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 	"http.port": 0,
 	"logger.fileName": "/tmp/example-gateway.log",
 	"logger.output": "disk",

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -341,9 +341,9 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		"service": service,
 	}
 	// Adds in any env variable variables specified in config
-	envToRootScopeTag := []string{}
-	config.MustGetStruct("env-to-root-scope-tag", &envToRootScopeTag)
-	for _, envVarName := range envToRootScopeTag {
+	envVarsToTagInRootScope := []string{}
+	config.MustGetStruct("envVarsToTagInRootScope", &envVarsToTagInRootScope)
+	for _, envVarName := range envVarsToTagInRootScope {
 		envVarValue := os.Getenv(envVarName)
 		if envVarValue != "" {
 			defaultTags[envVarName] = envVarValue

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -341,11 +341,13 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		"service": service,
 	}
 	// Adds in any env variable variables specified in config
-	envVarsToTagInRootScope := []string{}
-	config.MustGetStruct("env-vars-to-tag-in-root-scope", &envVarsToTagInRootScope)
-	for _, envVarName := range envVarsToTagInRootScope {
+	envToRootScopeTag := []string{}
+	config.MustGetStruct("env-to-root-scope-tag", &envToRootScopeTag)
+	for _, envVarName := range envToRootScopeTag {
 		envVarValue := os.Getenv(envVarName)
-		defaultTags[envVarName] = envVarValue
+		if envVarValue != "" {
+			defaultTags[envVarName] = envVarValue
+		}
 	}
 	gateway.RootScope, gateway.scopeCloser = tally.NewRootScope(
 		tally.ScopeOptions{

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -340,6 +340,13 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		"env":     env,
 		"service": service,
 	}
+	// Adds in any env variable variables specified in config
+	envVarsToTagInRootScope := []string{}
+	config.MustGetStruct("env-vars-to-tag-in-root-scope", &envVarsToTagInRootScope)
+	for _, envVarName := range envVarsToTagInRootScope {
+		envVarValue := os.Getenv(envVarName)
+		defaultTags[envVarName] = envVarValue
+	}
 	gateway.RootScope, gateway.scopeCloser = tally.NewRootScope(
 		tally.ScopeOptions{
 			Tags:            defaultTags,

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -345,9 +345,7 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 	config.MustGetStruct("envVarsToTagInRootScope", &envVarsToTagInRootScope)
 	for _, envVarName := range envVarsToTagInRootScope {
 		envVarValue := os.Getenv(envVarName)
-		if envVarValue != "" {
-			defaultTags[envVarName] = envVarValue
-		}
+		defaultTags[envVarName] = envVarValue
 	}
 	gateway.RootScope, gateway.scopeCloser = tally.NewRootScope(
 		tally.ScopeOptions{

--- a/test/config/test.json
+++ b/test/config/test.json
@@ -1,4 +1,5 @@
 {
+	"env-vars-to-tag-in-root-scope": [],
 	"serviceName": "my-gateway",
 	"http.port": 1000,
 

--- a/test/config/test.json
+++ b/test/config/test.json
@@ -1,5 +1,5 @@
 {
-	"env-to-root-scope-tag": [],
+	"envVarsToTagInRootScope": [],
 	"serviceName": "my-gateway",
 	"http.port": 1000,
 

--- a/test/config/test.json
+++ b/test/config/test.json
@@ -1,5 +1,5 @@
 {
-	"env-vars-to-tag-in-root-scope": [],
+	"env-to-root-scope-tag": [],
 	"serviceName": "my-gateway",
 	"http.port": 1000,
 

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -94,6 +94,7 @@ func CreateGateway(
 
 	seedConfig["http.port"] = int64(0)
 	seedConfig["tchannel.port"] = int64(0)
+	seedConfig["env-vars-to-tag-in-root-scope"] = []string{}
 
 	if _, ok := seedConfig["tchannel.serviceName"]; !ok {
 		seedConfig["tchannel.serviceName"] = "bench-gateway"

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -94,7 +94,7 @@ func CreateGateway(
 
 	seedConfig["http.port"] = int64(0)
 	seedConfig["tchannel.port"] = int64(0)
-	seedConfig["env-to-root-scope-tag"] = []string{}
+	seedConfig["envVarsToTagInRootScope"] = []string{}
 
 	if _, ok := seedConfig["tchannel.serviceName"]; !ok {
 		seedConfig["tchannel.serviceName"] = "bench-gateway"

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -94,7 +94,7 @@ func CreateGateway(
 
 	seedConfig["http.port"] = int64(0)
 	seedConfig["tchannel.port"] = int64(0)
-	seedConfig["env-vars-to-tag-in-root-scope"] = []string{}
+	seedConfig["env-to-root-scope-tag"] = []string{}
 
 	if _, ok := seedConfig["tchannel.serviceName"]; !ok {
 		seedConfig["tchannel.serviceName"] = "bench-gateway"


### PR DESCRIPTION
Per offline discussion, this appears to be the cleanest, shortest path to allow tagging the metrics RootScope object with values from env variables.

For example, this will allow services using zanzibar to emit metrics tagged with things like production deployment groups.