### PR TITLE
Refactor PackageHelper constructor

### DIFF
--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -63,18 +63,18 @@ func newPackageHelper(t *testing.T) *codegen.PackageHelper {
 		return nil
 	}
 
+	packageRoot := "github.com/uber/zanzibar/examples/example-gateway"
+	options := &codegen.PackageHelperOptions{
+		RelTargetGenDir: tmpDir,
+		CopyrightHeader: testCopyrightHeader,
+		GenCodePackage:  packageRoot + "/build/gen-code",
+		TraceKey:        "trace-key",
+	}
+
 	h, err := codegen.NewPackageHelper(
-		"github.com/uber/zanzibar/examples/example-gateway",
+		packageRoot,
 		absGatewayPath,
-		"middlewares",
-		"./idl",
-		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
-		tmpDir,
-		testCopyrightHeader,
-		"zanzibar",
-		"X-Zanzibar-Use-Staging",
-		"x-deputy-forwarded",
-		"trace-key",
+		options,
 	)
 	if !assert.NoError(t, err, "failed to create package helper") {
 		return nil

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -59,18 +59,18 @@ func TestGenerateBar(t *testing.T) {
 		return
 	}
 
+	packageRoot := "github.com/uber/zanzibar/examples/example-gateway"
+	options := &codegen.PackageHelperOptions{
+		RelTargetGenDir: tmpDir,
+		CopyrightHeader: testCopyrightHeader,
+		GenCodePackage:  packageRoot + "/build/gen-code",
+		TraceKey:        "trace-key",
+	}
+
 	packageHelper, err := codegen.NewPackageHelper(
-		"github.com/uber/zanzibar/examples/example-gateway",
+		packageRoot,
 		absGatewayPath,
-		"middlewares",
-		"./idl",
-		"github.com/uber/zanzibar/examples/example-gateway/build/gen-code",
-		tmpDir,
-		testCopyrightHeader,
-		"zanzibar",
-		"X-Zanzibar-Use-Staging",
-		"x-deputy-forwarded",
-		"trace-key",
+		options,
 	)
 	if !assert.NoError(t, err, "failed to create package helper", err) {
 		return


### PR DESCRIPTION
This PR refactors the `PackageHelper` constructor by consolidating many optional arguments into a struct, where each field is optional and has a default value if not set. Fixes https://github.com/uber/zanzibar/issues/418.