### PR TITLE
Turn on race detector for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,12 +148,13 @@ test: generate lint
 test-only:
 	@rm -f ./test/.cached_binary_test_info.json
 	@echo "Running all tests..."
-	@ZANZIBAR_CACHE=1 go test ./test/health_test.go # preload the binary cache
-	@PATH=$(PATH):$(GOIMPORTS) ZANZIBAR_CACHE=1 go test \
+	@ZANZIBAR_CACHE=1 go test -race ./test/health_test.go # preload the binary cache
+	@PATH=$(PATH):$(GOIMPORTS) ZANZIBAR_CACHE=1 go test -race \
 		./examples/example-gateway/... \
 		./codegen/... \
-		./runtime/... \
-		./test/... | \
+		./runtime/... | \
+		grep -v '\[no test files\]'
+	@PATH=$(PATH):$(GOIMPORTS) ZANZIBAR_CACHE=1 go test ./test/... | \
 		grep -v '\[no test files\]'
 	@rm -f ./test/.cached_binary_test_info.json
 	@echo "<coverage />" > ./coverage/cobertura-coverage.xml

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -43,6 +43,12 @@ var defaultTestOptions *testGateway.Options = &testGateway.Options{
 }
 var defaultTestConfig map[string]interface{} = map[string]interface{}{
 	"clients.baz.serviceName": "baz",
+
+	// disable circuit breaker to avoid race condition when running tests
+	// the circuit breaker lib emits metrics in a free goroutine, when the
+	// server closes, it attempts to close the channel for emitting metrics
+	// but the circuit breaker stats report goroutine could still be running
+	"clients.bar.circuitBreakerDisabled": true,
 }
 
 func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {


### PR DESCRIPTION
This PR turns on race detector for all tests except the legacy ones in ./test dir, which depends on process stdout logs to do a bunch of things. Probably does not worth the effort to get those tests to be race-free.