### PR TITLE
Graceful shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ run-%: $(EXAMPLE_SERVICES_DIR)%/
 	cd "$(EXAMPLE_BASE_DIR)"; \
 		UBER_ENVIRONMENT=production \
 		CONFIG_DIR=./config \
-		./bin/$* --config="config/production.json;"
+		./bin/$* --config="config/test.json;"
 
 
 .PHONY: bins

--- a/codegen/gateway_test.go
+++ b/codegen/gateway_test.go
@@ -22,9 +22,23 @@ package codegen
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	exampleGateway "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
+	benchGateway "github.com/uber/zanzibar/test/lib/bench_gateway"
+	testGateway "github.com/uber/zanzibar/test/lib/test_gateway"
+	"github.com/uber/zanzibar/test/lib/util"
 )
+
+var defaultTestOptions = &testGateway.Options{
+	KnownHTTPBackends:     []string{"bar", "contacts", "google-now"},
+	KnownTChannelBackends: []string{"baz"},
+	ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
+}
+var defaultTestConfig = map[string]interface{}{
+	"clients.baz.serviceName": "baz",
+}
 
 func TestHeadersPropagateMultiDest(t *testing.T) {
 	cfg := `{
@@ -47,4 +61,15 @@ func TestHeadersPropagateMultiDest(t *testing.T) {
 	assert.Nil(t, err)
 	_, err = setPropagateMiddleware(middlewareObj)
 	assert.NotNil(t, err)
+}
+
+func TestGracefulShutdown(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		exampleGateway.CreateGateway,
+	)
+	assert.NoError(t, err)
+	bg := gateway.(*benchGateway.BenchGateway)
+	bg.ActualGateway.Shutdown()
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1258,16 +1258,6 @@ func createGateway() (*zanzibar.Gateway, error) {
 	return gateway, nil
 }
 
-func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {
-	{{- range $idx, $endpoint := (index $instance.ResolvedDependencies "endpoint") }}
-	err{{$idx}} := deps.Endpoint.{{$endpoint.PackageInfo.QualifiedInstanceName}}.Register(g)
-	if err{{$idx}} != nil {
-		return err{{$idx}}
-	}
-	{{- end}}
-	return nil
-}
-
 func logAndWait(server *zanzibar.Gateway) {
 	server.Logger.Info("Started {{$instance.InstanceName | pascal}}",
 		zap.String("realHTTPAddr", server.RealHTTPAddr),
@@ -1315,7 +1305,7 @@ func mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "main.tmpl", size: 1931, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "main.tmpl", size: 1604, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1272,7 +1272,7 @@ func logAndWait(server *zanzibar.Gateway) {
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		<-sig
 		server.WaitGroup.Add(1)
-		server.Close()
+		server.Shutdown()
 		server.WaitGroup.Done()
 	}()
 	server.Wait()
@@ -1313,7 +1313,7 @@ func mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "main.tmpl", size: 1735, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "main.tmpl", size: 1738, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -63,7 +63,7 @@ func logAndWait(server *zanzibar.Gateway) {
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		<-sig
 		server.WaitGroup.Add(1)
-		server.Close()
+		server.Shutdown()
 		server.WaitGroup.Done()
 	}()
 	server.Wait()

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -49,16 +49,6 @@ func createGateway() (*zanzibar.Gateway, error) {
 	return gateway, nil
 }
 
-func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {
-	{{- range $idx, $endpoint := (index $instance.ResolvedDependencies "endpoint") }}
-	err{{$idx}} := deps.Endpoint.{{$endpoint.PackageInfo.QualifiedInstanceName}}.Register(g)
-	if err{{$idx}} != nil {
-		return err{{$idx}}
-	}
-	{{- end}}
-	return nil
-}
-
 func logAndWait(server *zanzibar.Gateway) {
 	server.Logger.Info("Started {{$instance.InstanceName | pascal}}",
 		zap.String("realHTTPAddr", server.RealHTTPAddr),

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -6,9 +6,11 @@ package main
 import (
 	"flag"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 
 	"go.uber.org/zap"
 
@@ -56,9 +58,15 @@ func logAndWait(server *zanzibar.Gateway) {
 		zap.Any("config", server.InspectOrDie()),
 	)
 
-	// TODO: handle sigterm gracefully
+	go func(){
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+		<-sig
+		server.WaitGroup.Add(1)
+		server.Close()
+		server.WaitGroup.Done()
+	}()
 	server.Wait()
-	// TODO: emit metrics about startup.
 }
 
 func readFlags() {

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/uber/zanzibar/runtime"
 
 	service "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway"
-	module "github.com/uber/zanzibar/examples/example-gateway/build/services/example-gateway/module"
 )
 
 var configFiles *string
@@ -65,34 +64,6 @@ func createGateway() (*zanzibar.Gateway, error) {
 	}
 
 	return gateway, nil
-}
-
-func registerEndpoints(g *zanzibar.Gateway, deps *module.Dependencies) error {
-	err0 := deps.Endpoint.Bar.Register(g)
-	if err0 != nil {
-		return err0
-	}
-	err1 := deps.Endpoint.Baz.Register(g)
-	if err1 != nil {
-		return err1
-	}
-	err2 := deps.Endpoint.BazTChannel.Register(g)
-	if err2 != nil {
-		return err2
-	}
-	err3 := deps.Endpoint.Contacts.Register(g)
-	if err3 != nil {
-		return err3
-	}
-	err4 := deps.Endpoint.Googlenow.Register(g)
-	if err4 != nil {
-		return err4
-	}
-	err5 := deps.Endpoint.Multi.Register(g)
-	if err5 != nil {
-		return err5
-	}
-	return nil
 }
 
 func logAndWait(server *zanzibar.Gateway) {

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -81,7 +81,7 @@ func logAndWait(server *zanzibar.Gateway) {
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		<-sig
 		server.WaitGroup.Add(1)
-		server.Close()
+		server.Shutdown()
 		server.WaitGroup.Done()
 	}()
 	server.Wait()

--- a/examples/example-gateway/config/test.json
+++ b/examples/example-gateway/config/test.json
@@ -43,5 +43,6 @@
 	"tchannel.port": 0,
 	"tchannel.processName": "example-gateway",
 	"tchannel.serviceName": "example-gateway",
-	"useDatacenter": false
+	"useDatacenter": false,
+	"shutdown.pollInterval": 10
 }

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -303,8 +303,10 @@ func (gateway *Gateway) Shutdown() {
 
 	select {
 	case err := <-ec:
+		// close ec so that the range ec will not block forever
 		close(ec)
-		errs := []string{err.Error()}
+		errs := make([]string, 0, cap(ec))
+		errs = append(errs, err.Error())
 		for e := range ec {
 			errs = append(errs, e.Error())
 		}

--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -21,6 +21,7 @@
 package zanzibar
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strconv"
@@ -67,7 +68,7 @@ func (server *HTTPServer) JustListen() (net.Listener, error) {
 	return ln, nil
 }
 
-// JustServe will serve all incoming requests
+// JustServe will serve all incoming requests, blocks unless error or server is shut down
 func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 	ln := server.listeningSocket.(*net.TCPListener)
 
@@ -80,19 +81,16 @@ func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 	waitGroup.Done()
 }
 
-// Close the listening socket
-func (server *HTTPServer) Close() {
+// Close gracefully shuts down the server, blocks until shutdown is successful or timeout
+// has reached if there is one associated with the given context.
+func (server *HTTPServer) Close(ctx context.Context) error {
 	server.closing = true
 	if server.listeningSocket == nil {
 		/* coverage ignore next line */
-		return
+		return nil
 	}
 
-	err := server.listeningSocket.Close()
-	if err != nil {
-		/* coverage ignore next line */
-		server.Logger.Error("Error closing listening socket", zap.Error(err))
-	}
+	return server.Shutdown(ctx)
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -21,7 +21,6 @@
 package zanzibar
 
 import (
-	"context"
 	"net"
 	"net/http"
 	"strconv"
@@ -68,7 +67,7 @@ func (server *HTTPServer) JustListen() (net.Listener, error) {
 	return ln, nil
 }
 
-// JustServe will serve all incoming requests, blocks unless error or server is shut down
+// JustServe will serve all incoming requests
 func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 	ln := server.listeningSocket.(*net.TCPListener)
 
@@ -81,16 +80,19 @@ func (server *HTTPServer) JustServe(waitGroup *sync.WaitGroup) {
 	waitGroup.Done()
 }
 
-// Close gracefully shuts down the server, blocks until shutdown is successful or timeout
-// has reached if there is one associated with the given context.
-func (server *HTTPServer) Close(ctx context.Context) error {
+// Close the listening socket
+func (server *HTTPServer) Close() {
 	server.closing = true
 	if server.listeningSocket == nil {
 		/* coverage ignore next line */
-		return nil
+		return
 	}
 
-	return server.Shutdown(ctx)
+	err := server.listeningSocket.Close()
+	if err != nil {
+		/* coverage ignore next line */
+		server.Logger.Error("Error closing listening socket", zap.Error(err))
+	}
 }
 
 // tcpKeepAliveListener sets TCP keep-alive timeouts on accepted

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -60,7 +60,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 14
+	numMetrics := 15
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -73,7 +73,7 @@ func TestCallMetrics(t *testing.T) {
 	headers["x-token"] = "token"
 	headers["x-uuid"] = "uuid"
 
-	numMetrics := 14
+	numMetrics := 15
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	_, err = gateway.MakeRequest(

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -72,7 +72,7 @@ func TestCallMetrics(t *testing.T) {
 		bazClient.NewSimpleServiceCallHandler(fakeCall),
 	)
 
-	numMetrics := 13
+	numMetrics := 14
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	ctx := context.Background()

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -112,7 +112,7 @@ func TestHealthMetrics(t *testing.T) {
 	defer gateway.Close()
 
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
-	numMetrics := 10
+	numMetrics := 11
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 
 	res, err := gateway.MakeRequest("GET", "/health", nil, nil)
@@ -211,12 +211,12 @@ func TestRuntimeMetrics(t *testing.T) {
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
 
 	// Expect 9 runtime metrics + 2 logged metric
-	numMetrics := 11
+	numMetrics := 12
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 	cgateway.MetricsWaitGroup.Wait()
 
 	metrics := cgateway.M3Service.GetMetrics()
-	assert.Equal(t, numMetrics, len(metrics), "expected 11 metrics")
+	assert.Equal(t, numMetrics, len(metrics), "expected 12 metrics")
 	names := []string{
 		"test-gateway.test.per-worker.runtime.num-cpu",
 		"test-gateway.test.per-worker.runtime.gomaxprocs",

--- a/test/lib/test_backend/test_http_backend.go
+++ b/test/lib/test_backend/test_http_backend.go
@@ -21,6 +21,7 @@
 package testbackend
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"sync"
@@ -88,7 +89,7 @@ func (backend *TestHTTPBackend) HandleFunc(
 
 // Close ...
 func (backend *TestHTTPBackend) Close() {
-	backend.Server.Close()
+	_ = backend.Server.Close(context.Background())
 	backend.WaitGroup.Wait()
 }
 

--- a/test/lib/test_backend/test_http_backend.go
+++ b/test/lib/test_backend/test_http_backend.go
@@ -21,14 +21,13 @@
 package testbackend
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"sync"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/uber/zanzibar/runtime"
-	zap "go.uber.org/zap"
+	"go.uber.org/zap"
 )
 
 // TestHTTPBackend will pretend to be a http backend
@@ -89,7 +88,7 @@ func (backend *TestHTTPBackend) HandleFunc(
 
 // Close ...
 func (backend *TestHTTPBackend) Close() {
-	_ = backend.Server.Close(context.Background())
+	backend.Server.Close()
 	backend.WaitGroup.Wait()
 }
 


### PR DESCRIPTION
This PR implements graceful shutdown for both the http and tchannel server.
For http server, it leverages [server.Shutdown](https://golang.org/pkg/net/http/#Server.Shutdown) which gracefully shuts down the server and blocks until it is complete;
TChannel also provides a [Close](https://godoc.org/github.com/uber/tchannel-go#Channel.Close) method to gracefully shut down the server, but it does not block, so we exit upon that polling check gets closed back or it reaches the shutdown timeout.