### PR TITLE
Fix moduleSearchPath dependency ordering

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -51,7 +51,7 @@ const jsonConfigSuffix = "-config.json"
 const yamlConfigSuffix = "-config.yaml"
 
 // NewModuleSystem returns a new module system
-func NewModuleSystem(moduleSearchPaths []string, postGenHook ...PostGenHook) *ModuleSystem {
+func NewModuleSystem(moduleSearchPaths map[string][]string, postGenHook ...PostGenHook) *ModuleSystem {
 	return &ModuleSystem{
 		classes:           map[string]*ModuleClass{},
 		classOrder:        []string{},
@@ -65,7 +65,7 @@ type ModuleSystem struct {
 	classes           map[string]*ModuleClass
 	classOrder        []string
 	postGenHook       []PostGenHook
-	moduleSearchPaths []string
+	moduleSearchPaths map[string][]string
 }
 
 // PostGenHook provides a way to do work after the build is generated,
@@ -557,93 +557,87 @@ func (system *ModuleSystem) ResolveModules(
 
 	resolvedModules := map[string][]*ModuleInstance{}
 
-	for _, moduleDirectoryGlob := range system.moduleSearchPaths {
-		moduleDirectoriesAbs, err := filepath.Glob(filepath.Join(baseDirectory, moduleDirectoryGlob))
-		if err != nil {
-			return nil, errors.Wrapf(err, "Error globbing %q", moduleDirectoryGlob)
-		}
-
-		// We don't know until reading the configuration file what the class name will be. For consistency we will
-		// continue to assume that all of the instances that match a glob pattern are the same class name, so
-		// once we've read the first instance we can populate this.
-		className := ""
-
-		for _, moduleDirAbs := range moduleDirectoriesAbs {
-			stat, err := os.Stat(moduleDirAbs)
+	// system.classOrder is important. Downstream dependencies **must** be resolved first
+	for _, className := range system.classOrder {
+		for _, moduleDirectoryGlob := range system.moduleSearchPaths[className] {
+			moduleDirectoriesAbs, err := filepath.Glob(filepath.Join(baseDirectory, moduleDirectoryGlob))
 			if err != nil {
-				return nil, errors.Wrapf(
-					err,
-					"internal error: cannot stat %q",
-					moduleDirAbs,
-				)
+				return nil, errors.Wrapf(err, "Error globbing %q", moduleDirectoryGlob)
 			}
 
-			if !stat.IsDir() {
-				// If a *-config.yaml file, or any other metadata file also matched the glob, skip it, since we are
-				// interested only in the containing directories.
-				continue
-			}
-
-			moduleDir, err := filepath.Rel(baseDirectory, moduleDirAbs)
-			if err != nil {
-				return nil, errors.Wrapf(
-					err,
-					"internal error: cannot make %q relative to %q",
-					moduleDirAbs,
-					baseDirectory,
-				)
-			}
-
-			instance, instanceErr := system.readInstance(
-				packageRoot,
-				baseDirectory,
-				targetGenDir,
-				moduleDir,
-			)
-			if instanceErr != nil {
-				if _, ok := instanceErr.(inferError); ok {
-					// It could be the case that a glob pattern like "endpoints/*" matches a *folder* that is later
-					// matched by a longer glob pattern like "endpoints/tchannel/*". It will fail at a later step
-					// if no globbing pattern matches the wanted instance.
-					continue
-				} else {
+			for _, moduleDirAbs := range moduleDirectoriesAbs {
+				stat, err := os.Stat(moduleDirAbs)
+				if err != nil {
 					return nil, errors.Wrapf(
-						instanceErr,
-						"Error reading multi instance %q",
+						err,
+						"internal error: cannot stat %q",
+						moduleDirAbs,
+					)
+				}
+
+				if !stat.IsDir() {
+					// If a *-config.yaml file, or any other metadata file also matched the glob, skip it, since we are
+					// interested only in the containing directories.
+					continue
+				}
+
+				moduleDir, err := filepath.Rel(baseDirectory, moduleDirAbs)
+				if err != nil {
+					return nil, errors.Wrapf(
+						err,
+						"internal error: cannot make %q relative to %q",
+						moduleDirAbs,
+						baseDirectory,
+					)
+				}
+
+				instance, instanceErr := system.readInstance(
+					packageRoot,
+					baseDirectory,
+					targetGenDir,
+					moduleDir,
+				)
+				if instanceErr != nil {
+					if _, ok := instanceErr.(inferError); ok {
+						// It could be the case that a glob pattern like "endpoints/*" matches a *folder* that is later
+						// matched by a longer glob pattern like "endpoints/tchannel/*". It will fail at a later step
+						// if no globbing pattern matches the wanted instance.
+						continue
+					} else {
+						return nil, errors.Wrapf(
+							instanceErr,
+							"Error reading multi instance %q",
+							moduleDir,
+						)
+					}
+				}
+
+				resolvedModules[instance.ClassName] = append(resolvedModules[instance.ClassName], instance)
+
+				if className != instance.ClassName {
+					return nil, fmt.Errorf(
+						"invariant: all instances in a multi-module directory %q are of type %q (violated by %q)",
+						moduleDirectoryGlob,
+						className,
 						moduleDir,
 					)
 				}
 			}
 
-			resolvedModules[instance.ClassName] = append(resolvedModules[instance.ClassName], instance)
-
-			// For consistency with prior zanzibar behavior of assuming all instances in a multi-module directory
-			// are of the same class name, we will return an error in this case.
-			if className == "" {
-				className = instance.ClassName
-			} else if className != instance.ClassName {
-				return nil, fmt.Errorf(
-					"invariant: all instances in a multi-module directory %q are of type %q (violated by %q)",
-					moduleDirectoryGlob,
-					className,
-					moduleDir,
-				)
+			// Resolve dependencies for all classes
+			resolveErr := system.populateResolvedDependencies(
+				resolvedModules[className],
+				resolvedModules,
+			)
+			if resolveErr != nil {
+				return nil, resolveErr
 			}
-		}
 
-		// Resolve dependencies for all classes
-		resolveErr := system.populateResolvedDependencies(
-			resolvedModules[className],
-			resolvedModules,
-		)
-		if resolveErr != nil {
-			return nil, resolveErr
-		}
-
-		// Resolved recursive dependencies for all classes
-		recursiveErr := system.populateRecursiveDependencies(resolvedModules[className])
-		if recursiveErr != nil {
-			return nil, recursiveErr
+			// Resolved recursive dependencies for all classes
+			recursiveErr := system.populateRecursiveDependencies(resolvedModules[className])
+			if recursiveErr != nil {
+				return nil, recursiveErr
+			}
 		}
 	}
 

--- a/codegen/module.go
+++ b/codegen/module.go
@@ -592,6 +592,7 @@ func (system *ModuleSystem) ResolveModules(
 				}
 
 				instance, instanceErr := system.readInstance(
+					className,
 					packageRoot,
 					baseDirectory,
 					targetGenDir,
@@ -653,6 +654,7 @@ func (i inferError) Error() string {
 }
 
 func (system *ModuleSystem) readInstance(
+	className string,
 	packageRoot string,
 	baseDirectory string,
 	targetGenDir string,
@@ -660,7 +662,6 @@ func (system *ModuleSystem) readInstance(
 ) (*ModuleInstance, error) {
 	classConfigDir := filepath.Join(baseDirectory, instanceDirectory)
 
-	// Try to infer the class name based on what *-config.yaml files exist.
 	instanceFiles, err := ioutil.ReadDir(classConfigDir)
 	if err != nil {
 		return nil, errors.Wrapf(
@@ -671,18 +672,16 @@ func (system *ModuleSystem) readInstance(
 	}
 
 	var (
-		className, jsonFileName, yamlFileName, classConfigPath string
+		jsonFileName, yamlFileName, classConfigPath string
 	)
 	for _, instanceFile := range instanceFiles {
 		if strings.HasSuffix(instanceFile.Name(), yamlConfigSuffix) {
-			className = strings.TrimSuffix(instanceFile.Name(), yamlConfigSuffix)
 			yamlFileName = instanceFile.Name()
 			classConfigPath = filepath.Join(classConfigDir, yamlFileName)
 			break
 		}
 
 		if strings.HasSuffix(instanceFile.Name(), jsonConfigSuffix) {
-			className = strings.TrimSuffix(instanceFile.Name(), jsonConfigSuffix)
 			jsonFileName = instanceFile.Name()
 			classConfigPath = filepath.Join(classConfigDir, jsonFileName)
 			break

--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -77,14 +77,18 @@ func (*TestHTTPEndpointGenerator) Generate(
 
 func TestExampleService(t *testing.T) {
 	moduleSystem := NewModuleSystem(
-		[]string{
-			"clients/*",
-			"endpoints/*",
-			"middlewares/*",
-			"services/*",
-			"another/*",
-			"more-endpoints/*",
-			"endpoints/*/*",
+		map[string][]string{
+			"client": {
+				"clients/*",
+				"endpoints/*/*",
+			},
+			"endpoint": {
+				"endpoints/*",
+				"another/*",
+				"more-endpoints/*",
+			},
+			"middleware": {"middlewares/*"},
+			"service":    {"services/*"},
 		},
 	)
 	var err error
@@ -423,7 +427,7 @@ func TestExampleService(t *testing.T) {
 }
 
 func TestExampleServiceIncremental(t *testing.T) {
-	moduleSystem := NewModuleSystem([]string{})
+	moduleSystem := NewModuleSystem(map[string][]string{})
 	var err error
 
 	err = moduleSystem.RegisterClass(ModuleClass{
@@ -764,9 +768,9 @@ func TestExampleServiceIncremental(t *testing.T) {
 }
 
 func TestExampleServiceCycles(t *testing.T) {
-	moduleSystem := NewModuleSystem([]string{
-		"clients/*",
-		"endpoints/*",
+	moduleSystem := NewModuleSystem(map[string][]string{
+		"client":   {"clients/*"},
+		"endpoint": {"endpoints/*"},
 	})
 	var err error
 
@@ -877,7 +881,7 @@ func TestSortDependencies(t *testing.T) {
 }
 
 func TestSortModuleClasses(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -910,7 +914,7 @@ func TestSortModuleClasses(t *testing.T) {
 }
 
 func TestSortModuleClassesNoDeps(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -938,7 +942,7 @@ func TestSortModuleClassesNoDeps(t *testing.T) {
 }
 
 func TestSortModuleClassesUndefined(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -957,7 +961,7 @@ func TestSortModuleClassesUndefined(t *testing.T) {
 }
 
 func TestSortModuleClassesUndefined2(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -976,7 +980,7 @@ func TestSortModuleClassesUndefined2(t *testing.T) {
 }
 
 func TestSortableModuleClassCycle(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -996,7 +1000,7 @@ func TestSortableModuleClassCycle(t *testing.T) {
 }
 
 func TestSortableModuleClassCycle2(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -1016,7 +1020,7 @@ func TestSortableModuleClassCycle2(t *testing.T) {
 }
 
 func TestSortModuleClassesIndirectCycle(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -1041,7 +1045,7 @@ func TestSortModuleClassesIndirectCycle(t *testing.T) {
 }
 
 func TestSortModuleClassesIndirectCycle2(t *testing.T) {
-	ms := NewModuleSystem([]string{})
+	ms := NewModuleSystem(map[string][]string{})
 	err := ms.RegisterClass(ModuleClass{
 		Name:       "a",
 		NamePlural: "as",
@@ -1476,9 +1480,8 @@ func TestModulePathStripping(t *testing.T) {
 }
 
 func TestModuleSearchDuplicateGlobs(t *testing.T) {
-	moduleSystem := NewModuleSystem([]string{
-		"clients/*",
-		"clients/*",
+	moduleSystem := NewModuleSystem(map[string][]string{
+		"client": {"clients/*", "clients/*"},
 	})
 	var err error
 

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -57,8 +57,8 @@ type PackageHelper struct {
 	deputyReqHeader string
 	// traceKey is the key for unique trace id that identifies request / response pair
 	traceKey string
-	// moduleSearchPaths is a list of glob patterns for folders that contain *-config.yaml files
-	moduleSearchPaths []string
+	// moduleSearchPaths is a dictionary of glob patterns for folders that contain *-config.yaml files
+	moduleSearchPaths map[string][]string
 }
 
 //NewDefaultPackageHelperOptions returns a new default PackageHelperOptions, all optional fields are set as default.
@@ -90,8 +90,8 @@ type PackageHelperOptions struct {
 	DeputyReqHeader string
 	// header key to uniquely identifies request/response pair, defaults to "x-trace-id"
 	TraceKey string
-	// ModuleSearchPaths is a list of glob patterns for folders that contain *-config.yaml files
-	ModuleSearchPaths []string
+	// ModuleSearchPaths is a dictionary of glob patterns for folders that contain *-config.yaml files
+	ModuleSearchPaths map[string][]string
 }
 
 func (p *PackageHelperOptions) relTargetGenDir() string {

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -92,7 +92,7 @@ func main() {
 		deputyReqHeader = config.MustGetString("deputyReqHeader")
 	}
 
-	searchPaths := make([]string, 0)
+	searchPaths := make(map[string][]string, 0)
 	config.MustGetStruct("moduleSearchPaths", &searchPaths)
 	options := &codegen.PackageHelperOptions{
 		RelThriftRootDir:       config.MustGetString("thriftRootDir"),

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -56,10 +56,10 @@ func TestGenerateBar(t *testing.T) {
 		CopyrightHeader: testCopyrightHeader,
 		GenCodePackage:  packageRoot + "/build/gen-code",
 		TraceKey:        "trace-key",
-		ModuleSearchPaths: []string{
-			"clients/*",
-			"middlewares/*",
-			"endpoints/*",
+		ModuleSearchPaths: map[string][]string{
+			"client":     {"clients/*"},
+			"middleware": {"middlewares/*"},
+			"endpoint":   {"endpoints/*"},
 		},
 	}
 

--- a/examples/example-gateway/build.yaml
+++ b/examples/example-gateway/build.yaml
@@ -10,11 +10,15 @@ targetGenDir: ./build
 thriftRootDir: ./idl
 traceKey: x-trace-id
 moduleSearchPaths:
-- clients/*
-- middlewares/*
-- endpoints/*
-- endpoints/tchannel/*
-- services/*
-- app/*/clients/*
-- app/*/endpoints/*
-- app/*/services/*
+  client:
+    - clients/*
+    - app/*/clients/*
+  middleware:
+    - middlewares/*
+  endpoint:
+    - endpoints/*
+    - endpoints/tchannel/*
+    - app/*/endpoints/*
+  service:
+    - services/*
+    - app/*/services/*


### PR DESCRIPTION
I was working on updating `moduleSearchPaths` from a string to a dictionary when I discovered a bug with `moduleSearchPaths`.

Switching
```
moduleSearchPaths:
-clients/*
-middlewares/*
```
to 
```
moduleSearchPaths:
-middlewares/*
-clients/*
```
resulted in code generation failure. This is because the new `moduleSearchPaths` code **ignores** class dependency ordering. It was working fine right now because `clients/*` was **coincidentally** put before `middlewares/*`. However, switching the ordering made it so that middlewares, which are dependent on clients, were discovered first. Since middlewares are dependent on clients, clients **must** be discovered before middleware.

Thus, I've labeled this update as a "Fix" rather than an "Update"

