### PR TITLE
Add ContextLogFieldsExtractor

### DIFF
--- a/examples/example-gateway/app.go
+++ b/examples/example-gateway/app.go
@@ -21,6 +21,8 @@
 package app
 
 import (
+	"go.uber.org/zap"
+
 	"context"
 	"github.com/uber/zanzibar/runtime"
 )
@@ -28,11 +30,20 @@ import (
 // AppOptions defines the custom application func
 var AppOptions = &zanzibar.Options{
 	GetContextScopeExtractors: getContextScopeTagExtractors,
+	GetContextFieldExtractors: getContextLogFieldExtractors,
 }
 
 func getContextScopeTagExtractors() []zanzibar.ContextScopeTagsExtractor {
 	extractors := []zanzibar.ContextScopeTagsExtractor{
 		getRequestTags,
+	}
+
+	return extractors
+}
+
+func getContextLogFieldExtractors() []zanzibar.ContextLogFieldsExtractor {
+	extractors := []zanzibar.ContextLogFieldsExtractor{
+		getRequestFields,
 	}
 
 	return extractors
@@ -46,4 +57,14 @@ func getRequestTags(ctx context.Context) map[string]string {
 	tags["deviceversion"] = headers["Deviceversion"]
 
 	return tags
+}
+
+func getRequestFields(ctx context.Context) []zap.Field {
+	var fields []zap.Field
+	headers := zanzibar.GetEndpointRequestHeadersFromCtx(ctx)
+	fields = append(fields, zap.String("regionname", headers["Regionname"]))
+	fields = append(fields, zap.String("device", headers["Device"]))
+	fields = append(fields, zap.String("deviceversion", headers["Deviceversion"]))
+
+	return fields
 }

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -235,7 +235,6 @@ func (c *ContextExtractors) ExtractLogFields(ctx context.Context) []zap.Field {
 	for _, fn := range c.contextLogFieldsExtractors {
 		logFields := fn(ctx)
 		fields = append(fields, logFields...)
-
 	}
 
 	return fields

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -64,6 +64,7 @@ type Options struct {
 	MetricsBackend            tally.CachedStatsReporter
 	LogWriter                 zapcore.WriteSyncer
 	GetContextScopeExtractors func() []ContextScopeTagsExtractor
+	GetContextFieldExtractors func() []ContextLogFieldsExtractor
 }
 
 // Gateway type
@@ -125,6 +126,7 @@ func CreateGateway(
 	var metricsBackend tally.CachedStatsReporter
 	var logWriter zapcore.WriteSyncer
 	var scopeExtractors []ContextScopeTagsExtractor
+	var fieldExtractors []ContextLogFieldsExtractor
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -141,6 +143,14 @@ func CreateGateway(
 
 		for _, scopeExtractor := range scopeExtractors {
 			contextExtractors.AddContextScopeTagsExtractor(scopeExtractor)
+		}
+	}
+
+	if opts.GetContextFieldExtractors != nil {
+		fieldExtractors = opts.GetContextFieldExtractors()
+
+		for _, fieldExtractor := range fieldExtractors {
+			contextExtractors.AddContextLogFieldsExtractor(fieldExtractor)
 		}
 	}
 

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -82,7 +82,7 @@ func NewServerHTTPRequest(
 		zap.String(logFieldEndpointID, endpoint.EndpointName),
 		zap.String(logFieldHandlerID, endpoint.HandlerName),
 	}
-	ctx = WithLogFields(ctx, logFields...)
+	logger := newLoggerWithFields(endpoint.logger, logFields)
 
 	// put request scope tags on context
 	scopeTags := map[string]string{
@@ -100,11 +100,14 @@ func NewServerHTTPRequest(
 		for k, v := range endpoint.contextExtractor.ExtractScopeTags(ctx) {
 			scopeTags[k] = v
 		}
+
+		logFields = append(logFields, endpoint.contextExtractor.ExtractLogFields(ctx)...)
 	}
 	ctx = WithScopeTags(ctx, scopeTags)
+	ctx = WithLogFields(ctx, logFields...)
 
 	httpRequest := r.WithContext(ctx)
-	logger := newLoggerWithFields(endpoint.logger, logFields)
+
 	scope := endpoint.scope.Tagged(scopeTags)
 
 	req := &ServerHTTPRequest{

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -213,6 +213,9 @@ func (s *TChannelRouter) handle(
 		c.scope = c.scope.Tagged(scopeTags)
 	}
 
+	logFields := s.extractor.ExtractLogFields(ctx)
+	ctx = WithLogFields(ctx, logFields...)
+
 	wireValue, err := c.readReqBody(ctx)
 	if err != nil {
 		return err

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -238,10 +238,13 @@ func TestCallMetrics(t *testing.T) {
 		"method":                     "POST",
 		"Request-Header-X-Client-Id": "bar",
 
-		"zone":       "unknown",
-		"service":    "example-gateway",
-		"endpointID": "bar",
-		"handlerID":  "normal",
+		"zone":          "unknown",
+		"service":       "example-gateway",
+		"endpointID":    "bar",
+		"handlerID":     "normal",
+		"regionname":    "san_francisco",
+		"device":        "ios",
+		"deviceversion": "carbon",
 	}
 	for actualKey, actualValue := range logMsg {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)


### PR DESCRIPTION
This commits
- Adds ContextLogFieldsExtractor at Context.go
- Use ContextLogFieldsExtractor to extract request headers for HTTP and TChannel request