### PR TITLE
Change NewRouterEndpoint to take DefaultDependencies 

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -283,7 +283,7 @@ func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"{{$endpointId}}", "{{$handleId}}",
 		{{ if len $middlewares | ne 0 -}}
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{
@@ -463,7 +463,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 7012, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 6964, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -67,7 +67,7 @@ func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"{{$endpointId}}", "{{$handleId}}",
 		{{ if len $middlewares | ne 0 -}}
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -53,7 +53,7 @@ func NewBarArgNotStructHandler(deps *module.Dependencies) *BarArgNotStructHandle
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argNotStruct",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -55,7 +55,7 @@ func NewBarArgWithHeadersHandler(deps *module.Dependencies) *BarArgWithHeadersHa
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithHeaders",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -55,7 +55,7 @@ func NewBarArgWithManyQueryParamsHandler(deps *module.Dependencies) *BarArgWithM
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithManyQueryParams",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -55,7 +55,7 @@ func NewBarArgWithNestedQueryParamsHandler(deps *module.Dependencies) *BarArgWit
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithNestedQueryParams",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -54,7 +54,7 @@ func NewBarArgWithParamsHandler(deps *module.Dependencies) *BarArgWithParamsHand
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithParams",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -55,7 +55,7 @@ func NewBarArgWithQueryHeaderHandler(deps *module.Dependencies) *BarArgWithQuery
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithQueryHeader",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -55,7 +55,7 @@ func NewBarArgWithQueryParamsHandler(deps *module.Dependencies) *BarArgWithQuery
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "argWithQueryParams",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -53,7 +53,7 @@ func NewBarHelloWorldHandler(deps *module.Dependencies) *BarHelloWorldHandler {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "helloWorld",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -52,7 +52,7 @@ func NewBarMissingArgHandler(deps *module.Dependencies) *BarMissingArgHandler {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "missingArg",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -52,7 +52,7 @@ func NewBarNoRequestHandler(deps *module.Dependencies) *BarNoRequestHandler {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "noRequest",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -56,7 +56,7 @@ func NewBarNormalHandler(deps *module.Dependencies) *BarNormalHandler {
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "normal",
 		zanzibar.NewStack([]zanzibar.MiddlewareHandle{
 			deps.Middleware.Example.NewMiddlewareHandle(

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -55,7 +55,7 @@ func NewBarTooManyArgsHandler(deps *module.Dependencies) *BarTooManyArgsHandler 
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"bar", "tooManyArgs",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -54,7 +54,7 @@ func NewSimpleServiceCallHandler(deps *module.Dependencies) *SimpleServiceCallHa
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "call",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -54,7 +54,7 @@ func NewSimpleServiceCompareHandler(deps *module.Dependencies) *SimpleServiceCom
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "compare",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
@@ -54,7 +54,7 @@ func NewSimpleServiceGetProfileHandler(deps *module.Dependencies) *SimpleService
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "getProfile",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
@@ -54,7 +54,7 @@ func NewSimpleServiceHeaderSchemaHandler(deps *module.Dependencies) *SimpleServi
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "headerSchema",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -51,7 +51,7 @@ func NewSimpleServicePingHandler(deps *module.Dependencies) *SimpleServicePingHa
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "ping",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -52,7 +52,7 @@ func NewSimpleServiceSillyNoopHandler(deps *module.Dependencies) *SimpleServiceS
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "sillyNoop",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -54,7 +54,7 @@ func NewSimpleServiceTransHandler(deps *module.Dependencies) *SimpleServiceTrans
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "trans",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -54,7 +54,7 @@ func NewSimpleServiceTransHeadersHandler(deps *module.Dependencies) *SimpleServi
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "transHeaders",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
@@ -52,7 +52,7 @@ func NewSimpleServiceTransHeadersNoReqHandler(deps *module.Dependencies) *Simple
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "transHeadersNoReq",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
@@ -54,7 +54,7 @@ func NewSimpleServiceTransHeadersTypeHandler(deps *module.Dependencies) *SimpleS
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"baz", "transHeadersType",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -54,7 +54,7 @@ func NewContactsSaveContactsHandler(deps *module.Dependencies) *ContactsSaveCont
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"contacts", "saveContacts",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -53,7 +53,7 @@ func NewGoogleNowAddCredentialsHandler(deps *module.Dependencies) *GoogleNowAddC
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"googlenow", "addCredentials",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -51,7 +51,7 @@ func NewGoogleNowCheckCredentialsHandler(deps *module.Dependencies) *GoogleNowCh
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"googlenow", "checkCredentials",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -52,7 +52,7 @@ func NewServiceAFrontHelloHandler(deps *module.Dependencies) *ServiceAFrontHello
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"multi", "helloA",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -52,7 +52,7 @@ func NewServiceBFrontHelloHandler(deps *module.Dependencies) *ServiceBFrontHello
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"multi", "helloB",
 		handler.HandleRequest,
 	)

--- a/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
@@ -52,7 +52,7 @@ func NewServiceCFrontHelloHandler(deps *module.Dependencies) *ServiceCFrontHello
 		Dependencies: deps,
 	}
 	handler.endpoint = zanzibar.NewRouterEndpoint(
-		deps.Default.ContextExtractor, deps.Default.Scope, deps.Default.Logger, deps.Default.Tracer,
+		deps.Default.ContextExtractor, deps.Default,
 		"panic", "panic",
 		handler.HandleRequest,
 	)

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -273,8 +273,15 @@ func (gateway *Gateway) registerPredefined() {
 	gateway.HTTPRouter.Handle("GET", "/debug/loglevel", gateway.atomLevel)
 	gateway.HTTPRouter.Handle("PUT", "/debug/loglevel", gateway.atomLevel)
 
+	deps := &DefaultDependencies{
+		Scope:         gateway.RootScope,
+		ContextLogger: gateway.ContextLogger,
+		Logger:        gateway.Logger,
+		Tracer:        gateway.Tracer,
+	}
+
 	tracer := NewRouterEndpoint(
-		gateway.ContextExtractor, gateway.RootScope, gateway.Logger, gateway.Tracer,
+		gateway.ContextExtractor, deps,
 		"health", "health",
 		gateway.handleHealthRequest,
 	)

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -68,13 +68,18 @@ func TestHandlers(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
+
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo",
 		http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			middlewareStack.Handle,
 		).HandleRequest),
@@ -156,14 +161,18 @@ func TestMiddlewareRequestAbort(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo",
 		http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			middlewareStack.Handle,
 		).HandleRequest),
@@ -214,13 +223,18 @@ func TestMiddlewareResponseAbort(t *testing.T) {
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
 
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
+
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo",
 		http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			middlewareStack.Handle,
 		).HandleRequest),
@@ -275,14 +289,18 @@ func TestMiddlewareSharedStates(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo",
 		http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			middlewareStack.Handle,
 		).HandleRequest),

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -60,11 +60,15 @@ func TestInvalidReadAndUnmarshalBody(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	endpoint := zanzibar.NewRouterEndpoint(
 		bgateway.ActualGateway.ContextExtractor,
-		bgateway.ActualGateway.RootScope,
-		bgateway.ActualGateway.Logger,
-		bgateway.ActualGateway.Tracer,
+		deps,
 		"foo", "foo",
 		func(
 			ctx context.Context,
@@ -122,12 +126,16 @@ func TestDoubleParseQueryValues(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -184,12 +192,16 @@ func TestFailingGetQueryBool(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -243,12 +255,16 @@ func TestFailingGetQueryInt8(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -302,12 +318,16 @@ func TestFailingHasQueryValue(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -361,12 +381,16 @@ func TestFailingGetQueryInt16(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -420,12 +444,16 @@ func TestFailingGetQueryInt32(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -479,12 +507,16 @@ func TestFailingGetQueryInt64(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -538,12 +570,16 @@ func TestFailingGetQueryFloat64(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -597,12 +633,16 @@ func TestFailingHasQueryPrefix(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -649,12 +689,16 @@ func TestGetQueryBoolList(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -683,12 +727,16 @@ func TestFailingGetQueryBoolList(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -742,12 +790,16 @@ func TestGetQueryInt8List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -776,12 +828,16 @@ func TestFailingGetQueryInt8List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -835,12 +891,16 @@ func TestGetQueryInt16List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -869,12 +929,16 @@ func TestFailingGetQueryInt16List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -928,12 +992,16 @@ func TestGetQueryInt32List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -962,12 +1030,16 @@ func TestFailingGetQueryInt32List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1021,12 +1093,16 @@ func TestGetQueryInt64List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1055,12 +1131,16 @@ func TestFailingGetQueryInt64List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1114,12 +1194,16 @@ func TestGetQueryFloat64List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1148,12 +1232,16 @@ func TestFailingGetQueryFloat64List(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1207,12 +1295,16 @@ func TestFailingGetQueryValues(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1254,12 +1346,16 @@ func TestGetQueryValues(t *testing.T) {
 	defer ms.Stop()
 
 	g := ms.Server()
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         g.RootScope,
+		Logger:        g.Logger,
+		ContextLogger: g.ContextLogger,
+		Tracer:        g.Tracer,
+	}
 	err := g.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			g.ContextExtractor,
-			g.RootScope,
-			g.Logger,
-			g.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1317,12 +1413,16 @@ func TestPeekBody(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"POST", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1370,12 +1470,16 @@ func TestSpanCreated(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"POST", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -1410,12 +1514,16 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -48,12 +48,16 @@ func TestInvalidStatusCode(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -104,12 +108,16 @@ func TestCallingWriteJSONWithNil(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -165,12 +173,16 @@ func TestCallWriteJSONWithBadJSON(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -235,12 +247,17 @@ func TestResponsePeekBody(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
+
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -302,12 +319,16 @@ func TestResponseSetHeaders(t *testing.T) {
 	headers.Set("foo", "bar")
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -351,12 +372,16 @@ func TestResponsePeekBodyError(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,
@@ -409,12 +434,16 @@ func TestPendingResponseBody(t *testing.T) {
 	defer gateway.Close()
 
 	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
 	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
-			bgateway.ActualGateway.RootScope,
-			bgateway.ActualGateway.Logger,
-			bgateway.ActualGateway.Tracer,
+			deps,
 			"foo", "foo",
 			func(
 				ctx context.Context,


### PR DESCRIPTION
Change NewRouterEndpoint to take DefaultDependencies to reduce number of arguments to NewRouterEndpoint and pass in ContextLogger. 

`deps.Logger` is deprecated, but we require user to initialize `NewRouterEndpoint`, so we need to provide a constructor that allows them to pass `ContextLogger`. 