### PR TITLE
Add support for incrementally building single module instance

### DIFF
--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -429,6 +429,365 @@ func TestExampleService(t *testing.T) {
 	}
 }
 
+func TestExampleServiceIncremental(t *testing.T) {
+	moduleSystem := NewModuleSystem()
+	var err error
+
+	err = moduleSystem.RegisterClass(ModuleClass{
+		Name:        "client",
+		ClassType:   MultiModule,
+		Directories: []string{"clients"},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error registering client class: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassType(
+		"client",
+		"http",
+		&TestHTTPClientGenerator{},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error registering http client class type: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassType(
+		"client",
+		"tchannel",
+		&TestTChannelClientGenerator{},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error registering tchannel client class type: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassDir("endpoint", "another")
+	if err == nil {
+		t.Error("Registering class dir for endpoint class should have errored")
+	}
+
+	err = moduleSystem.RegisterClass(ModuleClass{
+		Name:        "endpoint",
+		ClassType:   MultiModule,
+		DependsOn:   []string{"client"},
+		Directories: []string{"endpoints", "more-endpoints"},
+	})
+	if err != nil {
+		t.Errorf("Unexpected error registering endpoint class: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassDir("endpoint", "another")
+	if err != nil {
+		t.Errorf("Unexpected error registering endpoint class dir: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassType(
+		"endpoint",
+		"http",
+		&TestHTTPEndpointGenerator{},
+	)
+	if err != nil {
+		t.Errorf("Unexpected error registering http client class type: %s", err)
+	}
+
+	err = moduleSystem.RegisterClassType(
+		"endpoint",
+		"http",
+		&TestHTTPEndpointGenerator{},
+	)
+	if err == nil {
+		t.Errorf("Expected double creation of http endpoint to error")
+	}
+
+	err = moduleSystem.RegisterClass(ModuleClass{
+		Name:        "client",
+		ClassType:   MultiModule,
+		Directories: []string{"clients"},
+	})
+	if err == nil {
+		t.Errorf("Expected double definition of client class to error")
+	}
+
+	err = moduleSystem.RegisterClassDir("client", "endpoints")
+	if err != nil {
+		t.Error("Unexpected error registering dir for client class")
+	}
+
+	err = moduleSystem.RegisterClass(ModuleClass{
+		Name:        "newClient",
+		ClassType:   MultiModule,
+		Directories: []string{"./clients/../../../foo"},
+	})
+	if err == nil {
+		t.Errorf("Expected registering a module in an external directory to throw")
+	}
+
+	currentDir := getTestDirName()
+	testServiceDir := path.Join(currentDir, "test-service")
+
+	defer func() {
+		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
+		if err != nil {
+			panic(errors.Wrap(err, "error removing serialized module tree"))
+		}
+	}()
+
+	instances, err := moduleSystem.GenerateIncrementalBuild(
+		"github.com/uber/zanzibar/codegen/test-service",
+		testServiceDir,
+		path.Join(testServiceDir, "build"),
+		[]ModuleDependency{
+			{
+				ClassName:    "client",
+				InstanceName: "example",
+			},
+		},
+		true,
+	)
+	if err != nil {
+		t.Errorf("Unexpected error generating build %s", err)
+	}
+
+	expectedClientDependency := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "client",
+		ClassType:     "tchannel",
+		Directory:     "clients/example-dependency",
+		InstanceName:  "example-dependency",
+		JSONFileName:  "client-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewClient",
+			ExportType:            "Client",
+			GeneratedPackageAlias: "exampledependencyClientGenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/clients/example-dependency",
+			IsExportGenerated:     true,
+			PackageAlias:          "exampledependencyClientStatic",
+			PackageName:           "exampledependencyClient",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/clients/example-dependency",
+		},
+		Dependencies:          []ModuleDependency{},
+		ResolvedDependencies:  map[string][]*ModuleInstance{},
+		RecursiveDependencies: map[string][]*ModuleInstance{},
+	}
+
+	expectedClientInstance := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "client",
+		ClassType:     "http",
+		Directory:     "clients/example",
+		InstanceName:  "example",
+		JSONFileName:  "client-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewClient",
+			ExportType:            "Client",
+			GeneratedPackageAlias: "exampleClientGenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/clients/example",
+			IsExportGenerated:     true,
+			PackageAlias:          "exampleClientStatic",
+			PackageName:           "exampleClient",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/clients/example",
+		},
+		Dependencies: []ModuleDependency{
+			{
+				ClassName:    "client",
+				InstanceName: "example-dependency",
+			},
+		},
+		ResolvedDependencies: map[string][]*ModuleInstance{
+			"client": {
+				&expectedClientDependency,
+			},
+		},
+		RecursiveDependencies: map[string][]*ModuleInstance{
+			"client": {
+				&expectedClientDependency,
+			},
+		},
+	}
+
+	expectedEmbeddedClient := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "client",
+		ClassType:     "http",
+		Directory:     "endpoints/health/embedded-client",
+		InstanceName:  "embedded-client",
+		JSONFileName:  "client-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewClient",
+			ExportType:            "Client",
+			GeneratedPackageAlias: "embeddedClientGenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/endpoints/health/embedded-client",
+			IsExportGenerated:     true,
+			PackageAlias:          "embeddedClientStatic",
+			PackageName:           "embeddedClient",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/endpoints/health/embedded-client",
+		},
+		Dependencies:          []ModuleDependency{},
+		ResolvedDependencies:  map[string][]*ModuleInstance{},
+		RecursiveDependencies: map[string][]*ModuleInstance{},
+	}
+
+	expectedHealthEndpointInstance := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "endpoint",
+		ClassType:     "http",
+		Directory:     "endpoints/health",
+		InstanceName:  "health",
+		JSONFileName:  "endpoint-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewEndpoint",
+			ExportType:            "Endpoint",
+			GeneratedPackageAlias: "healthendpointgenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/endpoints/health",
+			IsExportGenerated:     true,
+			PackageAlias:          "healthendpointstatic",
+			PackageName:           "healthendpoint",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/endpoints/health",
+		},
+		Dependencies: []ModuleDependency{
+			{
+				ClassName:    "client",
+				InstanceName: "example",
+			},
+		},
+		ResolvedDependencies: map[string][]*ModuleInstance{
+			"client": {
+				&expectedClientInstance,
+			},
+		},
+		RecursiveDependencies: map[string][]*ModuleInstance{
+			"client": {
+				// Note that the dependencies are ordered
+				&expectedClientDependency,
+				&expectedClientInstance,
+			},
+		},
+	}
+
+	expectedFooEndpointInstance := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "endpoint",
+		ClassType:     "http",
+		Directory:     "more-endpoints/foo",
+		InstanceName:  "foo",
+		JSONFileName:  "endpoint-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewEndpoint",
+			ExportType:            "Endpoint",
+			GeneratedPackageAlias: "fooendpointgenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/more-endpoints/foo",
+			IsExportGenerated:     true,
+			PackageAlias:          "fooendpointstatic",
+			PackageName:           "fooendpoint",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/more-endpoints/foo",
+		},
+		Dependencies: []ModuleDependency{
+			{
+				ClassName:    "client",
+				InstanceName: "example",
+			},
+		},
+		ResolvedDependencies: map[string][]*ModuleInstance{
+			"client": {
+				&expectedClientInstance,
+			},
+		},
+		RecursiveDependencies: map[string][]*ModuleInstance{
+			"client": {
+				// Note that the dependencies are ordered
+				&expectedClientDependency,
+				&expectedClientInstance,
+			},
+		},
+	}
+
+	expectedBarEndpointInstance := ModuleInstance{
+		BaseDirectory: testServiceDir,
+		ClassName:     "endpoint",
+		ClassType:     "http",
+		Directory:     "another/bar",
+		InstanceName:  "bar",
+		JSONFileName:  "endpoint-config.json",
+		PackageInfo: &PackageInfo{
+			ExportName:            "NewEndpoint",
+			ExportType:            "Endpoint",
+			GeneratedPackageAlias: "barendpointgenerated",
+			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/another/bar",
+			IsExportGenerated:     true,
+			PackageAlias:          "barendpointstatic",
+			PackageName:           "barendpoint",
+			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/another/bar",
+		},
+		Dependencies: []ModuleDependency{
+			{
+				ClassName:    "client",
+				InstanceName: "example",
+			},
+		},
+		ResolvedDependencies: map[string][]*ModuleInstance{
+			"client": {
+				&expectedClientInstance,
+			},
+		},
+		RecursiveDependencies: map[string][]*ModuleInstance{
+			"client": {
+				// Note that the dependencies are ordered
+				&expectedClientDependency,
+				&expectedClientInstance,
+			},
+		},
+	}
+
+	expectedClients := []*ModuleInstance{
+		&expectedClientInstance,
+		&expectedClientDependency,
+		&expectedEmbeddedClient,
+	}
+	expectedEndpoints := []*ModuleInstance{
+		&expectedHealthEndpointInstance,
+		&expectedFooEndpointInstance,
+		&expectedBarEndpointInstance,
+	}
+
+	for className, classInstances := range instances {
+		if className == "client" {
+			if len(classInstances) != len(expectedClients) {
+				t.Errorf(
+					"Expected %d client class instance but found %d",
+					len(expectedClients),
+					len(classInstances),
+				)
+			}
+
+			for i, instance := range expectedClients {
+				compareInstances(t, instance, expectedClients[i])
+			}
+		} else if className == "endpoint" {
+			if len(classInstances) != len(expectedEndpoints) {
+				t.Errorf(
+					"Expected %d endpoint class instance but found %d",
+					len(expectedEndpoints),
+					len(classInstances),
+				)
+			}
+
+			for i, instance := range classInstances {
+				compareInstances(t, instance, expectedEndpoints[i])
+
+				clientDependency := instance.ResolvedDependencies["client"][0]
+				clientSpec := clientDependency.GeneratedSpec().(*TestClientSpec)
+
+				if clientSpec.Info != instance.ClassType {
+					t.Errorf(
+						"Expected client spec info on generated client spec",
+					)
+				}
+			}
+		} else {
+			t.Errorf("Unexpected resolved class type %s", className)
+		}
+	}
+}
+
 func TestExampleServiceCycles(t *testing.T) {
 	moduleSystem := NewModuleSystem()
 	var err error

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -51,6 +51,8 @@ func checkError(err error, message string) {
 
 func main() {
 	configFile := flag.String("config", "", "the config file path")
+	moduleName := flag.String("instance", "", "")
+	moduleClass := flag.String("type", "", "")
 	flag.Parse()
 
 	if *configFile == "" {
@@ -130,11 +132,28 @@ func main() {
 	)
 
 	fmt.Printf("Generating module system components:\n")
-	_, err = moduleSystem.GenerateBuild(
-		packageHelper.PackageRoot(),
-		configRoot,
-		packageHelper.CodeGenTargetPath(),
-		true,
-	)
+
+	if *moduleClass != "" && *moduleName != "" {
+		_, err = moduleSystem.GenerateIncrementalBuild(
+			packageHelper.PackageRoot(),
+			configRoot,
+			packageHelper.CodeGenTargetPath(),
+			[]codegen.ModuleDependency{
+				{
+					ClassName:    *moduleClass,
+					InstanceName: *moduleName,
+				},
+			},
+			true,
+		)
+	} else {
+		//lint:ignore SA1019 Migration to incremental builds is ongoing
+		_, err = moduleSystem.GenerateBuild(
+			packageHelper.PackageRoot(),
+			configRoot,
+			packageHelper.CodeGenTargetPath(),
+			true,
+		)
+	}
 	checkError(err, "Failed to generate module system components")
 }


### PR DESCRIPTION
* Deprecated `GenerateBuild` in favor of `GenerateIncrementalBuild` which has a similar API but accepts a list of module instances to build. `GenerateBuild` is called by the script `codegen/runner/runner.go` which is the entry point to the Go implementation of the zanzibar build process. 
* Adds `GenerateIncrementalBuild`, which replaces the old `GenerateBuild`. When building a module instance, we also will build anything that depends on it (for example, if endpoint `A` depends on client `B`, then building `B` will build `A` because `B` will likely have logic related to `A`. 
* Adds interface for `SpecProvider`. Currently code generators implement this interface:

```
type BuildResult {
    Files map[string][]byte
    Spec interface{}
}

type BuildGenerator {
    Generate(instance *ModuleInstance) (*BuildResult, error)
}
```

There is some implicit logic that `Spec` return value will be assigned to the `ModuleInstance` as a side effect as the build goes on. This is a problem for incremental builds because suppose we have `A` depends on both `B` and `C`, but we are only building `B`. Then because we must build `A` (as it depends on `B`) but we are not building `C`, the `*ModuleInstance` for `C` will have a nil Spec. To work around this, we add a `SpecProvider` interface, below, to separate out the `Spec` computation step, and still do `ComputeSpec` on every module instance. 

```
type SpecProvider interface {
    ComputeSpec(instance *ModuleInstance) (interface{}, error)
}
```

If a generator does not implement `SpecProvider` we fall back to full build to preserve backwards compatibility. 

* Changes `codegen/runner/runner.go` to take two new optional CLI flags `-type` and `-instance`. Example usage:

```
$ go run codegen/runner/runner.go -config="examples/example-gateway/build.json" -instance bar -type client
Could not read config file for middleware directory "headers-propagate" skipping...
Could not read config file for middleware directory "transform-request" skipping...
Could not read config file for middleware directory "transform-response" skipping...
Generating module system components:
Skipping generation of "apprentice" "client" class of type "tchannel" as not needed for incremental build
Skipping generation of "baz" "client" class of type "tchannel" as not needed for incremental build
Skipping generation of "contacts" "client" class of type "http" as not needed for incremental build
Skipping generation of "corge" "client" class of type "tchannel" as not needed for incremental build
Skipping generation of "corge-http" "client" class of type "http" as not needed for incremental build
Skipping generation of "google-now" "client" class of type "http" as not needed for incremental build
Skipping generation of "multi" "client" class of type "http" as not needed for incremental build
Skipping generation of "quux" "client" class of type "custom" as not needed for incremental build
Skipping generation of "example" "middleware" class of type "http" as not needed for incremental build
Skipping generation of "example_reader" "middleware" class of type "http" as not needed for incremental build
Skipping generation of "example_tchannel" "middleware" class of type "tchannel" as not needed for incremental build
Skipping generation of "bar" "endpoint" class of type "http" as not needed for incremental build
Skipping generation of "baz" "endpoint" class of type "http" as not needed for incremental build
Skipping generation of "contacts" "endpoint" class of type "http" as not needed for incremental build
Skipping generation of "googlenow" "endpoint" class of type "http" as not needed for incremental build
Skipping generation of "multi" "endpoint" class of type "http" as not needed for incremental build
Skipping generation of "bazTChannel" "endpoint" class of type "tchannel" as not needed for incremental build
Need to generate "bar" "endpoint" "http" because it transitively depends on "bar" "client" "http"
Skipping generation of "example-gateway" "service" class of type "gateway" as not needed for incremental build
Need to generate "example-gateway" "service" "gateway" because it transitively depends on "bar" "client" "http"
Need to generate "example-gateway" "service" "gateway" because it transitively depends on "bar" "endpoint" "http"
Generating         http       client bar                            in build/clients/bar                                  1/19
Generating         http     endpoint bar                            in build/endpoints/bar                                2/19
Generating      gateway      service example-gateway                in build/services/example-gateway                     3/19
Generating 1 client mocks:
Generating         mock       client bar                            in build/clients/bar/mock-client                      1/1
Generating 1 service mocks:
Generating         mock      service example-gateway                in build/services/example-gateway/mock-service        1/1
```

To take advantage of incremental builds, we will need to have a new set of tools that detect when to build what. For example, we should rebuild an endpoint if its thrift changes or if the template changes or if the endpoint configuration changes. 

For the example gateway, if we know that the `bar` client was changed, this saves about 5 seconds (60%) on my laptop:

```
$ time go run codegen/runner/runner.go -config="examples/example-gateway/build.json" -instance bar -type client
[...]
real	0m3.466s
$ time go run codegen/runner/runner.go -config="examples/example-gateway/build.json"
[...]
real	0m8.598s
```