### PR TITLE
Add accessor and fix linter issue

### DIFF
--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -38,11 +38,11 @@ type stackTracer interface {
 
 func checkError(err error, message string) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s:\n%s\n", message, err)
+		fmt.Printf("%s:\n%s\n", message, err)
 
 		causeErr := errors.Cause(err)
 		if causeErr, ok := causeErr.(stackTracer); ok {
-			fmt.Fprintf(os.Stderr, "%+v \n", causeErr.StackTrace())
+			fmt.Printf("%+v \n", causeErr.StackTrace())
 		}
 
 		os.Exit(1)

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -38,11 +38,15 @@ type stackTracer interface {
 
 func checkError(err error, message string) {
 	if err != nil {
-		fmt.Printf("%s:\n%s\n", message, err)
+		fmt.Fprintf(
+			os.Stderr, "%s:\n%s\n", message, err,
+		)
 
 		causeErr := errors.Cause(err)
 		if causeErr, ok := causeErr.(stackTracer); ok {
-			fmt.Printf("%+v \n", causeErr.StackTrace())
+			fmt.Fprintf(
+				os.Stderr, "%+v \n", causeErr.StackTrace(),
+			)
 		}
 
 		os.Exit(1)

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -282,7 +282,7 @@ func (res *ServerHTTPResponse) GetPendingResponse() ([]byte, int) {
 	return res.pendingBodyBytes, res.pendingStatusCode
 }
 
-// ResponseHeaders returns the underlying http response's headers
-func (res *ServerHTTPResponse) ResponseHeaders() http.Header {
+// Headers returns the underlying http response's headers
+func (res *ServerHTTPResponse) Headers() http.Header {
 	return res.responseWriter.Header()
 }

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -281,3 +281,8 @@ func (res *ServerHTTPResponse) writeBytes(bytes []byte) {
 func (res *ServerHTTPResponse) GetPendingResponse() ([]byte, int) {
 	return res.pendingBodyBytes, res.pendingStatusCode
 }
+
+// ResponseHeaders returns the underlying http response's headers
+func (res *ServerHTTPResponse) ResponseHeaders() http.Header {
+	return res.responseWriter.Header()
+}

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -465,6 +465,8 @@ func TestPendingResponseBody(t *testing.T) {
 				assert.Equal(t, bytes, pendingBytes)
 				assert.Equal(t, statusCode, pendingStatusCode)
 
+				headers := res.ResponseHeaders()
+				assert.NotNil(t, headers)
 			},
 		).HandleRequest),
 	)

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -465,7 +465,7 @@ func TestPendingResponseBody(t *testing.T) {
 				assert.Equal(t, bytes, pendingBytes)
 				assert.Equal(t, statusCode, pendingStatusCode)
 
-				headers := res.ResponseHeaders()
+				headers := res.Headers()
 				assert.NotNil(t, headers)
 			},
 		).HandleRequest),


### PR DESCRIPTION
Created an accessor for response headers (No other accessors are needed. Found workarounds for them).

Linter was checking for Fprintf and throwing an error so I had to change it to Printf.

