### PR TITLE
Fix middleware file naming in code generation

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -1306,7 +1306,10 @@ func (g *MiddlewareGenerator) generateMiddlewareFile(instance *ModuleInstance, o
 		return err
 	}
 
-	out[instance.InstanceName+".go"] = bytes
+	baseName := filepath.Base(instance.Directory)
+
+	out[baseName+".go"] = bytes
+
 	return nil
 }
 


### PR DESCRIPTION
Fixed a bug where middlewares would not be generated in the correct `build` directory due to "/" characters in the `instanceName`