### PR TITLE
Fix-forward pre-steps using 4th positional argument rather than 5th

### DIFF
--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -19,7 +19,8 @@ fi
 BUILD_DIR="$1"
 CONFIG_DIR="$2"
 ANNOPREFIX="$3"
-IDL_DIR="${4:-$CONFIG_DIR/idl}"
+
+IDL_DIR="${IDL_DIR:-$CONFIG_DIR/idl}"
 
 if [ -z "$4" ]; then
 	THRIFTRW_SRCS="$(find "$IDL_DIR" -name '*.thrift')"


### PR DESCRIPTION
Fixes #484 which was a regression in #483. The 4th positional argument was already an optional argument used to filter the list of Thrift files to run thriftrw-go for. The branch that uses 4th positional argument is not used in the example gateway or tests so that is why it was not caught by tests. In general this "feature" will go away in the future so not adding tests for it. 