### PR TITLE
Fixup log message fields tests by asserting on headers

### DIFF
--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -283,6 +283,9 @@ func TestMakingClientCallWithRespHeaders(t *testing.T) {
 	for actualKey, actualValue := range logMsg {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
 	}
+	for expectedKey, expectedValue := range expectedValues {
+		assert.Equal(t, logMsg[expectedKey], expectedValue, "unexpected header %q", expectedKey)
+	}
 }
 
 func TestMakingClientCallWithThriftException(t *testing.T) {

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1422,20 +1422,11 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 	}
 
 	expectedValues := map[string]interface{}{
-		"msg":                             "Finished an incoming server HTTP request",
-		"env":                             "production",
-		"clientID":                        "baz",
-		"level":                           "info",
-		"serviceName":                     "bazService",
-		"serviceMethod":                   "SimpleService::call",
-		"methodName":                      "Call",
-		"zone":                            "unknown",
-		"service":                         "example-gateway",
-		"Request-Header-Foo-Bar":          "Baz",
-		"Request-Header-x-uuid":           "uuid",
-		"Request-Header-x-token":          "token",
-		"Response-Header-some-res-header": "something",
-
+		"msg":                            "Finished an incoming server HTTP request",
+		"env":                            "production",
+		"level":                          "info",
+		"zone":                           "unknown",
+		"service":                        "example-gateway",
 		"method":                         "GET",
 		"pathname":                       "/foo?bar=bar",
 		"statusCode":                     float64(200),
@@ -1447,5 +1438,8 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 	}
 	for actualKey, actualValue := range tags {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+	}
+	for expectedKey, expectedValue := range expectedValues {
+		assert.Equal(t, expectedValue, tags[expectedKey], "unexpected header %q", expectedKey)
 	}
 }

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -135,6 +135,9 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	for actualKey, actualValue := range tags {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
 	}
+	for expectedKey, expectedValue := range expectedValues {
+		assert.Equal(t, expectedValue, tags[expectedKey], "unexpected header %q", expectedKey)
+	}
 
 	tags = allLogs["Finished an outgoing client TChannel request"][0]
 	dynamicHeaders = []string{
@@ -161,13 +164,15 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 		"methodName":                      "Call",
 		"zone":                            "unknown",
 		"service":                         "example-gateway",
-		"Request-Header-Foo-Bar":          "Baz",
 		"Request-Header-x-uuid":           "uuid",
 		"Request-Header-x-token":          "token",
 		"Response-Header-some-res-header": "something",
 	}
 	for actualKey, actualValue := range tags {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+	}
+	for expectedKey, expectedValue := range expectedValues {
+		assert.Equal(t, expectedValue, tags[expectedKey], "unexpected header %q", expectedKey)
 	}
 }
 


### PR DESCRIPTION
Assert both (1) expected log fields exist, and (2) no extra log fields are actually present. Current code is only doing (2). 