### PR TITLE
inject jaeger span before send http client request

### DIFF
--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -158,7 +158,8 @@ func (req *ClientHTTPRequest) Do(
 	methodTag := opentracing.Tag{Key: "Method", Value: req.httpReq.Method}
 	span, ctx := opentracing.StartSpanFromContext(ctx, opName, urlTag, methodTag)
 	carrier := opentracing.HTTPHeadersCarrier(req.httpReq.Header)
-	if err := span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier); err != nil {
+	err := span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
+	if err != nil {
 		req.Logger.Error("Failed to inject tracing span.", zap.Error(err))
 	}
 

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -172,7 +172,7 @@ func (req *ClientHTTPRequest) Do(
 	return req.res, nil
 }
 
-// InjectSpan will inject span to request header
+// InjectSpanToHeader will inject span to request header
 func (req *ClientHTTPRequest) InjectSpanToHeader(span opentracing.Span, format interface{}) error {
 	carrier := opentracing.HTTPHeadersCarrier(req.httpReq.Header)
 	if err := span.Tracer().Inject(span.Context(), format, carrier); err != nil {

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -157,6 +157,11 @@ func (req *ClientHTTPRequest) Do(
 	urlTag := opentracing.Tag{Key: "URL", Value: req.httpReq.URL}
 	methodTag := opentracing.Tag{Key: "Method", Value: req.httpReq.Method}
 	span, ctx := opentracing.StartSpanFromContext(ctx, opName, urlTag, methodTag)
+	carrier := opentracing.HTTPHeadersCarrier(req.httpReq.Header)
+	if err := span.Tracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier); err != nil {
+		req.Logger.Error("Failed to inject tracing span.", zap.Error(err))
+	}
+
 	res, err := req.client.Client.Do(req.httpReq.WithContext(ctx))
 	span.Finish()
 	if err != nil {

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -173,6 +173,8 @@ func (req *ClientHTTPRequest) Do(
 }
 
 // InjectSpanToHeader will inject span to request header
+// This method is current used for unit tests
+// TODO: we need to set source and test code as same pkg name which would makes UTs easier
 func (req *ClientHTTPRequest) InjectSpanToHeader(span opentracing.Span, format interface{}) error {
 	carrier := opentracing.HTTPHeadersCarrier(req.httpReq.Header)
 	if err := span.Tracer().Inject(span.Context(), format, carrier); err != nil {


### PR DESCRIPTION
inject jaeger span before send http client request, it is the [same](https://github.com/uber/zanzibar/blob/master/runtime/tchannel_client.go#L227) as we injecting span before sending out tchannel client request