### PR TITLE
allow writing raw bytes instead of JSON bytes for HTTP res

### DIFF
--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -169,8 +169,8 @@ func (res *ServerHTTPResponse) SendError(
 	)
 }
 
-// WriteJSONBytes writes a byte[] slice that is valid json to Response
-func (res *ServerHTTPResponse) WriteJSONBytes(
+// WriteBytes writes a byte[] slice that is valid Response
+func (res *ServerHTTPResponse) WriteBytes(
 	statusCode int, headers Header, bytes []byte,
 ) {
 	if headers != nil {
@@ -182,10 +182,20 @@ func (res *ServerHTTPResponse) WriteJSONBytes(
 		}
 	}
 
-	res.responseWriter.Header().Set("content-type", "application/json")
-
 	res.pendingStatusCode = statusCode
 	res.pendingBodyBytes = bytes
+}
+
+// WriteJSONBytes writes a byte[] slice that is valid json to Response
+func (res *ServerHTTPResponse) WriteJSONBytes(
+	statusCode int, headers Header, bytes []byte,
+) {
+	if headers == nil {
+		headers = ServerHTTPHeader{}
+	}
+
+	headers.Add("content-type", "application/json")
+	res.WriteBytes(statusCode, headers, bytes)
 }
 
 // WriteJSON writes a json serializable struct to Response

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -357,6 +357,12 @@ func TestResponseSetHeaders(t *testing.T) {
 		resp.Header.Get("foo"),
 		"bar",
 	)
+	// Ensure content-type is set for JSON body.
+	assert.Equal(
+		t,
+		resp.Header.Get("Content-type"),
+		"application/json",
+	)
 }
 
 func TestResponsePeekBodyError(t *testing.T) {


### PR DESCRIPTION
We have use cases where are not always writing JSON response. We did
like to control writing the payload as bytes and setting our own headers
based on the Content-Type.