### PR TITLE
Use ./vendor as path to vendor directory for finding mockgen.

### DIFF
--- a/codegen/mockgen.go
+++ b/codegen/mockgen.go
@@ -22,24 +22,20 @@ package codegen
 
 import (
 	"bytes"
+	"github.com/golang/mock/mockgen/model"
+	"github.com/pkg/errors"
 	"go/token"
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/golang/mock/mockgen/model"
-	"github.com/pkg/errors"
 )
 
 const (
-	exampleGatewayPkg = "github.com/uber/zanzibar/examples/example-gateway"
-	mockgenPkg        = "github.com/golang/mock/mockgen"
-	zanzibarPkg       = "github.com/uber/zanzibar"
+	mockgenPkg = "github.com/golang/mock/mockgen"
 )
 
 // MockgenBin is a struct abstracts the mockgen binary built from mockgen package in vendor
@@ -47,23 +43,14 @@ type MockgenBin struct {
 	// Bin is the absolute path to the mockgen binary built from vendor
 	Bin string
 
-	// projRoot is the absolute path of the project, it is also where the vendor directory is
-	projRoot  string
 	pkgHelper *PackageHelper
 	tmpl      *Template
 }
 
 // NewMockgenBin builds the mockgen binary from vendor directory
 func NewMockgenBin(h *PackageHelper, t *Template) (*MockgenBin, error) {
-	pkgRoot := h.PackageRoot()
-	// we would not need this if example gateway is a fully standalone application
-	if pkgRoot == exampleGatewayPkg {
-		pkgRoot = zanzibarPkg
-	}
-	projRoot := filepath.Join(os.Getenv("GOPATH"), "src", pkgRoot)
-
 	// we assume that the vendor directory is flattened as Glide does
-	mockgenDir := path.Join(projRoot, "vendor", mockgenPkg)
+	mockgenDir := path.Join("vendor", mockgenPkg)
 	if _, err := os.Stat(mockgenDir); err != nil {
 		return nil, errors.Wrapf(
 			err, "error finding mockgen package in the vendor dir: %q does not exist", mockgenDir,
@@ -93,9 +80,7 @@ func NewMockgenBin(h *PackageHelper, t *Template) (*MockgenBin, error) {
 	}
 
 	return &MockgenBin{
-		Bin: path.Join(mockgenDir, mockgenBin),
-
-		projRoot:  projRoot,
+		Bin:       path.Join(mockgenDir, mockgenBin),
 		pkgHelper: h,
 		tmpl:      t,
 	}, nil

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -113,7 +113,7 @@ func ClientMockGenHook(h *PackageHelper, t *Template) (PostGenHook, error) {
 		}
 
 		// only run reflect program once to gather interface info for all clients
-		pkgs, err := ReflectInterface(bin.projRoot, pathSymbolMap)
+		pkgs, err := ReflectInterface("", pathSymbolMap)
 		if err != nil {
 			return errors.Wrap(err, "error parsing Client interfaces")
 		}

--- a/codegen/reflect_interface.go
+++ b/codegen/reflect_interface.go
@@ -43,7 +43,7 @@ type reflectData struct {
 // projRoot is the root dir where mockgen is installed as a vendor package
 func ReflectInterface(projRoot string, pathSymbolMap map[string]string) (map[string]*model.Package, error) {
 	// We use TempDir instead of TempFile so we can control the filename.
-	tmpDir, err := ioutil.TempDir(projRoot, "gomock_reflect_")
+	tmpDir, err := ioutil.TempDir("./", "gomock_reflect_")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With pending customizations for config directory, the assumption that we can derive `vendor` folder absolute directory from GOPATH + config_dir + `"vendor"` is no longer true. We don't really need the flexibility to run mockgen from any directory, so just assume it is in `./vendor` for now. 