### PR TITLE
Add tally.TestScope to workflow mock

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2976,6 +2976,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
@@ -3007,6 +3008,7 @@ func New{{$workflowInterface}}Mock(t *testing.T) (workflow.{{$workflowInterface}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies {
 		Logger: zap.NewNop(),
+		Scope: tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}
@@ -3074,7 +3076,7 @@ func workflow_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow_mock.tmpl", size: 4638, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow_mock.tmpl", size: 4724, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/workflow_mock.tmpl
+++ b/codegen/templates/workflow_mock.tmpl
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
@@ -45,6 +46,7 @@ func New{{$workflowInterface}}Mock(t *testing.T) (workflow.{{$workflowInterface}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies {
 		Logger: zap.NewNop(),
+		Scope: tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/contacts/mock-workflow/contacts_savecontacts_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/contacts/mock-workflow/contacts_savecontacts_workflow_mock.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -43,6 +44,7 @@ func NewContactsSaveContactsWorkflowMock(t *testing.T) (workflow.ContactsSaveCon
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/panic/mock-workflow/servicecfront_hello_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/panic/mock-workflow/servicecfront_hello_workflow_mock.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -42,6 +43,7 @@ func NewServiceCFrontHelloWorkflowMock(t *testing.T) (workflow.ServiceCFrontHell
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_call_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_call_workflow_mock.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -46,6 +47,7 @@ func NewSimpleServiceCallWorkflowMock(t *testing.T) (workflow.SimpleServiceCallW
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_echo_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_echo_workflow_mock.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -46,6 +47,7 @@ func NewSimpleServiceEchoWorkflowMock(t *testing.T) (workflow.SimpleServiceEchoW
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/tchannel/echo/mock-workflow/echo_echo_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/mock-workflow/echo_echo_workflow_mock.go
@@ -26,6 +26,7 @@ package mockechoworkflow
 import (
 	"testing"
 
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -40,6 +41,7 @@ func NewEchoEchoWorkflowMock(t *testing.T) (workflow.EchoEchoWorkflow, *MockNode
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}

--- a/examples/example-gateway/build/endpoints/tchannel/panic/mock-workflow/simpleservice_anothercall_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/mock-workflow/simpleservice_anothercall_workflow_mock.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/uber-go/tally"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 
@@ -42,6 +43,7 @@ func NewSimpleServiceAnotherCallWorkflowMock(t *testing.T) (workflow.SimpleServi
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
 		Logger: zap.NewNop(),
+		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
 	contextExtractors := &zanzibar.ContextExtractors{}


### PR DESCRIPTION
Workflow level tests that utilize the workflow mock for testing segfault whenever they try to increment a metric using the scope. We fix the scope initialization here to prevent that from happening.