### PR TITLE
Clean up tchannel client/endpoint/server logs

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2512,7 +2512,7 @@ func (h *{{$handlerName}}) Handle(
 	{{if ne .RequestType "" -}}
 	var req {{unref .RequestType}}
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -2548,7 +2548,7 @@ func (h *{{$handlerName}}) Handle(
 
 	{{if eq (len .Exceptions) 0 -}}
 		if err != nil {
-			h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 			return false, nil, resHeaders, err
 		}
 		res.Success = {{.RefResponse "r"}}
@@ -2558,7 +2558,7 @@ func (h *{{$handlerName}}) Handle(
 			{{$method := .Name -}}
 			{{range .Exceptions -}}
 				case *{{.Type}}:
-					h.Deps.Default.ContextLogger.Warn(
+					h.Deps.Default.ContextLogger.Error(
 						ctx,
 						"Handler returned non-nil error type *{{.Type}} but nil value",
 						zap.Error(err),
@@ -2572,7 +2572,7 @@ func (h *{{$handlerName}}) Handle(
 					res.{{title .Name}} = v
 			{{end -}}
 				default:
-					h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+					h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 					return false, nil, resHeaders, errors.Wrapf(
 						err, "%s.%s (%s) handler returned error",
 						h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -2668,7 +2668,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8129, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8133, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2558,12 +2558,12 @@ func (h *{{$handlerName}}) Handle(
 			{{$method := .Name -}}
 			{{range .Exceptions -}}
 				case *{{.Type}}:
-					h.Deps.Default.ContextLogger.Error(
-						ctx,
-						"Handler returned non-nil error type *{{.Type}} but nil value",
-						zap.Error(err),
-					)
 					if v == nil {
+						h.Deps.Default.ContextLogger.Error(
+							ctx,
+							"Handler returned non-nil error type *{{.Type}} but nil value",
+							zap.Error(err),
+						)
 						return false, nil, resHeaders, errors.Errorf(
 							"%s.%s (%s) handler returned non-nil error type *{{.Type}} but nil value",
 							h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -2668,7 +2668,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8133, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8138, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -116,7 +116,7 @@ func (h *{{$handlerName}}) Handle(
 	{{if ne .RequestType "" -}}
 	var req {{unref .RequestType}}
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -152,7 +152,7 @@ func (h *{{$handlerName}}) Handle(
 
 	{{if eq (len .Exceptions) 0 -}}
 		if err != nil {
-			h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 			return false, nil, resHeaders, err
 		}
 		res.Success = {{.RefResponse "r"}}
@@ -162,7 +162,7 @@ func (h *{{$handlerName}}) Handle(
 			{{$method := .Name -}}
 			{{range .Exceptions -}}
 				case *{{.Type}}:
-					h.Deps.Default.ContextLogger.Warn(
+					h.Deps.Default.ContextLogger.Error(
 						ctx,
 						"Handler returned non-nil error type *{{.Type}} but nil value",
 						zap.Error(err),
@@ -176,7 +176,7 @@ func (h *{{$handlerName}}) Handle(
 					res.{{title .Name}} = v
 			{{end -}}
 				default:
-					h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+					h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 					return false, nil, resHeaders, errors.Wrapf(
 						err, "%s.%s (%s) handler returned error",
 						h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -162,12 +162,12 @@ func (h *{{$handlerName}}) Handle(
 			{{$method := .Name -}}
 			{{range .Exceptions -}}
 				case *{{.Type}}:
-					h.Deps.Default.ContextLogger.Error(
-						ctx,
-						"Handler returned non-nil error type *{{.Type}} but nil value",
-						zap.Error(err),
-					)
 					if v == nil {
+						h.Deps.Default.ContextLogger.Error(
+							ctx,
+							"Handler returned non-nil error type *{{.Type}} but nil value",
+							zap.Error(err),
+						)
 						return false, nil, resHeaders, errors.Errorf(
 							"%s.%s (%s) handler returned non-nil error type *{{.Type}} but nil value",
 							h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -133,12 +133,12 @@ func (h *SimpleServiceCallHandler) Handle(
 	if err != nil {
 		switch v := err.(type) {
 		case *endpointsTchannelBazBaz.AuthErr:
-			h.Deps.Default.ContextLogger.Error(
-				ctx,
-				"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
-				zap.Error(err),
-			)
 			if v == nil {
+				h.Deps.Default.ContextLogger.Error(
+					ctx,
+					"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
+					zap.Error(err),
+				)
 				return false, nil, resHeaders, errors.Errorf(
 					"%s.%s (%s) handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 					h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -107,7 +107,7 @@ func (h *SimpleServiceCallHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_Call_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -133,7 +133,7 @@ func (h *SimpleServiceCallHandler) Handle(
 	if err != nil {
 		switch v := err.(type) {
 		case *endpointsTchannelBazBaz.AuthErr:
-			h.Deps.Default.ContextLogger.Warn(
+			h.Deps.Default.ContextLogger.Error(
 				ctx,
 				"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 				zap.Error(err),
@@ -146,7 +146,7 @@ func (h *SimpleServiceCallHandler) Handle(
 			}
 			res.AuthErr = v
 		default:
-			h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 			return false, nil, resHeaders, errors.Wrapf(
 				err, "%s.%s (%s) handler returned error",
 				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -93,7 +93,7 @@ func (h *SimpleServiceEchoHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_Echo_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -117,7 +117,7 @@ func (h *SimpleServiceEchoHandler) Handle(
 	}
 
 	if err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 		return false, nil, resHeaders, err
 	}
 	res.Success = &r

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -93,7 +93,7 @@ func (h *EchoEchoHandler) Handle(
 
 	var req endpointsTchannelEchoEcho.Echo_Echo_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -117,7 +117,7 @@ func (h *EchoEchoHandler) Handle(
 	}
 
 	if err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 		return false, nil, resHeaders, err
 	}
 	res.Success = &r

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -126,12 +126,12 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 	if err != nil {
 		switch v := err.(type) {
 		case *endpointsTchannelBazBaz.AuthErr:
-			h.Deps.Default.ContextLogger.Error(
-				ctx,
-				"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
-				zap.Error(err),
-			)
 			if v == nil {
+				h.Deps.Default.ContextLogger.Error(
+					ctx,
+					"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
+					zap.Error(err),
+				)
 				return false, nil, resHeaders, errors.Errorf(
 					"%s.%s (%s) handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 					h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -100,7 +100,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_AnotherCall_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Warn(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -126,7 +126,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 	if err != nil {
 		switch v := err.(type) {
 		case *endpointsTchannelBazBaz.AuthErr:
-			h.Deps.Default.ContextLogger.Warn(
+			h.Deps.Default.ContextLogger.Error(
 				ctx,
 				"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 				zap.Error(err),
@@ -139,7 +139,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 			}
 			res.AuthErr = v
 		default:
-			h.Deps.Default.ContextLogger.Warn(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
 			return false, nil, resHeaders, errors.Wrapf(
 				err, "%s.%s (%s) handler returned error",
 				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call.go
@@ -75,10 +75,6 @@ func (w Workflow) Handle(
 		case *clientBaz.AuthErr:
 			return respHeaders, (*endpointBaz.AuthErr)(v)
 		default:
-			zanzibar.LogErrorWarnTimeoutContext(
-				ctx, w.contextLogger, err,
-				"baz.Call returned error",
-			)
 			return respHeaders, err
 		}
 	}

--- a/runtime/tchannel_logger.go
+++ b/runtime/tchannel_logger.go
@@ -126,27 +126,12 @@ func (l TChannelLogger) WithFields(fields ...tchannel.LogField) tchannel.Logger 
 // TODO: We want to improve the classification of errors, similar to:
 // https://github.com/uber/tchannel-node/blob/master/errors.js#L907-L930
 //
-// Deprecated: Use LogErrorWarnTimeoutContext instead.
+// Deprecated: use proper level to log instead
 func LogErrorWarnTimeout(logger *zap.Logger, err error, msg string) {
-	if err != nil {
-		if isTimeout(err) {
-			logger.Warn(msg, zap.Error(err))
-		} else {
-			logger.Error(msg, zap.Error(err))
-		}
-	}
-}
-
-// LogErrorWarnTimeoutContext logs warnings for timeout errors, otherwise logs errors
-// TODO: We want to improve the classification of errors, similar to:
-// https://github.com/uber/tchannel-node/blob/master/errors.js#L907-L930
-func LogErrorWarnTimeoutContext(ctx context.Context, logger ContextLogger, err error, msg string) {
-	if err != nil {
-		if isTimeout(err) {
-			logger.Warn(ctx, msg, zap.Error(err))
-		} else {
-			logger.Error(ctx, msg, zap.Error(err))
-		}
+	if isTimeout(err) {
+		logger.Warn(msg, zap.Error(err))
+	} else {
+		logger.Error(msg, zap.Error(err))
 	}
 }
 

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -163,10 +163,6 @@ func TestPingWithInvalidResponse(t *testing.T) {
 		KnownTChannelBackends: []string{"baz"},
 		TestBinary:            util.DefaultMainFile("example-gateway"),
 		ConfigFiles:           util.DefaultConfigFiles("example-gateway"),
-		LogWhitelist: map[string]bool{
-			"Could not create arg2reader for outbound response": true,
-			"Could not make outbound request":                   true,
-		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
 		return
@@ -206,17 +202,13 @@ func TestPingWithInvalidResponse(t *testing.T) {
 
 	assert.Equal(t, `{"error":"Unexpected server error"}`, string(bytes))
 
-	allLogs := gateway.AllLogs()
-
-	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
-	assert.Equal(t, 1, len(allLogs["Created new active connection."]))
-	assert.Equal(t, 1, len(allLogs["Could not create arg2reader for outbound response"]))
-	assert.Equal(t, 1, len(allLogs["Failed after non-retriable error."]))
-	assert.Equal(t, 1, len(allLogs["Could not make outbound request"]))
-	assert.Equal(t, 1, len(allLogs["TChannel client call returned error"]))
-	assert.Equal(t, 1, len(allLogs["Finished an incoming server HTTP request"]))
-	assert.Equal(t, 1, len(allLogs["Finished an outgoing client TChannel request"]))
-	assert.Equal(t, 1, len(allLogs["Could not make client request"]))
+	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
+	assert.Len(t, gateway.Logs("info", "Created new active connection."), 1)
+	assert.Len(t, gateway.Logs("info", "Failed after non-retriable error."), 1)
+	assert.Len(t, gateway.Logs("warn", "TChannel client call returned error"), 1)
+	assert.Len(t, gateway.Logs("info", "Finished an incoming server HTTP request"), 1)
+	assert.Len(t, gateway.Logs("warn", "Failed to send outgoing client TChannel request"), 1)
+	assert.Len(t, gateway.Logs("warn", "Could not make client request"), 1)
 
 	logLines := gateway.Logs("warn", "Could not make client request")
 	assert.Equal(t, 1, len(logLines))


### PR DESCRIPTION
This PR cleans up tchannel client/endpoint/server logs in the following way:
- remove redundent tchannel client/server runtime logs since errors are warpped and returned to callers where logging happens;
- generated endpoint handler log errors with `error` level, everywhere else errrors are logged with `warn` level;

There will be a another PR that takes cares of http client/endpoint/server logs.