### PR TITLE
Better runtime config for mock service

### DIFF
--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -1,4 +1,5 @@
-{{- $instance := . -}}
+{{- $instance := .Instance -}}
+{{- $defaultTestConfigPath := .TestConfigPath -}}
 {{- $leafClass := firstIsClientOrEmpty $instance.DependencyOrder -}}
 {{- $mockType := printf "Mock%sNodes" (title $leafClass) -}}
 {{- $mock := printf "Mock%ss" (title $leafClass) -}}
@@ -10,8 +11,8 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -54,11 +55,18 @@ type mockService struct {
 }
 
 // MustCreateTestService creates a new MockService, panics if it fails doing so.
-func MustCreateTestService(t *testing.T) MockService {
-	_, file, _, _ := runtime.Caller(0)
-	currentDir := zanzibar.GetDirnameFromRuntimeCaller(file)
-	testConfigPath := filepath.Join(currentDir, "../../../../config/test.yaml")
-	c := config.NewRuntimeConfigOrDie([]string{testConfigPath}, nil)
+// Optional testConfigPaths specifies runtime config files used in tests, it
+// should be paths that are relative to "$GOPATH/src".
+// If testConfigPaths is absent, a default test config file is used.
+// The default test config file is chosen base on existence in order below:
+// - "../../config/test.yaml" where current dir is the dir of service-config.yaml for the mocked service
+// - "config/test.yaml" where current dir is the project root
+func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
+	if len(testConfigPaths) == 0 {
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "{{$defaultTestConfigPath}}")
+		testConfigPaths = append(testConfigPaths, defaultPath)
+	}
+	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 
 	server, err := zanzibar.CreateGateway(c, nil)
 	if err != nil {


### PR DESCRIPTION
This PR refactors the mock service generation logic to allow more flexible runtime config settings for tests.