### PR TITLE
fix backward compatible issues

### DIFF
--- a/codegen/gateway_test.go
+++ b/codegen/gateway_test.go
@@ -73,3 +73,112 @@ func TestGracefulShutdown(t *testing.T) {
 	bg := gateway.(*benchGateway.BenchGateway)
 	bg.ActualGateway.Shutdown()
 }
+
+func TestGetModuleConfigNameWhenConfigFileIsYAML(t *testing.T) {
+	expectedFileName := "yamlFile"
+	instance := &ModuleInstance{
+		JSONFileName: "unexpectedFileName",
+		YAMLFileName: expectedFileName,
+	}
+	assert.Equal(t, expectedFileName, getModuleConfigFileName(instance))
+}
+
+func TestGetModuleConfigNameWhenConfigFileIsJSON(t *testing.T) {
+	expectedFileName := "jsonFile"
+	instance := &ModuleInstance{
+		JSONFileName: expectedFileName,
+		YAMLFileName: "",
+	}
+	assert.Equal(t, expectedFileName, getModuleConfigFileName(instance))
+}
+
+func TestExposedMethodKeyTypeError(t *testing.T) {
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": map[interface{}]interface{}{
+				1: "justice",
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.Nil(t, exposedMethods)
+	assert.Error(t, err)
+}
+
+func TestExposedMethodValueTypeError(t *testing.T) {
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": map[interface{}]interface{}{
+				"sicence": 2.71,
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.Nil(t, exposedMethods)
+	assert.Error(t, err)
+}
+
+func TestExposedMethodsTypeError(t *testing.T) {
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": []string{
+				"should", "be", "map",
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.Nil(t, exposedMethods)
+	assert.Error(t, err)
+}
+
+func TestExposedMethodsKeyString(t *testing.T) {
+	expectedMethods := map[string]string{
+		"method1": "func1",
+		"method2": "func2",
+	}
+
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": map[string]interface{}{
+				"method1": "func1",
+				"method2": "func2",
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMethods, exposedMethods)
+}
+
+func TestExposedMethodsKeyInterface(t *testing.T) {
+	expectedMethods := map[string]string{
+		"method1": "func1",
+		"method2": "func2",
+	}
+
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": map[interface{}]interface{}{
+				"method1": "func1",
+				"method2": "func2",
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMethods, exposedMethods)
+}
+
+func TestExposedMethodsDuplication(t *testing.T) {
+	clientConfig := &ClientClassConfig{
+		Config: map[string]interface{}{
+			"exposedMethods": map[string]interface{}{
+				"method1": "func1",
+				"method2": "func1",
+			},
+		},
+	}
+	exposedMethods, err := getExposedMethods(clientConfig)
+	assert.Nil(t, exposedMethods)
+	assert.Error(t, err)
+}

--- a/codegen/module.go
+++ b/codegen/module.go
@@ -751,9 +751,9 @@ func (system *ModuleSystem) readInstance(
 		ResolvedDependencies:  map[string][]*ModuleInstance{},
 		RecursiveDependencies: map[string][]*ModuleInstance{},
 		DependencyOrder:       []string{},
-		JSONFileName:          "",
+		JSONFileName:          yamlFileName,
 		YAMLFileName:          yamlFileName,
-		JSONFileRaw:           []byte{},
+		JSONFileRaw:           raw,
 		YAMLFileRaw:           raw,
 		Config:                yamlConfig.Config,
 	}, nil


### PR DESCRIPTION
Fix two compatible issues:
1. JSONFileRaw should not be empty.
2. ExposedMethods can be either "map[interface{}]interface{}" or "map[string]interface{}"
Error out if the ExposedMethods map key type or value type is not a string. Choose the right file name to be encoded into the error message.