### PR TITLE
Add GetRequestEndpointFromCtx function

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -40,6 +40,15 @@ func withEndpointField(ctx context.Context, endpoint string) context.Context {
 	return context.WithValue(ctx, endpointKey, endpoint)
 }
 
+// GetRequestEndpointFromCtx returns the endpoint, if it exists on context
+func GetRequestEndpointFromCtx(ctx context.Context) string {
+	if val := ctx.Value(endpointKey); val != nil {
+		endpoint, _ := val.(string)
+		return endpoint
+	}
+	return ""
+}
+
 // withRequestFields annotates zanzibar request context to context.Context. In
 // future, we can use a request context struct to add more context in terms of
 // request handler, etc if need be.

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWithEndpointFields(t *testing.T) {
+func TestWithEndpointField(t *testing.T) {
 	expected := "someEndpoint"
 	ctx := withEndpointField(context.TODO(), expected)
 
@@ -37,6 +37,14 @@ func TestWithEndpointFields(t *testing.T) {
 
 	assert.True(t, ok)
 	assert.Equal(t, endpoint, expected)
+}
+
+func TestGetRequestEndpointFromCtx(t *testing.T) {
+	expected := "someEndpoint"
+	ctx := withEndpointField(context.TODO(), expected)
+	endpoint := GetRequestEndpointFromCtx(ctx)
+
+	assert.Equal(t, expected, endpoint)
 }
 
 func TestWithRequestFields(t *testing.T) {

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -43,7 +43,11 @@ func TestGetRequestEndpointFromCtx(t *testing.T) {
 	expected := "someEndpoint"
 	ctx := withEndpointField(context.TODO(), expected)
 	endpoint := GetRequestEndpointFromCtx(ctx)
+	assert.Equal(t, expected, endpoint)
 
+	expected = ""
+	ctx = context.TODO()
+	endpoint = GetRequestEndpointFromCtx(ctx)
 	assert.Equal(t, expected, endpoint)
 }
 


### PR DESCRIPTION
This commit adds a getter function for [endpoint field at zanzibar context](https://github.com/uber/zanzibar/pull/432).
