### PR TITLE
Fix static config inspection

### DIFF
--- a/runtime/static_config_test.go
+++ b/runtime/static_config_test.go
@@ -818,7 +818,7 @@ func TestInspectFromFile(t *testing.T) {
 		"bool":  true,
 		"float": float64(1.2),
 		"int":   int(1),
-		"struct": map[interface{}]interface{}{
+		"struct": map[string]interface{}{
 			"Field": "a",
 			"Foo":   int(4),
 		},


### PR DESCRIPTION
This PR fixes the config inspection logging [field](https://github.com/uber/zanzibar/blob/master/examples/example-gateway/build/services/example-gateway/main/main.go#L75).

Previously upon starting the server, the logging field errors:

>  {"level":"info","ts":1540234473.504451,"msg":"Started ExampleGateway","zone":"unknown","env":"production","hostname":"skiptomylu","service":"example-gateway","pid":86696,"realHTTPAddr":"10.32.102.222:60030","realTChannelAddr":"10.32.102.222:60031",**"configError":"json: unsupported type: map[interface {}]interface {}"**}


Now:

> {"level":"info","ts":1540235432.748769,"msg":"Started ExampleGateway","zone":"unknown","env":"production","hostname":"skiptomylu","service":"example-gateway","pid":93769,"realHTTPAddr":"10.32.102.222:61658","realTChannelAddr":"10.32.102.222:61659","config":{"clients.bar.defaultHeaders":{"X-Client-ID":"bar"},"clients.bar.ip":"127.0.0.1","clients.bar.port":4001,"clients.bar.timeout":10000,"clients.baz.ip":"127.0.0.1","clients.baz.port":4002,"clients.baz.serviceName":"Qux","clients.baz.timeout":10000,"clients.baz.timeoutPerAttempt":2000,"clients.contacts.ip":"127.0.0.1","clients.contacts.port":4000,"clients.contacts.timeout":10000,"clients.corge.serviceName":"Corge","clients.corge.timeout":10000,"clients.corge.timeoutPerAttempt":2000,"clients.google-now.ip":"127.0.0.1","clients.google-now.port":14120,"clients.google-now.timeout":10000,"clients.googleNowTChannel.connectionType":"p2p","clients.googleNowTChannel.hostList":["127.0.0.1:4002"],"clients.googleNowTChannel.timeout":10000,"clients.multi.ip":"127.0.0.1","clients.multi.port":4003,"clients.multi.timeout":10000,"datacenter":"unknown","env":"production","envVarsToTagInRootScope":[],"http.port":0,"jaeger.disabled":false,"jaeger.reporter.flush.milliseconds":10000,"jaeger.reporter.hostport":"localhost:6831","jaeger.sampler.param":0.001,"jaeger.sampler.type":"remote","logger.fileName":"/tmp/example-gateway.log","logger.output":"disk","metrics.flushInterval":1000,"metrics.m3.hostPort":"127.0.0.1:9052","metrics.m3.maxPacketSizeBytes":1440,"metrics.m3.maxQueueSize":10000,"metrics.runtime.collectInterval":1000,"metrics.runtime.enableCPUMetrics":true,"metrics.runtime.enableGCMetrics":true,"metrics.runtime.enableMemMetrics":true,"metrics.serviceName":"example-gateway","metrics.type":"m3","service.env.config":{},"serviceName":"example-gateway","shutdown.pollInterval":10,"sidecarRouter.default.http.calleeHeader":"RPC-Service","sidecarRouter.default.http.callerHeader":"RPC-Caller","sidecarRouter.default.http.ip":"127.0.0.1","sidecarRouter.default.http.port":4999,"sidecarRouter.default.tchannel.ip":"127.0.0.1","sidecarRouter.default.tchannel.port":5000,"subLoggerLevel.http":"info","subLoggerLevel.jaeger":"info","subLoggerLevel.tchannel":"info","tchannel.port":0,"tchannel.processName":"example-gateway","tchannel.serviceName":"example-gateway","useDatacenter":false}}
