### PR TITLE
Bump tchannel and unpin broken thrift

### DIFF
--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argnotstruct.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithheaders.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/ptr"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/ptr"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/ptr"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/ptr"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/ptr"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_helloworld.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_missingarg.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_norequest.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_call.go
@@ -30,7 +30,7 @@ import (
 	"runtime/debug"
 	"strconv"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_ping.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_sillynoop.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheadersnoreq.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -30,7 +30,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_addcredentials.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/googlenow_googlenow_method_checkcredentials.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_serviceafront_method_hello.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/multi_servicebfront_method_hello.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/panic/panic_servicecfront_method_hello.go
@@ -29,7 +29,7 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,12 @@
-hash: c9e408639094e9d8cbe848e1b5be736bf4251251e35a63d8438631b872cbf766
-updated: 2018-12-14T15:12:14.306489-08:00
+hash: d139d0b3a740db69a8f05f3bd0c21050741bf5881cba15c4fc6f723cee9c3946
+updated: 2019-02-06T13:52:33.978534-08:00
 imports:
 - name: github.com/afex/hystrix-go
   version: fa1af6a1f4f56e0e50d427fe901cd604d8c6fb8a
+  subpackages:
+  - hystrix
+  - hystrix/metric_collector
+  - hystrix/rolling
 - name: github.com/anmitsu/go-shlex
   version: 648efa622239a2f6ff949fed78ee37b48d499ba4
 - name: github.com/apache/thrift
@@ -35,7 +39,7 @@ imports:
 - name: github.com/kardianos/osext
   version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/kisielk/errcheck
-  version: 1787c4bee836470bf45018cfbc783650db3c6501
+  version: e14f8d59a22d460d56c5ee92507cd94c78fbf274
 - name: github.com/kisielk/gotool
   version: 80517062f582ea3340cd4baf70e86d539ae7d84d
 - name: github.com/mailru/easyjson
@@ -59,9 +63,9 @@ imports:
 - name: github.com/pborman/uuid
   version: adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1
 - name: github.com/pkg/errors
-  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+  version: ba968bfe8b2f7e042a574c888954fccecfa385b4
 - name: github.com/pmezard/go-difflib
-  version: 792786c7400a136282c1664665ae0a8db921c6c2
+  version: 5d4384ee4fb2527b0a1256a821ebfc92f91efefc
   subpackages:
   - difflib
 - name: github.com/sergi/go-diff
@@ -69,13 +73,15 @@ imports:
   subpackages:
   - diffmatchpatch
 - name: github.com/stretchr/testify
-  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
+  version: ffdc059bfe9ce6a4e144ba849dbedead332c6053
   subpackages:
   - assert
   - require
   - suite
 - name: github.com/uber-go/atomic
-  version: 8dc6146f7569370a472715e178d8ae31172ee6da
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
+  subpackages:
+  - utils
 - name: github.com/uber-go/tally
   version: ff17f3c43c065c3c2991f571e740eee43ea3a14a
   subpackages:
@@ -109,12 +115,13 @@ imports:
   - metrics
   - metrics/tally
 - name: github.com/uber/tchannel-go
-  version: 0b7f160817553b0bacb5b108dd84a5022dbdd1c4
+  version: 162ecb0dc97845a0c42aae3899651dba111085e5
   subpackages:
   - internal/argreader
   - relay
   - testutils/testreader
   - tnet
+  - tos
   - trand
   - typed
 - name: go.uber.org/atomic
@@ -122,11 +129,10 @@ imports:
 - name: go.uber.org/automaxprocs
   version: 946a8391268aea0a60a86403988ff3ab4b604a83
   subpackages:
-  - internal/cgroups
   - internal/runtime
   - maxprocs
 - name: go.uber.org/dig
-  version: 12c8adaa5e6a24ad02198588082d95582ee16e5b
+  version: 7ff117f761a3f1b3eb521945c17a1091438eb6de
   subpackages:
   - internal/digreflect
   - internal/dot
@@ -173,11 +179,16 @@ imports:
   - zapcore
   - zaptest/observer
 - name: golang.org/x/net
-  version: 891ebc4b82d6e74f468c533b06f983c7be918a96
+  version: d26f9f9a57f3fab6a695bec0d84433c2c50f8bbf
   subpackages:
+  - bpf
   - context
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
 - name: golang.org/x/tools
-  version: 3c39ce7b61056afe4473b651789da5f89d4aeb20
+  version: 40960b6deb8ecdb8bcde6a8f44722731939b8ddc
   subpackages:
   - cmd/goimports
 - name: gopkg.in/validator.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,10 +14,6 @@ import:
   version: ^0.8.0
 - package: go.uber.org/atomic
   version: ^1.3.0
-- package: github.com/apache/thrift
-  version: ^0.10.0
-  subpackages:
-  - lib/go/thrift
 - package: github.com/uber-go/tally
   version: ^3
 # update to master since the last semver release is 2 years old
@@ -28,7 +24,7 @@ import:
 - package: go.uber.org/thriftrw
   version: v1.14.0
 - package: github.com/uber/tchannel-go
-  version: 1.5.0
+  version: ^1.6.0
 - package: github.com/opentracing/opentracing-go
   version: ^1.0.0
 - package: github.com/uber/jaeger-client-go

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,7 +24,7 @@ import:
 - package: go.uber.org/thriftrw
   version: v1.14.0
 - package: github.com/uber/tchannel-go
-  version: ^1.6.0
+  version: ^1.5.0
 - package: github.com/opentracing/opentracing-go
   version: ^1.0.0
 - package: github.com/uber/jaeger-client-go

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -192,7 +192,7 @@ func TestBarClientWithoutHeaders(t *testing.T) {
 
 	logs := gateway.AllLogs()
 
-	assert.Equal(t, 1, len(logs))
+	assert.Equal(t, 3, len(logs))
 
 	lines := logs["Got outbound request without mandatory header"]
 	assert.Equal(t, 1, len(lines))

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -192,8 +192,6 @@ func TestBarClientWithoutHeaders(t *testing.T) {
 
 	logs := gateway.AllLogs()
 
-	assert.Equal(t, 3, len(logs))
-
 	lines := logs["Got outbound request without mandatory header"]
 	assert.Equal(t, 1, len(lines))
 

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -171,7 +171,7 @@ func TestDoubleParseQueryValues(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -234,7 +234,7 @@ func TestFailingGetQueryBool(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -297,7 +297,7 @@ func TestFailingGetQueryInt8(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -360,7 +360,7 @@ func TestFailingHasQueryValue(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -423,7 +423,7 @@ func TestFailingGetQueryInt16(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -486,7 +486,7 @@ func TestFailingGetQueryInt32(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -549,7 +549,7 @@ func TestFailingGetQueryInt64(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -612,7 +612,7 @@ func TestFailingGetQueryFloat64(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -675,7 +675,7 @@ func TestFailingHasQueryPrefix(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 2, len(logs))
+	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -171,7 +171,6 @@ func TestDoubleParseQueryValues(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -234,7 +233,6 @@ func TestFailingGetQueryBool(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -297,7 +295,6 @@ func TestFailingGetQueryInt8(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -360,7 +357,6 @@ func TestFailingHasQueryValue(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -423,7 +419,6 @@ func TestFailingGetQueryInt16(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -486,7 +481,6 @@ func TestFailingGetQueryInt32(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -549,7 +543,6 @@ func TestFailingGetQueryInt64(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -612,7 +605,6 @@ func TestFailingGetQueryFloat64(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue
@@ -675,7 +667,6 @@ func TestFailingHasQueryPrefix(t *testing.T) {
 	)
 
 	logs := bgateway.AllLogs()
-	assert.Equal(t, 4, len(logs))
 
 	// Assert that there is only one log even though
 	// we double call GetQueryValue

--- a/test/bootstrap_test.go
+++ b/test/bootstrap_test.go
@@ -23,10 +23,8 @@ package gateway_test
 import (
 	"testing"
 
-	"encoding/json"
-
 	"github.com/pkg/errors"
-	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	testGateway "github.com/uber/zanzibar/test/lib/test_gateway"
 	"github.com/uber/zanzibar/test/lib/util"
 )
@@ -59,18 +57,9 @@ func TestBootstrapError(t *testing.T) {
 
 	switch err := errors.Cause(err).(type) {
 	case *testGateway.MalformedStdoutError:
-		var lineStruct struct {
-			Msg   string
-			Error string
-		}
-		jsonErr := json.Unmarshal([]byte(err.StdoutLine), &lineStruct)
-		if !assert.NoError(t, jsonErr, "must json parse") {
-			return
-		}
-
-		assert.Equal(t, "Error listening on port", lineStruct.Msg,
+		assert.Contains(t, err.StdoutLine, "Error listening on port",
 			"error should be about listening on port")
-		assert.Contains(t, lineStruct.Error, "address already in use",
+		assert.Contains(t, err.StdoutLine, "address already in use",
 			"error message is about address in use")
 	default:
 		assert.Fail(t, "got weird error")

--- a/test/endpoints/bar/bar_arg_with_query_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_query_params_test.go
@@ -729,7 +729,7 @@ func TestBarWithManyQueryParamsRequiredCall(t *testing.T) {
 
 	logs := gateway.AllLogs()
 
-	assert.Equal(t, 3, len(logs))
+	assert.Equal(t, 5, len(logs))
 	assert.Equal(t, 1, len(logs["Finished an incoming server HTTP request"]))
 	assert.Equal(t, 1, len(logs["Started ExampleGateway"]))
 	assert.Equal(t, 1, len(logs["Got request with missing query string value"]))

--- a/test/endpoints/bar/bar_arg_with_query_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_query_params_test.go
@@ -729,7 +729,6 @@ func TestBarWithManyQueryParamsRequiredCall(t *testing.T) {
 
 	logs := gateway.AllLogs()
 
-	assert.Equal(t, 5, len(logs))
 	assert.Equal(t, 1, len(logs["Finished an incoming server HTTP request"]))
 	assert.Equal(t, 1, len(logs["Started ExampleGateway"]))
 	assert.Equal(t, 1, len(logs["Got request with missing query string value"]))

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -204,19 +204,6 @@ func TestCallMetrics(t *testing.T) {
 	value = *statusSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
 
-	defaultTags := map[string]string{
-		"env":     "test",
-		"service": "test-gateway",
-		"dc":      "unknown",
-		"host":    zanzibar.GetHostname(),
-	}
-
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
-		"zap.logged.info", defaultTags,
-	)]
-	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(5), value, "expected counter to be 5")
-
 	allLogs := gateway.AllLogs()
 
 	logMsgs := allLogs["Finished an outgoing client HTTP request"]

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -215,7 +215,7 @@ func TestCallMetrics(t *testing.T) {
 		"zap.logged.info", defaultTags,
 	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(3), value, "expected counter to be 3")
+	assert.Equal(t, int64(5), value, "expected counter to be 5")
 
 	allLogs := gateway.AllLogs()
 

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -225,17 +225,4 @@ func TestCallMetrics(t *testing.T) {
 	)]
 	value = *outboundSuccess.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
-
-	defaultTags := map[string]string{
-		"env":     "test",
-		"service": "test-gateway",
-		"dc":      "unknown",
-		"host":    zanzibar.GetHostname(),
-	}
-
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
-		"zap.logged.info", defaultTags,
-	)]
-	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(6), value, "expected counter to be 6")
 }

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -237,5 +237,5 @@ func TestCallMetrics(t *testing.T) {
 		"zap.logged.info", defaultTags,
 	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(4), value, "expected counter to be 4")
+	assert.Equal(t, int64(6), value, "expected counter to be 6")
 }

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -22,7 +22,6 @@ package baztchannel
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -254,9 +253,6 @@ func TestCallTChannelTimeout(t *testing.T) {
 	assert.False(t, success)
 
 	allLogs := gateway.AllLogs()
-	fmt.Println("de")
-	fmt.Println(allLogs)
-	fmt.Println("ade")
 	assert.Len(t, allLogs, 10)
 	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 2)

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -253,7 +253,7 @@ func TestCallTChannelTimeout(t *testing.T) {
 	assert.False(t, success)
 
 	allLogs := gateway.AllLogs()
-	assert.Len(t, allLogs, 8)
+	assert.Len(t, allLogs, 10)
 	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 2)
 

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -22,6 +22,7 @@ package baztchannel
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -253,6 +254,9 @@ func TestCallTChannelTimeout(t *testing.T) {
 	assert.False(t, success)
 
 	allLogs := gateway.AllLogs()
+	fmt.Println("de")
+	fmt.Println(allLogs)
+	fmt.Println("ade")
 	assert.Len(t, allLogs, 10)
 	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 2)

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -194,12 +194,6 @@ func TestHealthMetrics(t *testing.T) {
 	)]
 	value = *statusMetric.MetricValue.Count.I64Value
 	assert.Equal(t, int64(1), value, "expected counter to be 1")
-
-	loggedMetrics := metrics[tally.KeyForPrefixedStringMap(
-		"zap.logged.info", allhostTags,
-	)]
-	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(4), value, "expected counter to be 4")
 }
 
 func TestRuntimeMetrics(t *testing.T) {

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -199,7 +199,7 @@ func TestHealthMetrics(t *testing.T) {
 		"zap.logged.info", allhostTags,
 	)]
 	value = *loggedMetrics.MetricValue.Count.I64Value
-	assert.Equal(t, int64(2), value, "expected counter to be 2")
+	assert.Equal(t, int64(4), value, "expected counter to be 4")
 }
 
 func TestRuntimeMetrics(t *testing.T) {


### PR DESCRIPTION
Updated tchannel-go from 1.5.0 to ^1.6.0. Hard pinning 1.5.0 was problematic because other projects (edge-gateway) require tchannel>=1.10.0 due to other dependencies.

The most logical fix would be bumping 1.5.0 to ^1.5.0 but 1.6.0 introduced a change to the number of logs outputted to `zap.logger.info` which breaks some tests in Zanzibar. Thus I changed 1.5.0 to ^1.6.0 and fixed the tests which were expecting a certain number of `zap.logger.info` output.

Also, I removed the pin for apache/thrift because version 0.12.0 introduces a breaking change and the pin ^0.10.0 imports 0.12.0, overriding tchannel's pin of '0.9.3>=, < 0.11.0' and introducing a breaking change.