### PR TITLE
populating request uuid from context  in log util function

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1028,7 +1028,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	{{if .ResponseType -}}
 	var defaultRes  {{.ResponseType}}
 	{{end -}}
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "{{$methodName}}", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "{{$methodName}}", c.httpClient)
 
 	{{if .ReqHeaderGoStatements }}
 	{{range $index, $line := .ReqClientHeaderGoStatements -}}
@@ -1074,7 +1074,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	}
 	{{- end}}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return {{if eq .ResponseType ""}}nil, err{{else}}defaultRes, nil, err{{end}}
 	}
@@ -1203,7 +1203,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 8003, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 8005, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -122,7 +122,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	{{if .ResponseType -}}
 	var defaultRes  {{.ResponseType}}
 	{{end -}}
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "{{$methodName}}", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "{{$methodName}}", c.httpClient)
 
 	{{if .ReqHeaderGoStatements }}
 	{{range $index, $line := .ReqClientHeaderGoStatements -}}
@@ -168,7 +168,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	}
 	{{- end}}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return {{if eq .ResponseType ""}}nil, err{{else}}defaultRes, nil, err{{end}}
 	}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -258,7 +258,7 @@ func (c *barClient) ArgNotStruct(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgNotStruct", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgNotStruct", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/arg-not-struct-path"
@@ -268,7 +268,7 @@ func (c *barClient) ArgNotStruct(
 		return nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (c *barClient) ArgWithHeaders(
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithHeaders", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithHeaders", c.httpClient)
 
 	headers["name"] = string(r.Name)
 	headers["x-uuid"] = string(*r.UserUUID)
@@ -335,7 +335,7 @@ func (c *barClient) ArgWithHeaders(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -377,7 +377,7 @@ func (c *barClient) ArgWithManyQueryParams(
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithManyQueryParams", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithManyQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithManyQueryParams"
@@ -432,7 +432,7 @@ func (c *barClient) ArgWithManyQueryParams(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -474,7 +474,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 	r *clientsBarBar.Bar_ArgWithNestedQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithNestedQueryParams", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithNestedQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithNestedQueryParams"
@@ -522,7 +522,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -564,7 +564,7 @@ func (c *barClient) ArgWithParams(
 	r *clientsBarBar.Bar_ArgWithParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithParams", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithParams" + "/" + string(r.UUID) + "/segment" + "/" + string(r.Params.UserUUID)
@@ -577,7 +577,7 @@ func (c *barClient) ArgWithParams(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -619,7 +619,7 @@ func (c *barClient) ArgWithQueryHeader(
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryHeader", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithQueryHeader", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryHeader"
@@ -629,7 +629,7 @@ func (c *barClient) ArgWithQueryHeader(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -671,7 +671,7 @@ func (c *barClient) ArgWithQueryParams(
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "ArgWithQueryParams", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithQueryParams", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithQueryParams"
@@ -690,7 +690,7 @@ func (c *barClient) ArgWithQueryParams(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -731,7 +731,7 @@ func (c *barClient) Hello(
 	headers map[string]string,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "Hello", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "Hello", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/hello"
@@ -741,7 +741,7 @@ func (c *barClient) Hello(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -790,7 +790,7 @@ func (c *barClient) MissingArg(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "MissingArg", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "MissingArg", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/missing-arg-path"
@@ -800,7 +800,7 @@ func (c *barClient) MissingArg(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -850,7 +850,7 @@ func (c *barClient) NoRequest(
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "NoRequest", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "NoRequest", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/no-request-path"
@@ -860,7 +860,7 @@ func (c *barClient) NoRequest(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -911,7 +911,7 @@ func (c *barClient) Normal(
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "Normal", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "Normal", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar-path"
@@ -921,7 +921,7 @@ func (c *barClient) Normal(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -972,7 +972,7 @@ func (c *barClient) NormalRecur(
 	r *clientsBarBar.Bar_NormalRecur_Args,
 ) (*clientsBarBar.BarResponseRecur, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponseRecur
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "NormalRecur", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "NormalRecur", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/recur"
@@ -982,7 +982,7 @@ func (c *barClient) NormalRecur(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1032,7 +1032,7 @@ func (c *barClient) TooManyArgs(
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes *clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "TooManyArgs", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "TooManyArgs", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/too-many-args-path"
@@ -1042,7 +1042,7 @@ func (c *barClient) TooManyArgs(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1101,7 +1101,7 @@ func (c *barClient) EchoBinary(
 	r *clientsBarBar.Echo_EchoBinary_Args,
 ) ([]byte, map[string]string, error) {
 	var defaultRes []byte
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBinary", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoBinary", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/binary"
@@ -1116,7 +1116,7 @@ func (c *barClient) EchoBinary(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1157,7 +1157,7 @@ func (c *barClient) EchoBool(
 	r *clientsBarBar.Echo_EchoBool_Args,
 ) (bool, map[string]string, error) {
 	var defaultRes bool
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoBool", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoBool", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/bool"
@@ -1172,7 +1172,7 @@ func (c *barClient) EchoBool(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1213,7 +1213,7 @@ func (c *barClient) EchoDouble(
 	r *clientsBarBar.Echo_EchoDouble_Args,
 ) (float64, map[string]string, error) {
 	var defaultRes float64
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoDouble", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoDouble", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/double"
@@ -1228,7 +1228,7 @@ func (c *barClient) EchoDouble(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1269,7 +1269,7 @@ func (c *barClient) EchoEnum(
 	r *clientsBarBar.Echo_EchoEnum_Args,
 ) (clientsBarBar.Fruit, map[string]string, error) {
 	var defaultRes clientsBarBar.Fruit
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoEnum", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoEnum", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/enum"
@@ -1284,7 +1284,7 @@ func (c *barClient) EchoEnum(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1325,7 +1325,7 @@ func (c *barClient) EchoI16(
 	r *clientsBarBar.Echo_EchoI16_Args,
 ) (int16, map[string]string, error) {
 	var defaultRes int16
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI16", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI16", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/i16"
@@ -1340,7 +1340,7 @@ func (c *barClient) EchoI16(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1381,7 +1381,7 @@ func (c *barClient) EchoI32(
 	r *clientsBarBar.Echo_EchoI32_Args,
 ) (int32, map[string]string, error) {
 	var defaultRes int32
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI32", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI32", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/i32"
@@ -1396,7 +1396,7 @@ func (c *barClient) EchoI32(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1437,7 +1437,7 @@ func (c *barClient) EchoI32Map(
 	r *clientsBarBar.Echo_EchoI32Map_Args,
 ) (map[int32]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes map[int32]*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI32Map", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI32Map", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/i32-map"
@@ -1452,7 +1452,7 @@ func (c *barClient) EchoI32Map(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1493,7 +1493,7 @@ func (c *barClient) EchoI64(
 	r *clientsBarBar.Echo_EchoI64_Args,
 ) (int64, map[string]string, error) {
 	var defaultRes int64
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI64", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI64", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/i64"
@@ -1508,7 +1508,7 @@ func (c *barClient) EchoI64(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1549,7 +1549,7 @@ func (c *barClient) EchoI8(
 	r *clientsBarBar.Echo_EchoI8_Args,
 ) (int8, map[string]string, error) {
 	var defaultRes int8
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoI8", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI8", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/i8"
@@ -1564,7 +1564,7 @@ func (c *barClient) EchoI8(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1605,7 +1605,7 @@ func (c *barClient) EchoString(
 	r *clientsBarBar.Echo_EchoString_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoString", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoString", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/string"
@@ -1620,7 +1620,7 @@ func (c *barClient) EchoString(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1661,7 +1661,7 @@ func (c *barClient) EchoStringList(
 	r *clientsBarBar.Echo_EchoStringList_Args,
 ) ([]string, map[string]string, error) {
 	var defaultRes []string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringList", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringList", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/string-list"
@@ -1676,7 +1676,7 @@ func (c *barClient) EchoStringList(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1717,7 +1717,7 @@ func (c *barClient) EchoStringMap(
 	r *clientsBarBar.Echo_EchoStringMap_Args,
 ) (map[string]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes map[string]*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringMap", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringMap", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/string-map"
@@ -1732,7 +1732,7 @@ func (c *barClient) EchoStringMap(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1773,7 +1773,7 @@ func (c *barClient) EchoStringSet(
 	r *clientsBarBar.Echo_EchoStringSet_Args,
 ) (map[string]struct{}, map[string]string, error) {
 	var defaultRes map[string]struct{}
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStringSet", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringSet", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/string-set"
@@ -1788,7 +1788,7 @@ func (c *barClient) EchoStringSet(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1829,7 +1829,7 @@ func (c *barClient) EchoStructList(
 	r *clientsBarBar.Echo_EchoStructList_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructList", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStructList", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/struct-list"
@@ -1844,7 +1844,7 @@ func (c *barClient) EchoStructList(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1885,7 +1885,7 @@ func (c *barClient) EchoStructSet(
 	r *clientsBarBar.Echo_EchoStructSet_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	var defaultRes []*clientsBarBar.BarResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoStructSet", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStructSet", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/struct-set"
@@ -1900,7 +1900,7 @@ func (c *barClient) EchoStructSet(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -1941,7 +1941,7 @@ func (c *barClient) EchoTypedef(
 	r *clientsBarBar.Echo_EchoTypedef_Args,
 ) (clientsBarBar.UUID, map[string]string, error) {
 	var defaultRes clientsBarBar.UUID
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoTypedef", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoTypedef", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/echo" + "/typedef"
@@ -1956,7 +1956,7 @@ func (c *barClient) EchoTypedef(
 		return defaultRes, nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -94,7 +94,7 @@ func (c *contactsClient) SaveContacts(
 	r *clientsContactsContacts.SaveContactsRequest,
 ) (*clientsContactsContacts.SaveContactsResponse, map[string]string, error) {
 	var defaultRes *clientsContactsContacts.SaveContactsResponse
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "SaveContacts", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "SaveContacts", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/" + string(r.UserUUID) + "/contacts"
@@ -104,7 +104,7 @@ func (c *contactsClient) SaveContacts(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -144,7 +144,7 @@ func (c *contactsClient) TestURLURL(
 	headers map[string]string,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "TestURLURL", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "TestURLURL", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/contacts" + "/testUrl"
@@ -154,7 +154,7 @@ func (c *contactsClient) TestURLURL(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -103,7 +103,7 @@ func (c *corgeHTTPClient) EchoString(
 	r *clientsCorgeCorge.Corge_EchoString_Args,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "EchoString", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoString", c.httpClient)
 
 	headers[c.callerHeader] = c.callerName
 	headers[c.calleeHeader] = c.calleeName
@@ -116,7 +116,7 @@ func (c *corgeHTTPClient) EchoString(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -93,7 +93,7 @@ func (c *googleNowClient) AddCredentials(
 	headers map[string]string,
 	r *clientsGooglenowGooglenow.GoogleNowService_AddCredentials_Args,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "AddCredentials", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "AddCredentials", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/add-credentials"
@@ -108,7 +108,7 @@ func (c *googleNowClient) AddCredentials(
 		return nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +146,7 @@ func (c *googleNowClient) CheckCredentials(
 	ctx context.Context,
 	headers map[string]string,
 ) (map[string]string, error) {
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "CheckCredentials", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "CheckCredentials", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/check-credentials"
@@ -161,7 +161,7 @@ func (c *googleNowClient) CheckCredentials(
 		return nil, headerErr
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return nil, err
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -91,7 +91,7 @@ func (c *multiClient) HelloA(
 	headers map[string]string,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "HelloA", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "HelloA", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/multi" + "/serviceA_b" + "/hello"
@@ -101,7 +101,7 @@ func (c *multiClient) HelloA(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}
@@ -141,7 +141,7 @@ func (c *multiClient) HelloB(
 	headers map[string]string,
 ) (string, map[string]string, error) {
 	var defaultRes string
-	req := zanzibar.NewClientHTTPRequest(c.clientID, "HelloB", c.httpClient)
+	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "HelloB", c.httpClient)
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/multi" + "/serviceB_b" + "/hello"
@@ -151,7 +151,7 @@ func (c *multiClient) HelloB(
 		return defaultRes, nil, err
 	}
 
-	res, err := req.Do(ctx)
+	res, err := req.Do()
 	if err != nil {
 		return defaultRes, nil, err
 	}

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -66,7 +66,7 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 		map[string]string{},
 		time.Second,
 	)
-	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "clientID", "DoStuff", client)
 
 	err = req.WriteJSON("GET", "/foo", nil, &failingJsonObj{})
 	assert.NotNil(t, err)
@@ -140,7 +140,7 @@ func TestMakingClientCallWithHeaders(t *testing.T) {
 	barClient := deps.Client.Bar
 	client := barClient.HTTPClient()
 
-	req := zanzibar.NewClientHTTPRequest("bar", "Normal", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "bar", "Normal", client)
 
 	err = req.WriteJSON(
 		"POST",
@@ -415,7 +415,7 @@ func TestInjectSpan(t *testing.T) {
 	deps := bgateway.Dependencies.(*exampleGateway.DependenciesTree)
 	barClient := deps.Client.Bar
 	client := barClient.HTTPClient()
-	req := zanzibar.NewClientHTTPRequest("bar", "Normal", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "bar", "Normal", client)
 	err = req.WriteJSON(
 		"POST",
 		client.BaseURL+"/bar-path",

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -100,7 +100,7 @@ func TestMakingClientWriteJSONWithBadHTTPMethod(t *testing.T) {
 		map[string]string{},
 		time.Second,
 	)
-	req := zanzibar.NewClientHTTPRequest("clientID", "DoStuff", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "clientID", "DoStuff", client)
 
 	err = req.WriteJSON("@INVALIDMETHOD", "/foo", nil, nil)
 	assert.NotNil(t, err)
@@ -152,7 +152,7 @@ func TestMakingClientCallWithHeaders(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	res, err := req.Do(context.Background())
+	res, err := req.Do()
 	assert.NoError(t, err)
 	assert.Equal(t, 200, res.StatusCode)
 

--- a/runtime/client_http_response_test.go
+++ b/runtime/client_http_response_test.go
@@ -75,11 +75,11 @@ func TestReadAndUnmarshalNonStructBody(t *testing.T) {
 		map[string]string{},
 		time.Second,
 	)
-	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "bar", "echo", client)
 
 	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
 	assert.NoError(t, err)
-	res, err := req.Do(context.Background())
+	res, err := req.Do()
 	assert.NoError(t, err)
 
 	var resp string
@@ -131,11 +131,11 @@ func TestReadAndUnmarshalNonStructBodyUnmarshalError(t *testing.T) {
 		map[string]string{},
 		time.Second,
 	)
-	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "bar", "echo", client)
 
 	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
 	assert.NoError(t, err)
-	res, err := req.Do(context.Background())
+	res, err := req.Do()
 	assert.NoError(t, err)
 
 	var resp string
@@ -187,12 +187,12 @@ func TestUnknownStatusCode(t *testing.T) {
 		time.Second,
 	)
 
-	req := zanzibar.NewClientHTTPRequest("bar", "echo", client)
+	req := zanzibar.NewClientHTTPRequest(context.Background(), "bar", "echo", client)
 
 	err = req.WriteJSON("POST", baseURL+"/bar/echo", nil, myJson{})
 	assert.NoError(t, err)
 
-	res, err := req.Do(context.Background())
+	res, err := req.Do()
 	assert.NoError(t, err)
 
 	var resp string

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -29,7 +29,8 @@ import (
 type contextFieldKey string
 
 const (
-	requestUUIDKey     = contextFieldKey("requestUUID")
+	// RequestUUIDKey is the key for request UUID
+	RequestUUIDKey     = contextFieldKey("requestUUID")
 	routingDelegateKey = contextFieldKey("rd")
 )
 
@@ -37,13 +38,13 @@ const (
 // future, we can use a request context struct to add more context in terms of
 // request handler, etc if need be.
 func withRequestFields(ctx context.Context) context.Context {
-	return context.WithValue(ctx, requestUUIDKey, uuid.NewUUID())
+	return context.WithValue(ctx, RequestUUIDKey, uuid.NewUUID())
 }
 
 // GetRequestUUIDFromCtx returns the RequestUUID, if it exists on context
 // TODO: in future, we can extend this to have request object
 func GetRequestUUIDFromCtx(ctx context.Context) uuid.UUID {
-	if val := ctx.Value(requestUUIDKey); val != nil {
+	if val := ctx.Value(RequestUUIDKey); val != nil {
 		uuid, _ := val.(uuid.UUID)
 		return uuid
 	}

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -31,7 +31,7 @@ import (
 func TestWithRequestFields(t *testing.T) {
 	ctx := withRequestFields(context.TODO())
 
-	u := ctx.Value(requestUUIDKey)
+	u := ctx.Value(RequestUUIDKey)
 	u1, ok := u.(uuid.UUID)
 
 	assert.NotNil(t, ctx)

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -98,9 +98,8 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	//	ctx, cancel = context.WithTimeout(ctx, time.Duration(100)*time.Millisecond)
 	//	defer cancel()
 	//}
-	ctx := withRequestFields(r.Context())
 
-	endpoint.HandlerFn(ctx, req, req.res)
+	endpoint.HandlerFn(req.ctx, req, req.res)
 	req.res.flush()
 }
 

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -107,7 +107,9 @@ func (res *ServerHTTPResponse) finish() {
 	// write logs
 	res.Request.Logger.Info(
 		"Finished an incoming server HTTP request",
-		serverHTTPLogFields(res.Request, res)...,
+		res.Request.GetExtendedLogFields(
+			serverHTTPLogFields(res.Request, res)...,
+		)...,
 	)
 }
 

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -85,6 +85,7 @@ func (r *RawTChannelClient) Call(
 	serviceMethod := thriftService + "::" + methodName
 
 	call := &tchannelOutboundCall{
+		ctx:           ctx,
 		client:        r.tc,
 		methodName:    serviceMethod,
 		serviceMethod: serviceMethod,
@@ -99,5 +100,5 @@ func (r *RawTChannelClient) Call(
 		call.metrics = r.tc.metrics[serviceMethod]
 	}
 
-	return r.tc.call(ctx, call, reqHeaders, req, resp, false)
+	return r.tc.call(call, reqHeaders, req, resp, false)
 }

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -21,6 +21,7 @@
 package zanzibar
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -33,6 +34,7 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 	}
 	staticTestTime := time.Unix(1500000000, 0)
 	outboundCall := &tchannelOutboundCall{
+		ctx:           context.Background(),
 		methodName:    "Get",
 		serviceMethod: "Test",
 		startTime:     staticTestTime,


### PR DESCRIPTION
we need some container during the life-cycle of a request (tchannel server / tchannel client / http server / http client) within zanzibar gateway, to hold the background context data we care, like `requestUUID`, since the log might happen anytime, and we probably want to propagate such context data across the boundary of different modules and services, there're a couple of options here:

1: sub-logger spawn on each request, which we proved with benchmark that it only works better if we have very intense logging: https://github.com/uber/zanzibar/pull/425, with our current requirement it's not worth the memory signature

2: bind context to a request object, so that we can access it every time we need to log, binding context rationale:
  - there's only one context per request
  - context mutation is done in request initialization, it's mostly read only during the life cycle of the request
  - it seems we're already referencing context and pass it around as param multiple places  in request

questions: what's the con of binding context to request?

3: use request header as container:
pros: 
  - it's already there, it will be a uniq place we find all context
  - header can cross RPC boundary (pass to another service) 

cons: 
  - current endpoint / client req / res have its own header schema and we mutate headers heavily in endpoint / workflow for business use cases, header as the container to carry log context may lead to nondeterministic logging behavior and logic couple

open to discussions ^