### PR TITLE
Only set content-type header when body is not empty

### DIFF
--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -149,7 +149,10 @@ func (req *ClientHTTPRequest) WriteJSON(
 	for k := range headers {
 		httpReq.Header.Add(k, headers[k])
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
+
+	if body != nil {
+		httpReq.Header.Set("Content-Type", "application/json")
+	}
 
 	req.httpReq = httpReq
 	req.ctx = WithLogFields(req.ctx,


### PR DESCRIPTION
Fixes https://github.com/uber/zanzibar/issues/472.