### PR TITLE
Fix tchannel server error propagation

### DIFF
--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -396,7 +396,9 @@ func (c *tchannelInboundCall) handle(ctx context.Context, wireValue *wire.Value)
 	}
 	if err != nil {
 		LogErrorWarnTimeoutContext(c.ctx, c.endpoint.contextLogger, err, "Unexpected tchannel system error")
-		err = c.call.Response().SendSystemError(errors.New("Server Error"))
+		if er := c.call.Response().SendSystemError(errors.New("Server Error")); er != nil {
+			LogErrorWarnTimeoutContext(c.ctx, c.endpoint.contextLogger, err, "Error sending server error response")
+		}
 		return
 	}
 	if !c.success {


### PR DESCRIPTION
This PR fixes the tchannel server error propagation when unexpected error happens.
https://github.com/uber/zanzibar/blob/master/runtime/tchannel_server.go#L399 overwrites the error to nil when the `SendSystemError` call succeeds, which means https://github.com/uber/zanzibar/blob/master/runtime/tchannel_server.go#L237 gets a nil error back even when there is actually an error. https://github.com/uber/zanzibar/blob/master/runtime/tchannel_server.go#L243 which should have been bypassed in error case now is called and it naturally fails. This leads to that the `Unexpected tchannel system error` error is always followed by `Could not create arg2writer for inbound response` error.