### PR TITLE
Add more info to error messages

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -325,7 +325,7 @@ func (h *{{$handlerName}}) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))
@@ -463,7 +463,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 6994, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 7012, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2249,7 +2249,7 @@ type {{$clientName}} struct {
 			}
 		}
 		if err != nil {
-			logger.Warn("TChannel client call returned error", zap.Error(err))
+			logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		{{if eq .ResponseType "" -}}
 			return nil, err
 		{{else -}}
@@ -2262,7 +2262,7 @@ type {{$clientName}} struct {
 		{{else -}}
 			resp, err = {{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Helper.UnwrapResponse(&result)
 			if err != nil {
-				logger.Warn("Unable to unwrap client response", zap.Error(err))
+				logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 			}
 			return resp, respHeaders, err
 		{{end -}}
@@ -2282,7 +2282,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6287, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 6319, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2496,7 +2496,7 @@ func (h *{{$handlerName}}) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -2523,7 +2523,7 @@ func (h *{{$handlerName}}) Handle(
 	{{if ne .RequestType "" -}}
 	var req {{unref .RequestType}}
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -2559,7 +2559,7 @@ func (h *{{$handlerName}}) Handle(
 
 	{{if eq (len .Exceptions) 0 -}}
 		if err != nil {
-			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 			return false, nil, resHeaders, err
 		}
 		res.Success = {{.RefResponse "r"}}
@@ -2572,7 +2572,7 @@ func (h *{{$handlerName}}) Handle(
 					if v == nil {
 						h.Deps.Default.ContextLogger.Error(
 							ctx,
-							"Handler returned non-nil error type *{{.Type}} but nil value",
+							"Endpoint failure: handler returned non-nil error type *{{.Type}} but nil value",
 							zap.Error(err),
 						)
 						return false, nil, resHeaders, errors.Errorf(
@@ -2583,7 +2583,7 @@ func (h *{{$handlerName}}) Handle(
 					res.{{title .Name}} = v
 			{{end -}}
 				default:
-					h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+					h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 					return false, nil, resHeaders, errors.Wrapf(
 						err, "%s.%s (%s) handler returned error",
 						h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -2679,7 +2679,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8159, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8249, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2871,7 +2871,7 @@ func (w {{$workflowStruct}}) Handle(
 				{{end}}
 			{{end}}
 			default:
-				w.Logger.Warn("Could not make client request",
+				w.Logger.Warn("Client failure: could not make client request",
 					zap.Error(errValue),
 					zap.String("client", "{{$clientName}}"),
 				)
@@ -2951,7 +2951,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 7462, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 7478, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -109,7 +109,7 @@ func (h *{{$handlerName}}) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -169,7 +169,7 @@ type {{$clientName}} struct {
 			}
 		}
 		if err != nil {
-			logger.Warn("TChannel client call returned error", zap.Error(err))
+			logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		{{if eq .ResponseType "" -}}
 			return nil, err
 		{{else -}}
@@ -182,7 +182,7 @@ type {{$clientName}} struct {
 		{{else -}}
 			resp, err = {{.GenCodePkgName}}.{{title $svc.Name}}_{{title .Name}}_Helper.UnwrapResponse(&result)
 			if err != nil {
-				logger.Warn("Unable to unwrap client response", zap.Error(err))
+				logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 			}
 			return resp, respHeaders, err
 		{{end -}}

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -88,7 +88,7 @@ func (h *{{$handlerName}}) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -115,7 +115,7 @@ func (h *{{$handlerName}}) Handle(
 	{{if ne .RequestType "" -}}
 	var req {{unref .RequestType}}
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -151,7 +151,7 @@ func (h *{{$handlerName}}) Handle(
 
 	{{if eq (len .Exceptions) 0 -}}
 		if err != nil {
-			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 			return false, nil, resHeaders, err
 		}
 		res.Success = {{.RefResponse "r"}}
@@ -164,7 +164,7 @@ func (h *{{$handlerName}}) Handle(
 					if v == nil {
 						h.Deps.Default.ContextLogger.Error(
 							ctx,
-							"Handler returned non-nil error type *{{.Type}} but nil value",
+							"Endpoint failure: handler returned non-nil error type *{{.Type}} but nil value",
 							zap.Error(err),
 						)
 						return false, nil, resHeaders, errors.Errorf(
@@ -175,7 +175,7 @@ func (h *{{$handlerName}}) Handle(
 					res.{{title .Name}} = v
 			{{end -}}
 				default:
-					h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+					h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 					return false, nil, resHeaders, errors.Wrapf(
 						err, "%s.%s (%s) handler returned error",
 						h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -185,7 +185,7 @@ func (w {{$workflowStruct}}) Handle(
 				{{end}}
 			{{end}}
 			default:
-				w.Logger.Warn("Could not make client request",
+				w.Logger.Warn("Client failure: could not make client request",
 					zap.Error(errValue),
 					zap.String("client", "{{$clientName}}"),
 				)

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -295,13 +295,13 @@ func (c *bazClient) EchoBinary(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoBinary_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -332,13 +332,13 @@ func (c *bazClient) EchoBool(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoBool_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -369,13 +369,13 @@ func (c *bazClient) EchoDouble(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoDouble_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -406,13 +406,13 @@ func (c *bazClient) EchoEnum(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoEnum_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -443,13 +443,13 @@ func (c *bazClient) EchoI16(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI16_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -480,13 +480,13 @@ func (c *bazClient) EchoI32(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI32_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -517,13 +517,13 @@ func (c *bazClient) EchoI64(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI64_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -554,13 +554,13 @@ func (c *bazClient) EchoI8(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI8_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -591,13 +591,13 @@ func (c *bazClient) EchoString(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoString_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -628,13 +628,13 @@ func (c *bazClient) EchoStringList(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringList_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -665,13 +665,13 @@ func (c *bazClient) EchoStringMap(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringMap_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -702,13 +702,13 @@ func (c *bazClient) EchoStringSet(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringSet_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -739,13 +739,13 @@ func (c *bazClient) EchoStructList(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStructList_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -776,13 +776,13 @@ func (c *bazClient) EchoStructSet(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStructSet_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -813,13 +813,13 @@ func (c *bazClient) EchoTypedef(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoTypedef_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -851,7 +851,7 @@ func (c *bazClient) Call(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return nil, err
 	}
 
@@ -888,13 +888,13 @@ func (c *bazClient) Compare(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Compare_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -927,13 +927,13 @@ func (c *bazClient) GetProfile(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_GetProfile_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -968,13 +968,13 @@ func (c *bazClient) HeaderSchema(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_HeaderSchema_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1005,13 +1005,13 @@ func (c *bazClient) Ping(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Ping_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1045,7 +1045,7 @@ func (c *bazClient) DeliberateDiffNoop(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return nil, err
 	}
 
@@ -1077,7 +1077,7 @@ func (c *bazClient) TestUUID(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return nil, err
 	}
 
@@ -1114,13 +1114,13 @@ func (c *bazClient) Trans(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Trans_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1155,13 +1155,13 @@ func (c *bazClient) TransHeaders(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeaders_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1194,13 +1194,13 @@ func (c *bazClient) TransHeadersNoReq(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeadersNoReq_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1235,13 +1235,13 @@ func (c *bazClient) TransHeadersType(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeadersType_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }
@@ -1271,7 +1271,7 @@ func (c *bazClient) URLTest(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return nil, err
 	}
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -140,13 +140,13 @@ func (c *corgeClient) EchoString(
 		}
 	}
 	if err != nil {
-		logger.Warn("TChannel client call returned error", zap.Error(err))
+		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		return resp, nil, err
 	}
 
 	resp, err = clientsCorgeCorge.Corge_EchoString_Helper.UnwrapResponse(&result)
 	if err != nil {
-		logger.Warn("Unable to unwrap client response", zap.Error(err))
+		logger.Warn("Client failure: unable to unwrap client response", zap.Error(err))
 	}
 	return resp, respHeaders, err
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -81,7 +81,7 @@ func (h *BarArgNotStructHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -83,7 +83,7 @@ func (h *BarArgWithHeadersHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -83,7 +83,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -83,7 +83,7 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -82,7 +82,7 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -83,7 +83,7 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -83,7 +83,7 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -81,7 +81,7 @@ func (h *BarHelloWorldHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -80,7 +80,7 @@ func (h *BarMissingArgHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -80,7 +80,7 @@ func (h *BarNoRequestHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -91,7 +91,7 @@ func (h *BarNormalHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -83,7 +83,7 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -94,7 +94,7 @@ func (w barArgNotStructWorkflow) Handle(
 			return nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -91,7 +91,7 @@ func (w barArgWithHeadersWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -87,7 +87,7 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -87,7 +87,7 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -87,7 +87,7 @@ func (w barArgWithParamsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -87,7 +87,7 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -95,7 +95,7 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -91,7 +91,7 @@ func (w barHelloWorldWorkflow) Handle(
 			return "", nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -91,7 +91,7 @@ func (w barMissingArgWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -91,7 +91,7 @@ func (w barNoRequestWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -94,7 +94,7 @@ func (w barNormalWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -112,7 +112,7 @@ func (w barTooManyArgsWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Bar"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceCallHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceCompareHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceGetProfileHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceHeaderSchemaHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -79,7 +79,7 @@ func (h *SimpleServicePingHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -80,7 +80,7 @@ func (h *SimpleServiceSillyNoopHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceTransHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceTransHeadersHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
@@ -80,7 +80,7 @@ func (h *SimpleServiceTransHeadersNoReqHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
@@ -82,7 +82,7 @@ func (h *SimpleServiceTransHeadersTypeHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -102,7 +102,7 @@ func (w simpleServiceCallWorkflow) Handle(
 			return nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -102,7 +102,7 @@ func (w simpleServiceCompareWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -94,7 +94,7 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -117,7 +117,7 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -84,7 +84,7 @@ func (w simpleServicePingWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -97,7 +97,7 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 			return nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -102,7 +102,7 @@ func (w simpleServiceTransWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -111,7 +111,7 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -106,7 +106,7 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -103,7 +103,7 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 			return nil, nil, serverErr
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Baz"),
 			)

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -82,7 +82,7 @@ func (h *ContactsSaveContactsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -81,7 +81,7 @@ func (h *GoogleNowAddCredentialsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -79,7 +79,7 @@ func (h *GoogleNowCheckCredentialsHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -95,7 +95,7 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "GoogleNow"),
 			)

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -87,7 +87,7 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "GoogleNow"),
 			)

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -80,7 +80,7 @@ func (h *ServiceAFrontHelloHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -80,7 +80,7 @@ func (h *ServiceBFrontHelloHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -81,7 +81,7 @@ func (w serviceAFrontHelloWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Multi"),
 			)

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -81,7 +81,7 @@ func (w serviceBFrontHelloWorkflow) Handle(
 		switch errValue := err.(type) {
 
 		default:
-			w.Logger.Warn("Could not make client request",
+			w.Logger.Warn("Client failure: could not make client request",
 				zap.Error(errValue),
 				zap.String("client", "Multi"),
 			)

--- a/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
@@ -80,7 +80,7 @@ func (h *ServiceCFrontHelloHandler) HandleRequest(
 			e := errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Dependencies.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointName))

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -85,7 +85,7 @@ func (h *SimpleServiceCallHandler) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -109,7 +109,7 @@ func (h *SimpleServiceCallHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_Call_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -138,7 +138,7 @@ func (h *SimpleServiceCallHandler) Handle(
 			if v == nil {
 				h.Deps.Default.ContextLogger.Error(
 					ctx,
-					"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
+					"Endpoint failure: handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 					zap.Error(err),
 				)
 				return false, nil, resHeaders, errors.Errorf(
@@ -148,7 +148,7 @@ func (h *SimpleServiceCallHandler) Handle(
 			}
 			res.AuthErr = v
 		default:
-			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 			return false, nil, resHeaders, errors.Wrapf(
 				err, "%s.%s (%s) handler returned error",
 				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -76,7 +76,7 @@ func (h *SimpleServiceEchoHandler) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -94,7 +94,7 @@ func (h *SimpleServiceEchoHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_Echo_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -118,7 +118,7 @@ func (h *SimpleServiceEchoHandler) Handle(
 	}
 
 	if err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 		return false, nil, resHeaders, err
 	}
 	res.Success = &r

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -76,7 +76,7 @@ func (h *EchoEchoHandler) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -94,7 +94,7 @@ func (h *EchoEchoHandler) Handle(
 
 	var req endpointsTchannelEchoEcho.Echo_Echo_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -118,7 +118,7 @@ func (h *EchoEchoHandler) Handle(
 	}
 
 	if err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 		return false, nil, resHeaders, err
 	}
 	res.Success = &r

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -77,7 +77,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 			e = errors.Errorf("enpoint panic: %v, stacktrace: %v", r, stacktrace)
 			h.Deps.Default.ContextLogger.Error(
 				ctx,
-				"endpoint panic",
+				"Endpoint failure: endpoint panic",
 				zap.Error(e),
 				zap.String("stacktrace", stacktrace),
 				zap.String("endpoint", h.endpoint.EndpointID))
@@ -101,7 +101,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 
 	var req endpointsTchannelBazBaz.SimpleService_AnotherCall_Args
 	if err := req.FromWire(*wireValue); err != nil {
-		h.Deps.Default.ContextLogger.Error(ctx, "Error converting request from wire", zap.Error(err))
+		h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: error converting request from wire", zap.Error(err))
 		return false, nil, nil, errors.Wrapf(
 			err, "Error converting %s.%s (%s) request from wire",
 			h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,
@@ -130,7 +130,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 			if v == nil {
 				h.Deps.Default.ContextLogger.Error(
 					ctx,
-					"Handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
+					"Endpoint failure: handler returned non-nil error type *endpointsTchannelBazBaz.AuthErr but nil value",
 					zap.Error(err),
 				)
 				return false, nil, resHeaders, errors.Errorf(
@@ -140,7 +140,7 @@ func (h *SimpleServiceAnotherCallHandler) Handle(
 			}
 			res.AuthErr = v
 		default:
-			h.Deps.Default.ContextLogger.Error(ctx, "Handler returned error", zap.Error(err))
+			h.Deps.Default.ContextLogger.Error(ctx, "Endpoint failure: handler returned error", zap.Error(err))
 			return false, nil, resHeaders, errors.Wrapf(
 				err, "%s.%s (%s) handler returned error",
 				h.endpoint.EndpointID, h.endpoint.HandlerID, h.endpoint.Method,

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -205,12 +205,12 @@ func TestPingWithInvalidResponse(t *testing.T) {
 	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 1)
 	assert.Len(t, gateway.Logs("info", "Failed after non-retriable error."), 1)
-	assert.Len(t, gateway.Logs("warn", "TChannel client call returned error"), 1)
+	assert.Len(t, gateway.Logs("warn", "Client failure: TChannel client call returned error"), 1)
 	assert.Len(t, gateway.Logs("info", "Finished an incoming server HTTP request"), 1)
 	assert.Len(t, gateway.Logs("warn", "Failed to send outgoing client TChannel request"), 1)
-	assert.Len(t, gateway.Logs("warn", "Could not make client request"), 1)
+	assert.Len(t, gateway.Logs("warn", "Client failure: could not make client request"), 1)
 
-	logLines := gateway.Logs("warn", "Could not make client request")
+	logLines := gateway.Logs("warn", "Client failure: could not make client request")
 	assert.Equal(t, 1, len(logLines))
 
 	logObj := logLines[0]

--- a/test/endpoints/googlenow/googlenow_test.go
+++ b/test/endpoints/googlenow/googlenow_test.go
@@ -363,7 +363,7 @@ func TestAddCredentialsBackendDown(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	logLines := gateway.Logs("warn", "Could not make client request")
+	logLines := gateway.Logs("warn", "Client failure: could not make client request")
 
 	assert.NotNil(t, logLines)
 	assert.Equal(t, 1, len(logLines))
@@ -593,7 +593,7 @@ func TestCheckCredentialsBackendDown(t *testing.T) {
 
 	time.Sleep(10 * time.Millisecond)
 
-	logLines := gateway.Logs("warn", "Could not make client request")
+	logLines := gateway.Logs("warn", "Client failure: could not make client request")
 
 	assert.NotNil(t, logLines)
 	assert.Equal(t, 1, len(logLines))

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -202,7 +202,7 @@ func TestCallTChannelTimeout(t *testing.T) {
 			"SimpleService::Call": "Call",
 		},
 		LogWhitelist: map[string]bool{
-			"Handler returned error": true,
+			"Endpoint failure: handler returned error": true,
 		},
 	})
 	if !assert.NoError(t, err, "got bootstrap err") {
@@ -259,10 +259,10 @@ func TestCallTChannelTimeout(t *testing.T) {
 	assert.Len(t, gateway.Logs("warn", "Failed to send outgoing client TChannel request"), 1)
 
 	// logged from generated client
-	assert.Len(t, gateway.Logs("warn", "TChannel client call returned error"), 1)
+	assert.Len(t, gateway.Logs("warn", "Client failure: TChannel client call returned error"), 1)
 
 	// logged from generated endpoint
-	assert.Len(t, gateway.Logs("error", "Handler returned error"), 1)
+	assert.Len(t, gateway.Logs("error", "Endpoint failure: handler returned error"), 1)
 
 	// logged from tchannel server runtime
 	assert.Len(t, gateway.Logs("warn", "Failed to serve incoming TChannel request"), 1)


### PR DESCRIPTION
This commits add prefix

- "Endpoint failure:"

- "Client failure:"

to existing error and warn messages at contextLogger which would help[ to indicate where(endpoint or client) this error happens