### PR TITLE
Add default tags to metrics

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -452,7 +452,6 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 	defaultTags := map[string]string{
 		"env":     env,
 		"service": service,
-		"type":    metricsType,
 		"host":    GetHostname(),
 		"dc":      gateway.Config.MustGetString("datacenter"),
 	}

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -452,6 +452,9 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 	defaultTags := map[string]string{
 		"env":     env,
 		"service": service,
+		"type":    metricsType,
+		"host":    GetHostname(),
+		"dc":      gateway.Config.MustGetString("datacenter"),
 	}
 	// Adds in any env variable variables specified in config
 	envVarsToTagInRootScope := []string{}

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -90,7 +90,6 @@ func TestCallMetrics(t *testing.T) {
 		"endpoint": "bar",
 		"handler":  "normal",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	eStatusTags := map[string]string{
@@ -100,7 +99,6 @@ func TestCallMetrics(t *testing.T) {
 		"handler":  "normal",
 		"status":   "200",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	for _, name := range endpointNames {
@@ -138,7 +136,6 @@ func TestCallMetrics(t *testing.T) {
 		"client":  "bar",
 		"method":  "Normal",
 		"dc":      "unknown",
-		"type":    "m3",
 		"host":    zanzibar.GetHostname(),
 	}
 	cStatusTags := map[string]string{
@@ -148,7 +145,6 @@ func TestCallMetrics(t *testing.T) {
 		"method":  "Normal",
 		"status":  "200",
 		"dc":      "unknown",
-		"type":    "m3",
 		"host":    zanzibar.GetHostname(),
 	}
 
@@ -187,7 +183,6 @@ func TestCallMetrics(t *testing.T) {
 		"env":     "test",
 		"service": "test-gateway",
 		"dc":      "unknown",
-		"type":    "m3",
 		"host":    zanzibar.GetHostname(),
 	}
 

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
+	zanzibar "github.com/uber/zanzibar/runtime"
 	testGateway "github.com/uber/zanzibar/test/lib/test_gateway"
 	"github.com/uber/zanzibar/test/lib/util"
 )
@@ -88,6 +89,9 @@ func TestCallMetrics(t *testing.T) {
 		"service":  "test-gateway",
 		"endpoint": "bar",
 		"handler":  "normal",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	eStatusTags := map[string]string{
 		"env":      "test",
@@ -95,6 +99,9 @@ func TestCallMetrics(t *testing.T) {
 		"endpoint": "bar",
 		"handler":  "normal",
 		"status":   "200",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	for _, name := range endpointNames {
 		key := tally.KeyForPrefixedStringMap(name, endpointTags)
@@ -130,6 +137,9 @@ func TestCallMetrics(t *testing.T) {
 		"service": "test-gateway",
 		"client":  "bar",
 		"method":  "Normal",
+		"dc":      "unknown",
+		"type":    "m3",
+		"host":    zanzibar.GetHostname(),
 	}
 	cStatusTags := map[string]string{
 		"env":     "test",
@@ -137,6 +147,9 @@ func TestCallMetrics(t *testing.T) {
 		"client":  "bar",
 		"method":  "Normal",
 		"status":  "200",
+		"dc":      "unknown",
+		"type":    "m3",
+		"host":    zanzibar.GetHostname(),
 	}
 
 	for _, name := range httpClientNames {
@@ -173,6 +186,9 @@ func TestCallMetrics(t *testing.T) {
 	defaultTags := map[string]string{
 		"env":     "test",
 		"service": "test-gateway",
+		"dc":      "unknown",
+		"type":    "m3",
+		"host":    zanzibar.GetHostname(),
 	}
 
 	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -102,6 +102,9 @@ func TestCallMetrics(t *testing.T) {
 		"service":  "test-gateway",
 		"endpoint": "baz",
 		"handler":  "call",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	statusTags := map[string]string{
 		"env":      "test",
@@ -109,6 +112,9 @@ func TestCallMetrics(t *testing.T) {
 		"endpoint": "baz",
 		"handler":  "call",
 		"status":   "204",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	for _, name := range endpointNames {
 		key := tally.KeyForPrefixedStringMap(name, endpointTags)
@@ -150,6 +156,8 @@ func TestCallMetrics(t *testing.T) {
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
 		"host":            zanzibar.GetHostname(),
+		"dc":              "unknown",
+		"type":            "m3",
 	}
 	for _, name := range tchannelNames {
 		key := tally.KeyForPrefixedStringMap(name, tchannelTags)
@@ -176,6 +184,9 @@ func TestCallMetrics(t *testing.T) {
 		"method":          "Call",
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
+		"dc":              "unknown",
+		"type":            "m3",
+		"host":            zanzibar.GetHostname(),
 	}
 	for _, name := range clientNames {
 		key := tally.KeyForPrefixedStringMap(name, clientTags)
@@ -204,6 +215,9 @@ func TestCallMetrics(t *testing.T) {
 	defaultTags := map[string]string{
 		"env":     "test",
 		"service": "test-gateway",
+		"dc":      "unknown",
+		"type":    "m3",
+		"host":    zanzibar.GetHostname(),
 	}
 
 	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -103,7 +103,6 @@ func TestCallMetrics(t *testing.T) {
 		"endpoint": "baz",
 		"handler":  "call",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	statusTags := map[string]string{
@@ -113,7 +112,6 @@ func TestCallMetrics(t *testing.T) {
 		"handler":  "call",
 		"status":   "204",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	for _, name := range endpointNames {
@@ -157,7 +155,6 @@ func TestCallMetrics(t *testing.T) {
 		"target-endpoint": "SimpleService__call",
 		"host":            zanzibar.GetHostname(),
 		"dc":              "unknown",
-		"type":            "m3",
 	}
 	for _, name := range tchannelNames {
 		key := tally.KeyForPrefixedStringMap(name, tchannelTags)
@@ -185,7 +182,6 @@ func TestCallMetrics(t *testing.T) {
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
 		"dc":              "unknown",
-		"type":            "m3",
 		"host":            zanzibar.GetHostname(),
 	}
 	for _, name := range clientNames {
@@ -216,7 +212,6 @@ func TestCallMetrics(t *testing.T) {
 		"env":     "test",
 		"service": "test-gateway",
 		"dc":      "unknown",
-		"type":    "m3",
 		"host":    zanzibar.GetHostname(),
 	}
 

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -119,6 +119,9 @@ func TestCallMetrics(t *testing.T) {
 		"endpoint": "bazTChannel",
 		"handler":  "call",
 		"method":   "SimpleService__Call",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 
 	for _, name := range endpointNames {
@@ -155,6 +158,8 @@ func TestCallMetrics(t *testing.T) {
 		"service":         "test-gateway",
 		"target-endpoint": "SimpleService__call",
 		"target-service":  "bazService",
+		"dc":              "unknown",
+		"type":            "m3",
 	}
 
 	for _, name := range tchannelOutboundNames {
@@ -182,6 +187,9 @@ func TestCallMetrics(t *testing.T) {
 		"method":          "Call",
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
+		"dc":              "unknown",
+		"type":            "m3",
+		"host":            zanzibar.GetHostname(),
 	}
 
 	for _, name := range clientNames {

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -120,7 +120,6 @@ func TestCallMetrics(t *testing.T) {
 		"handler":  "call",
 		"method":   "SimpleService__Call",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 
@@ -159,7 +158,6 @@ func TestCallMetrics(t *testing.T) {
 		"target-endpoint": "SimpleService__call",
 		"target-service":  "bazService",
 		"dc":              "unknown",
-		"type":            "m3",
 	}
 
 	for _, name := range tchannelOutboundNames {
@@ -188,7 +186,6 @@ func TestCallMetrics(t *testing.T) {
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
 		"dc":              "unknown",
-		"type":            "m3",
 		"host":            zanzibar.GetHostname(),
 	}
 

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -135,6 +135,9 @@ func TestHealthMetrics(t *testing.T) {
 		"service":  "test-gateway",
 		"endpoint": "health",
 		"handler":  "health",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	statusTags := map[string]string{
 		"env":      "test",
@@ -142,10 +145,16 @@ func TestHealthMetrics(t *testing.T) {
 		"endpoint": "health",
 		"handler":  "health",
 		"status":   "200",
+		"dc":       "unknown",
+		"type":     "m3",
+		"host":     zanzibar.GetHostname(),
 	}
 	defaultTags := map[string]string{
 		"env":     "test",
 		"service": "test-gateway",
+		"dc":      "unknown",
+		"type":    "m3",
+		"host":    zanzibar.GetHostname(),
 	}
 
 	for _, name := range names {
@@ -234,6 +243,8 @@ func TestRuntimeMetrics(t *testing.T) {
 		"env":     "test",
 		"service": "test-gateway",
 		"host":    zanzibar.GetHostname(),
+		"dc":      "unknown",
+		"type":    "m3",
 	}
 	for _, name := range names {
 		key := tally.KeyForPrefixedStringMap(name, tags)

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -136,7 +136,6 @@ func TestHealthMetrics(t *testing.T) {
 		"endpoint": "health",
 		"handler":  "health",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	statusTags := map[string]string{
@@ -146,14 +145,12 @@ func TestHealthMetrics(t *testing.T) {
 		"handler":  "health",
 		"status":   "200",
 		"dc":       "unknown",
-		"type":     "m3",
 		"host":     zanzibar.GetHostname(),
 	}
 	defaultTags := map[string]string{
 		"env":     "test",
 		"service": "test-gateway",
 		"dc":      "unknown",
-		"type":    "m3",
 		"host":    zanzibar.GetHostname(),
 	}
 
@@ -244,7 +241,6 @@ func TestRuntimeMetrics(t *testing.T) {
 		"service": "test-gateway",
 		"host":    zanzibar.GetHostname(),
 		"dc":      "unknown",
-		"type":    "m3",
 	}
 	for _, name := range names {
 		key := tally.KeyForPrefixedStringMap(name, tags)


### PR DESCRIPTION
This commits add host, type and dc as default tags at gateway.go