### PR TITLE
Provide solution to filter log fields by user demand

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3149,8 +3149,7 @@ func New{{$workflowInterface}}Mock(t *testing.T) (workflow.{{$workflowInterface}
 		Scope: tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	{{range $idx, $className := $instance.DependencyOrder}}
 	{{- $moduleInstances := (index $instance.RecursiveDependencies $className)}}
@@ -3214,7 +3213,7 @@ func workflow_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow_mock.tmpl", size: 4716, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow_mock.tmpl", size: 4653, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1101,6 +1101,9 @@ func (c *{{$clientName}}) {{$methodName}}(
 ) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1297,7 +1300,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 11411, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 11474, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -177,6 +177,9 @@ func (c *{{$clientName}}) {{$methodName}}(
 ) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -49,6 +49,7 @@ type {{$clientName}} struct {
 	clientID string
 	httpClient   *zanzibar.HTTPClient
 	circuitBreakerDisabled bool
+	requestUUIDHeaderKey string
 
 	{{if $sidecarRouter -}}
 	calleeHeader string
@@ -80,6 +81,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.defaultHeaders", &defaultHeaders)
 	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("http.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("http.clients.requestUUIDHeaderKey")
+	}
 
 
 	circuitBreakerDisabled := configureCicruitBreaker(deps, timeoutVal)
@@ -105,6 +110,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			timeout,
 		),
 		circuitBreakerDisabled: circuitBreakerDisabled,
+		requestUUIDHeaderKey: requestUUIDHeaderKey,
 	}
 }
 
@@ -169,6 +175,11 @@ func (c *{{$clientName}}) {{$methodName}}(
 	r {{.RequestType}},
 	{{end -}}
 ) ({{- if ne .ResponseType "" -}} {{.ResponseType}}, {{- end -}}map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	{{if .ResponseType -}}
 	var defaultRes  {{.ResponseType}}
 	{{end -}}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -55,6 +55,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.routingKey") {
 		routingKey = deps.Default.Config.MustGetString("clients.{{$clientID}}.routingKey")
 	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
+	}
 	sc := deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
 
 	{{if $sidecarRouter -}}
@@ -111,13 +115,14 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		deps.Default.Logger,
 		deps.Default.ContextMetrics,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       serviceName,
-			ClientID:          "{{$clientID}}",
-			MethodNames:       methodNames,
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
-			RoutingKey:        &routingKey,
-			AltSubchannelName: scAltName,
+			ServiceName:          serviceName,
+			ClientID:             "{{$clientID}}",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			AltSubchannelName:    scAltName,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
 		},
 	)
 

--- a/codegen/templates/workflow_mock.tmpl
+++ b/codegen/templates/workflow_mock.tmpl
@@ -49,8 +49,7 @@ func New{{$workflowInterface}}Mock(t *testing.T) (workflow.{{$workflowInterface}
 		Scope: tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	{{range $idx, $className := $instance.DependencyOrder}}
 	{{- $moduleInstances := (index $instance.RecursiveDependencies $className)}}

--- a/examples/example-gateway/app.go
+++ b/examples/example-gateway/app.go
@@ -62,7 +62,11 @@ func getRequestTags(ctx context.Context) map[string]string {
 func getRequestFields(ctx context.Context) []zap.Field {
 	var fields []zap.Field
 	headers := zanzibar.GetEndpointRequestHeadersFromCtx(ctx)
-	fields = append(fields, zap.String("x-uuid", headers["x-uuid"]))
+	uuid, ok := headers["X-Uuid"]
+	if !ok {
+		uuid = headers["x-uuid"]
+	}
+	fields = append(fields, zap.String("x-uuid", uuid))
 	fields = append(fields, zap.String("regionname", headers["Regionname"]))
 	fields = append(fields, zap.String("device", headers["Device"]))
 	fields = append(fields, zap.String("deviceversion", headers["Deviceversion"]))

--- a/examples/example-gateway/app.go
+++ b/examples/example-gateway/app.go
@@ -62,6 +62,7 @@ func getRequestTags(ctx context.Context) map[string]string {
 func getRequestFields(ctx context.Context) []zap.Field {
 	var fields []zap.Field
 	headers := zanzibar.GetEndpointRequestHeadersFromCtx(ctx)
+	fields = append(fields, zap.String("x-uuid", headers["x-uuid"]))
 	fields = append(fields, zap.String("regionname", headers["Regionname"]))
 	fields = append(fields, zap.String("device", headers["Device"]))
 	fields = append(fields, zap.String("deviceversion", headers["Deviceversion"]))

--- a/examples/example-gateway/build/app/demo/endpoints/abc/mock-workflow/appdemoservice_call_workflow_mock.go
+++ b/examples/example-gateway/build/app/demo/endpoints/abc/mock-workflow/appdemoservice_call_workflow_mock.go
@@ -52,8 +52,7 @@ func NewAppDemoServiceCallWorkflowMock(t *testing.T) (workflow.AppDemoServiceCal
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -322,6 +322,9 @@ func (c *barClient) ArgNotStruct(
 ) (map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -394,6 +397,9 @@ func (c *barClient) ArgWithHeaders(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -467,6 +473,9 @@ func (c *barClient) ArgWithManyQueryParams(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -613,6 +622,9 @@ func (c *barClient) ArgWithNestedQueryParams(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -719,6 +731,9 @@ func (c *barClient) ArgWithParams(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -787,6 +802,9 @@ func (c *barClient) ArgWithQueryHeader(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -852,6 +870,9 @@ func (c *barClient) ArgWithQueryParams(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -934,6 +955,9 @@ func (c *barClient) DeleteFoo(
 ) (map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -994,6 +1018,9 @@ func (c *barClient) Hello(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1067,6 +1094,9 @@ func (c *barClient) MissingArg(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1141,6 +1171,9 @@ func (c *barClient) NoRequest(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1216,6 +1249,9 @@ func (c *barClient) Normal(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1291,6 +1327,9 @@ func (c *barClient) NormalRecur(
 ) (*clientsBarBar.BarResponseRecur, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1365,6 +1404,9 @@ func (c *barClient) TooManyArgs(
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1449,6 +1491,9 @@ func (c *barClient) EchoBinary(
 ) ([]byte, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1518,6 +1563,9 @@ func (c *barClient) EchoBool(
 ) (bool, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1587,6 +1635,9 @@ func (c *barClient) EchoDouble(
 ) (float64, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1656,6 +1707,9 @@ func (c *barClient) EchoEnum(
 ) (clientsBarBar.Fruit, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1725,6 +1779,9 @@ func (c *barClient) EchoI16(
 ) (int16, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1794,6 +1851,9 @@ func (c *barClient) EchoI32(
 ) (int32, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1863,6 +1923,9 @@ func (c *barClient) EchoI32Map(
 ) (map[int32]*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -1932,6 +1995,9 @@ func (c *barClient) EchoI64(
 ) (int64, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2001,6 +2067,9 @@ func (c *barClient) EchoI8(
 ) (int8, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2070,6 +2139,9 @@ func (c *barClient) EchoString(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2139,6 +2211,9 @@ func (c *barClient) EchoStringList(
 ) ([]string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2208,6 +2283,9 @@ func (c *barClient) EchoStringMap(
 ) (map[string]*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2277,6 +2355,9 @@ func (c *barClient) EchoStringSet(
 ) (map[string]struct{}, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2346,6 +2427,9 @@ func (c *barClient) EchoStructList(
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2415,6 +2499,9 @@ func (c *barClient) EchoStructSet(
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -2484,6 +2571,9 @@ func (c *barClient) EchoTypedef(
 ) (clientsBarBar.UUID, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -198,6 +198,7 @@ type barClient struct {
 	clientID               string
 	httpClient             *zanzibar.HTTPClient
 	circuitBreakerDisabled bool
+	requestUUIDHeaderKey   string
 }
 
 // NewClient returns a new http client.
@@ -212,6 +213,10 @@ func NewClient(deps *module.Dependencies) Client {
 	defaultHeaders := make(map[string]string)
 	if deps.Default.Config.ContainsKey("clients.bar.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
+	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("http.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("http.clients.requestUUIDHeaderKey")
 	}
 
 	circuitBreakerDisabled := configureCicruitBreaker(deps, timeoutVal)
@@ -258,6 +263,7 @@ func NewClient(deps *module.Dependencies) Client {
 			timeout,
 		),
 		circuitBreakerDisabled: circuitBreakerDisabled,
+		requestUUIDHeaderKey:   requestUUIDHeaderKey,
 	}
 }
 
@@ -314,6 +320,11 @@ func (c *barClient) ArgNotStruct(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgNotStruct_Args,
 ) (map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgNotStruct", c.httpClient)
 
 	// Generate full URL.
@@ -381,6 +392,11 @@ func (c *barClient) ArgWithHeaders(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithHeaders_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithHeaders", c.httpClient)
 
@@ -449,6 +465,11 @@ func (c *barClient) ArgWithManyQueryParams(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithManyQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithManyQueryParams", c.httpClient)
 
@@ -590,6 +611,11 @@ func (c *barClient) ArgWithNestedQueryParams(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithNestedQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithNestedQueryParams", c.httpClient)
 
@@ -691,6 +717,11 @@ func (c *barClient) ArgWithParams(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithParams", c.httpClient)
 
@@ -754,6 +785,11 @@ func (c *barClient) ArgWithQueryHeader(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryHeader_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithQueryHeader", c.httpClient)
 
@@ -814,6 +850,11 @@ func (c *barClient) ArgWithQueryParams(
 	headers map[string]string,
 	r *clientsBarBar.Bar_ArgWithQueryParams_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithQueryParams", c.httpClient)
 
@@ -891,6 +932,11 @@ func (c *barClient) DeleteFoo(
 	headers map[string]string,
 	r *clientsBarBar.Bar_DeleteFoo_Args,
 ) (map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "DeleteFoo", c.httpClient)
 
 	// Generate full URL.
@@ -946,6 +992,11 @@ func (c *barClient) Hello(
 	ctx context.Context,
 	headers map[string]string,
 ) (string, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "Hello", c.httpClient)
 
@@ -1014,6 +1065,11 @@ func (c *barClient) MissingArg(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "MissingArg", c.httpClient)
 
@@ -1083,6 +1139,11 @@ func (c *barClient) NoRequest(
 	ctx context.Context,
 	headers map[string]string,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "NoRequest", c.httpClient)
 
@@ -1153,6 +1214,11 @@ func (c *barClient) Normal(
 	headers map[string]string,
 	r *clientsBarBar.Bar_Normal_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "Normal", c.httpClient)
 
@@ -1223,6 +1289,11 @@ func (c *barClient) NormalRecur(
 	headers map[string]string,
 	r *clientsBarBar.Bar_NormalRecur_Args,
 ) (*clientsBarBar.BarResponseRecur, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponseRecur
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "NormalRecur", c.httpClient)
 
@@ -1292,6 +1363,11 @@ func (c *barClient) TooManyArgs(
 	headers map[string]string,
 	r *clientsBarBar.Bar_TooManyArgs_Args,
 ) (*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "TooManyArgs", c.httpClient)
 
@@ -1371,6 +1447,11 @@ func (c *barClient) EchoBinary(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoBinary_Args,
 ) ([]byte, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes []byte
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoBinary", c.httpClient)
 
@@ -1435,6 +1516,11 @@ func (c *barClient) EchoBool(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoBool_Args,
 ) (bool, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes bool
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoBool", c.httpClient)
 
@@ -1499,6 +1585,11 @@ func (c *barClient) EchoDouble(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoDouble_Args,
 ) (float64, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes float64
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoDouble", c.httpClient)
 
@@ -1563,6 +1654,11 @@ func (c *barClient) EchoEnum(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoEnum_Args,
 ) (clientsBarBar.Fruit, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes clientsBarBar.Fruit
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoEnum", c.httpClient)
 
@@ -1627,6 +1723,11 @@ func (c *barClient) EchoI16(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoI16_Args,
 ) (int16, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes int16
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI16", c.httpClient)
 
@@ -1691,6 +1792,11 @@ func (c *barClient) EchoI32(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoI32_Args,
 ) (int32, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes int32
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI32", c.httpClient)
 
@@ -1755,6 +1861,11 @@ func (c *barClient) EchoI32Map(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoI32Map_Args,
 ) (map[int32]*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes map[int32]*clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI32Map", c.httpClient)
 
@@ -1819,6 +1930,11 @@ func (c *barClient) EchoI64(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoI64_Args,
 ) (int64, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes int64
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI64", c.httpClient)
 
@@ -1883,6 +1999,11 @@ func (c *barClient) EchoI8(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoI8_Args,
 ) (int8, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes int8
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoI8", c.httpClient)
 
@@ -1947,6 +2068,11 @@ func (c *barClient) EchoString(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoString_Args,
 ) (string, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoString", c.httpClient)
 
@@ -2011,6 +2137,11 @@ func (c *barClient) EchoStringList(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoStringList_Args,
 ) ([]string, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes []string
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringList", c.httpClient)
 
@@ -2075,6 +2206,11 @@ func (c *barClient) EchoStringMap(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoStringMap_Args,
 ) (map[string]*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes map[string]*clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringMap", c.httpClient)
 
@@ -2139,6 +2275,11 @@ func (c *barClient) EchoStringSet(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoStringSet_Args,
 ) (map[string]struct{}, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes map[string]struct{}
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStringSet", c.httpClient)
 
@@ -2203,6 +2344,11 @@ func (c *barClient) EchoStructList(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoStructList_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes []*clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStructList", c.httpClient)
 
@@ -2267,6 +2413,11 @@ func (c *barClient) EchoStructSet(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoStructSet_Args,
 ) ([]*clientsBarBar.BarResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes []*clientsBarBar.BarResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoStructSet", c.httpClient)
 
@@ -2331,6 +2482,11 @@ func (c *barClient) EchoTypedef(
 	headers map[string]string,
 	r *clientsBarBar.Echo_EchoTypedef_Args,
 ) (clientsBarBar.UUID, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes clientsBarBar.UUID
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoTypedef", c.httpClient)
 

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -186,6 +186,10 @@ func NewClient(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("clients.baz.routingKey") {
 		routingKey = deps.Default.Config.MustGetString("clients.baz.routingKey")
 	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
+	}
 	sc := deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
 
 	ip := deps.Default.Config.MustGetString("clients.baz.ip")
@@ -254,13 +258,14 @@ func NewClient(deps *module.Dependencies) Client {
 		deps.Default.Logger,
 		deps.Default.ContextMetrics,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       serviceName,
-			ClientID:          "baz",
-			MethodNames:       methodNames,
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
-			RoutingKey:        &routingKey,
-			AltSubchannelName: scAltName,
+			ServiceName:          serviceName,
+			ClientID:             "baz",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			AltSubchannelName:    scAltName,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
 		},
 	)
 

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -55,6 +55,7 @@ type contactsClient struct {
 	clientID               string
 	httpClient             *zanzibar.HTTPClient
 	circuitBreakerDisabled bool
+	requestUUIDHeaderKey   string
 }
 
 // NewClient returns a new http client.
@@ -69,6 +70,10 @@ func NewClient(deps *module.Dependencies) Client {
 	defaultHeaders := make(map[string]string)
 	if deps.Default.Config.ContainsKey("clients.contacts.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.contacts.defaultHeaders", &defaultHeaders)
+	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("http.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("http.clients.requestUUIDHeaderKey")
 	}
 
 	circuitBreakerDisabled := configureCicruitBreaker(deps, timeoutVal)
@@ -87,6 +92,7 @@ func NewClient(deps *module.Dependencies) Client {
 			timeout,
 		),
 		circuitBreakerDisabled: circuitBreakerDisabled,
+		requestUUIDHeaderKey:   requestUUIDHeaderKey,
 	}
 }
 
@@ -143,6 +149,11 @@ func (c *contactsClient) SaveContacts(
 	headers map[string]string,
 	r *clientsContactsContacts.SaveContactsRequest,
 ) (*clientsContactsContacts.SaveContactsResponse, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes *clientsContactsContacts.SaveContactsResponse
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "SaveContacts", c.httpClient)
 
@@ -201,6 +212,11 @@ func (c *contactsClient) TestURLURL(
 	ctx context.Context,
 	headers map[string]string,
 ) (string, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "TestURLURL", c.httpClient)
 

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -151,6 +151,9 @@ func (c *contactsClient) SaveContacts(
 ) (*clientsContactsContacts.SaveContactsResponse, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -214,6 +217,9 @@ func (c *contactsClient) TestURLURL(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -52,6 +52,7 @@ type corgeHTTPClient struct {
 	clientID               string
 	httpClient             *zanzibar.HTTPClient
 	circuitBreakerDisabled bool
+	requestUUIDHeaderKey   string
 
 	calleeHeader string
 	callerHeader string
@@ -76,6 +77,10 @@ func NewClient(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("clients.corge-http.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.corge-http.defaultHeaders", &defaultHeaders)
 	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("http.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("http.clients.requestUUIDHeaderKey")
+	}
 
 	circuitBreakerDisabled := configureCicruitBreaker(deps, timeoutVal)
 
@@ -96,6 +101,7 @@ func NewClient(deps *module.Dependencies) Client {
 			timeout,
 		),
 		circuitBreakerDisabled: circuitBreakerDisabled,
+		requestUUIDHeaderKey:   requestUUIDHeaderKey,
 	}
 }
 
@@ -152,6 +158,11 @@ func (c *corgeHTTPClient) EchoString(
 	headers map[string]string,
 	r *clientsCorgeCorge.Corge_EchoString_Args,
 ) (string, map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	var defaultRes string
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "EchoString", c.httpClient)
 

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -160,6 +160,9 @@ func (c *corgeHTTPClient) EchoString(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -57,6 +57,10 @@ func NewClient(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("clients.corge.routingKey") {
 		routingKey = deps.Default.Config.MustGetString("clients.corge.routingKey")
 	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
+	}
 	sc := deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
 
 	ip := deps.Default.Config.MustGetString("sidecarRouter.default.tchannel.ip")
@@ -99,13 +103,14 @@ func NewClient(deps *module.Dependencies) Client {
 		deps.Default.Logger,
 		deps.Default.ContextMetrics,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       serviceName,
-			ClientID:          "corge",
-			MethodNames:       methodNames,
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
-			RoutingKey:        &routingKey,
-			AltSubchannelName: scAltName,
+			ServiceName:          serviceName,
+			ClientID:             "corge",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			AltSubchannelName:    scAltName,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
 		},
 	)
 

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -55,6 +55,7 @@ type googleNowClient struct {
 	clientID               string
 	httpClient             *zanzibar.HTTPClient
 	circuitBreakerDisabled bool
+	requestUUIDHeaderKey   string
 }
 
 // NewClient returns a new http client.
@@ -69,6 +70,10 @@ func NewClient(deps *module.Dependencies) Client {
 	defaultHeaders := make(map[string]string)
 	if deps.Default.Config.ContainsKey("clients.google-now.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.google-now.defaultHeaders", &defaultHeaders)
+	}
+	var requestUUIDHeaderKey string
+	if deps.Default.Config.ContainsKey("http.clients.requestUUIDHeaderKey") {
+		requestUUIDHeaderKey = deps.Default.Config.MustGetString("http.clients.requestUUIDHeaderKey")
 	}
 
 	circuitBreakerDisabled := configureCicruitBreaker(deps, timeoutVal)
@@ -87,6 +92,7 @@ func NewClient(deps *module.Dependencies) Client {
 			timeout,
 		),
 		circuitBreakerDisabled: circuitBreakerDisabled,
+		requestUUIDHeaderKey:   requestUUIDHeaderKey,
 	}
 }
 
@@ -143,6 +149,11 @@ func (c *googleNowClient) AddCredentials(
 	headers map[string]string,
 	r *clientsGooglenowGooglenow.GoogleNowService_AddCredentials_Args,
 ) (map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "AddCredentials", c.httpClient)
 
 	// Generate full URL.
@@ -204,6 +215,11 @@ func (c *googleNowClient) CheckCredentials(
 	ctx context.Context,
 	headers map[string]string,
 ) (map[string]string, error) {
+	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
+	if reqUUID != "" {
+		headers[c.requestUUIDHeaderKey] = reqUUID
+	}
+
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "CheckCredentials", c.httpClient)
 
 	// Generate full URL.

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -151,6 +151,9 @@ func (c *googleNowClient) AddCredentials(
 ) (map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -217,6 +220,9 @@ func (c *googleNowClient) CheckCredentials(
 ) (map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -148,6 +148,9 @@ func (c *multiClient) HelloA(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 
@@ -211,6 +214,9 @@ func (c *multiClient) HelloB(
 ) (string, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -144,6 +144,9 @@ func (c *withexceptionsClient) Func1(
 ) (*clientsWithexceptionsWithexceptions.Response, map[string]string, error) {
 	reqUUID := zanzibar.RequestUUIDFromCtx(ctx)
 	if reqUUID != "" {
+		if headers == nil {
+			headers = make(map[string]string)
+		}
 		headers[c.requestUUIDHeaderKey] = reqUUID
 	}
 

--- a/examples/example-gateway/build/endpoints/contacts/mock-workflow/contacts_savecontacts_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/contacts/mock-workflow/contacts_savecontacts_workflow_mock.go
@@ -54,8 +54,7 @@ func NewContactsSaveContactsWorkflowMock(t *testing.T) (workflow.ContactsSaveCon
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/endpoints/panic/mock-workflow/servicecfront_hello_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/panic/mock-workflow/servicecfront_hello_workflow_mock.go
@@ -53,8 +53,7 @@ func NewServiceCFrontHelloWorkflowMock(t *testing.T) (workflow.ServiceCFrontHell
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_call_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_call_workflow_mock.go
@@ -56,8 +56,7 @@ func NewSimpleServiceCallWorkflowMock(t *testing.T) (workflow.SimpleServiceCallW
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_echo_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/mock-workflow/simpleservice_echo_workflow_mock.go
@@ -56,8 +56,7 @@ func NewSimpleServiceEchoWorkflowMock(t *testing.T) (workflow.SimpleServiceEchoW
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/endpoints/tchannel/echo/mock-workflow/echo_echo_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/mock-workflow/echo_echo_workflow_mock.go
@@ -52,8 +52,7 @@ func NewEchoEchoWorkflowMock(t *testing.T) (workflow.EchoEchoWorkflow, *MockClie
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/build/endpoints/tchannel/panic/mock-workflow/simpleservice_anothercall_workflow_mock.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/mock-workflow/simpleservice_anothercall_workflow_mock.go
@@ -52,8 +52,7 @@ func NewSimpleServiceAnotherCallWorkflowMock(t *testing.T) (workflow.SimpleServi
 		Scope:  tally.NewTestScope("", make(map[string]string)),
 	}
 	initializedDefaultDependencies.ContextLogger = zanzibar.NewContextLogger(initializedDefaultDependencies.Logger)
-	contextExtractors := &zanzibar.ContextExtractors{}
-	initializedDefaultDependencies.ContextExtractor = contextExtractors.MakeContextExtractor()
+	initializedDefaultDependencies.ContextExtractor = &zanzibar.ContextExtractors{}
 
 	initializedClientDependencies := &clientDependenciesNodes{}
 	mockClientNodes := &MockClientNodes{

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -50,6 +50,7 @@
 	"clients.withexceptions.errorPercentThreshold": 20,
 	"envVarsToTagInRootScope": [],
 	"http.port": 7783,
+	"http.clients.requestUUIDHeaderKey": "x-request-uuid",
 	"logger.fileName": "/var/log/example-gateway/example-gateway.log",
 	"logger.output": "disk",
 	"metrics.serviceName": "example-gateway",
@@ -65,5 +66,7 @@
 	"tchannel.port": 7784,
 	"tchannel.processName": "example-gateway",
 	"tchannel.serviceName": "example-gateway",
-	"useDatacenter": false
+	"tchannel.clients.requestUUIDHeaderKey": "x-request-uuid",
+	"useDatacenter": false,
+
 }

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -47,6 +47,7 @@ clients.withexceptions.maxConcurrentRequests: 1000
 clients.withexceptions.errorPercentThreshold: 20
 envVarsToTagInRootScope: []
 http.port: 7783
+http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /var/log/example-gateway/example-gateway.log
 logger.output: disk
 metrics.serviceName: example-gateway
@@ -62,4 +63,5 @@ sidecarRouter.default.tchannel.port: 5000
 tchannel.port: 7784
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
+tchannel.clients.requestUUIDHeaderKey: x-request-uuid
 useDatacenter: false

--- a/examples/example-gateway/config/test.json
+++ b/examples/example-gateway/config/test.json
@@ -48,6 +48,7 @@
 	"envVarsToTagInRootScope": [],
 	"env": "test",
 	"http.port": 0,
+	"http.clients.requestUUIDHeaderKey": "x-request-uuid",
 	"logger.fileName": "/tmp/example-gateway.log",
 	"logger.output": "disk",
 	"metrics.serviceName": "example-gateway",
@@ -63,6 +64,7 @@
 	"tchannel.port": 0,
 	"tchannel.processName": "example-gateway",
 	"tchannel.serviceName": "example-gateway",
+	"tchannel.clients.requestUUIDHeaderKey": "x-request-uuid",
 	"useDatacenter": false,
 	"shutdown.pollInterval": 10
 }

--- a/examples/example-gateway/config/test.yaml
+++ b/examples/example-gateway/config/test.yaml
@@ -45,6 +45,7 @@ clients.withexceptions.errorPercentThreshold: 20
 env: test
 envVarsToTagInRootScope: []
 http.port: 0
+http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /tmp/example-gateway.log
 logger.output: disk
 metrics.serviceName: example-gateway
@@ -61,4 +62,5 @@ sidecarRouter.default.tchannel.port: 5000
 tchannel.port: 0
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
+tchannel.clients.requestUUIDHeaderKey: x-request-uuid
 useDatacenter: false

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -156,7 +156,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 
 	req.httpReq = httpReq
 	req.ctx = WithLogFields(req.ctx,
-		zap.String(logFieldRequestMethod, method),
+		zap.String(logFieldClientHTTPMethod, method),
 		zap.String(logFieldRequestURL, url),
 		zap.Time(logFieldRequestStartTime, req.startTime),
 	)

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -197,7 +197,7 @@ func TestBarClientWithoutHeaders(t *testing.T) {
 
 	logLine := lines[0]
 	assert.Equal(t, "bar", logLine["clientID"])
-	assert.Equal(t, "EchoI8", logLine["methodName"])
+	assert.Equal(t, "EchoI8", logLine["clientMethod"])
 	assert.Equal(t, "x-uuid", logLine["headerName"])
 }
 
@@ -265,24 +265,24 @@ func TestMakingClientCallWithRespHeaders(t *testing.T) {
 		"msg":                            "Finished an outgoing client HTTP request",
 		"env":                            "test",
 		"clientID":                       "bar",
+		"clientHTTPMethod":               "POST",
 		"Response-Header-Example-Header": "Example-Value",
 		"statusCode":                     float64(200),
 		"Request-Header-Content-Type":    "application/json",
 		"Response-Header-Content-Type":   "text/plain; charset=utf-8",
 
 		"level":                      "info",
-		"methodName":                 "Normal",
-		"method":                     "POST",
+		"clientMethod":               "Normal",
 		"Request-Header-X-Client-Id": "bar",
 
 		"zone":    "unknown",
 		"service": "example-gateway",
 	}
 	for actualKey, actualValue := range logMsg {
-		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected field %q", actualKey)
 	}
 	for expectedKey, expectedValue := range expectedValues {
-		assert.Equal(t, logMsg[expectedKey], expectedValue, "unexpected header %q", expectedKey)
+		assert.Equal(t, logMsg[expectedKey], expectedValue, "unexpected field %q", expectedKey)
 	}
 }
 

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -47,7 +47,8 @@ const (
 )
 
 const (
-	logFieldRequestMethod       = "method"
+	// thrift service::method of endpoint thrift spec
+	logFieldRequestMethod       = "endpointThriftMethod"
 	logFieldRequestURL          = "url"
 	logFieldRequestStartTime    = "timestamp-started"
 	logFieldRequestFinishedTime = "timestamp-finished"
@@ -55,7 +56,7 @@ const (
 	logFieldResponseStatusCode  = "statusCode"
 	logFieldRequestUUID         = "requestUUID"
 	logFieldEndpointID          = "endpointID"
-	logFieldHandlerID           = "handlerID"
+	logFieldEndpointHandler     = "endpointHandler"
 )
 
 const (
@@ -275,45 +276,6 @@ type Logger interface {
 	Panic(msg string, fields ...zap.Field)
 	Warn(msg string, fields ...zap.Field)
 	Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry
-}
-
-// newLoggerWithFields creates a lightweight logger that implements Logger interface
-func newLoggerWithFields(logger *zap.Logger, fields []zap.Field) Logger {
-	return &loggerWithFields{
-		logger: logger,
-		fields: fields,
-	}
-}
-
-// loggerWithFields is a logger that logs entries with default fields, it is not
-// a child logger and does not clone, therefore suitable for per request creation.
-type loggerWithFields struct {
-	logger *zap.Logger
-	fields []zap.Field
-}
-
-func (l *loggerWithFields) Debug(msg string, userFields ...zap.Field) {
-	l.logger.Debug(msg, append(l.fields, userFields...)...)
-}
-
-func (l *loggerWithFields) Error(msg string, userFields ...zap.Field) {
-	l.logger.Error(msg, append(l.fields, userFields...)...)
-}
-
-func (l *loggerWithFields) Info(msg string, userFields ...zap.Field) {
-	l.logger.Info(msg, append(l.fields, userFields...)...)
-}
-
-func (l *loggerWithFields) Panic(msg string, userFields ...zap.Field) {
-	l.logger.Panic(msg, append(l.fields, userFields...)...)
-}
-
-func (l *loggerWithFields) Warn(msg string, userFields ...zap.Field) {
-	l.logger.Warn(msg, append(l.fields, userFields...)...)
-}
-
-func (l *loggerWithFields) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
-	return l.logger.Check(lvl, msg)
 }
 
 // ContextMetrics emit metrics with tags extracted from context.

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -114,17 +113,17 @@ func GetEndpointRequestHeadersFromCtx(ctx context.Context) map[string]string {
 }
 
 // withRequestUUID returns a context with request uuid.
-func withRequestUUID(ctx context.Context, reqUUID uuid.UUID) context.Context {
+func withRequestUUID(ctx context.Context, reqUUID string) context.Context {
 	return context.WithValue(ctx, requestUUIDKey, reqUUID)
 }
 
 // RequestUUIDFromCtx returns the RequestUUID, if it exists on context
-func RequestUUIDFromCtx(ctx context.Context) uuid.UUID {
+func RequestUUIDFromCtx(ctx context.Context) string {
 	if val := ctx.Value(requestUUIDKey); val != nil {
-		uuid, _ := val.(uuid.UUID)
+		uuid, _ := val.(string)
 		return uuid
 	}
-	return nil
+	return ""
 }
 
 // WithRoutingDelegate adds the tchannel routing delegate information in the

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -57,6 +57,7 @@ const (
 	logFieldRequestUUID         = "requestUUID"
 	logFieldEndpointID          = "endpointID"
 	logFieldEndpointHandler     = "endpointHandler"
+	logFieldClientHTTPMethod    = "clientHTTPMethod"
 )
 
 const (

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -118,9 +118,8 @@ func withRequestUUID(ctx context.Context, reqUUID uuid.UUID) context.Context {
 	return context.WithValue(ctx, requestUUIDKey, reqUUID)
 }
 
-// GetRequestUUIDFromCtx returns the RequestUUID, if it exists on context
-// TODO: in future, we can extend this to have request object
-func GetRequestUUIDFromCtx(ctx context.Context) uuid.UUID {
+// RequestUUIDFromCtx returns the RequestUUID, if it exists on context
+func RequestUUIDFromCtx(ctx context.Context) uuid.UUID {
 	if val := ctx.Value(requestUUIDKey); val != nil {
 		uuid, _ := val.(uuid.UUID)
 		return uuid
@@ -149,7 +148,7 @@ func WithLogFields(ctx context.Context, newFields ...zap.Field) context.Context 
 	return context.WithValue(ctx, requestLogFields, accumulateLogFields(ctx, newFields))
 }
 
-func getLogFieldsFromCtx(ctx context.Context) []zap.Field {
+func logFieldsFromCtx(ctx context.Context) []zap.Field {
 	var fields []zap.Field
 	v := ctx.Value(requestLogFields)
 	if v != nil {
@@ -182,7 +181,7 @@ func GetScopeTagsFromCtx(ctx context.Context) map[string]string {
 }
 
 func accumulateLogFields(ctx context.Context, newFields []zap.Field) []zap.Field {
-	previousFields := getLogFieldsFromCtx(ctx)
+	previousFields := logFieldsFromCtx(ctx)
 	return append(previousFields, newFields...)
 }
 

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -104,11 +104,9 @@ func TestWithRequestFields(t *testing.T) {
 	ctx := withRequestUUID(context.TODO(), uid)
 
 	u := ctx.Value(requestUUIDKey)
-	u1, ok := u.(uuid.UUID)
 
 	assert.NotNil(t, ctx)
-	assert.Equal(t, uid, u1)
-	assert.True(t, ok)
+	assert.Equal(t, uid, u)
 }
 
 func TestGetRequestUUIDFromCtx(t *testing.T) {
@@ -225,65 +223,4 @@ func TestExtractLogField(t *testing.T) {
 	}
 	fields := extractors.ExtractLogFields(ctx)
 	assert.Equal(t, expected, fields)
-}
-
-func TestLoggerWithFields(t *testing.T) {
-	zapLoggerCore, logs := observer.New(zap.DebugLevel)
-	zapLogger := zap.New(zapLoggerCore)
-	fields := []zap.Field{
-		zap.String("key", "value"),
-	}
-	logger := newLoggerWithFields(zapLogger, fields)
-
-	var logMessages []observer.LoggedEntry
-
-	logger.Debug("msg", zap.String("argField", "argValue"))
-	logMessages = logs.TakeAll()
-	assert.Len(t, logMessages, 1)
-	assert.Equal(t, zap.DebugLevel, logMessages[0].Level)
-	assert.Equal(t, logMessages[0].Context[0].Key, "key")
-	assert.Equal(t, logMessages[0].Context[0].String, "value")
-	assert.Equal(t, logMessages[0].Context[1].Key, "argField")
-	assert.Equal(t, logMessages[0].Context[1].String, "argValue")
-
-	logger.Info("msg", zap.String("argField", "argValue"))
-	logMessages = logs.TakeAll()
-	assert.Len(t, logMessages, 1)
-	assert.Equal(t, zap.InfoLevel, logMessages[0].Level)
-	assert.Equal(t, logMessages[0].Context[0].Key, "key")
-	assert.Equal(t, logMessages[0].Context[0].String, "value")
-	assert.Equal(t, logMessages[0].Context[1].Key, "argField")
-	assert.Equal(t, logMessages[0].Context[1].String, "argValue")
-
-	logger.Warn("msg", zap.String("argField", "argValue"))
-	logMessages = logs.TakeAll()
-	assert.Len(t, logMessages, 1)
-	assert.Equal(t, zap.WarnLevel, logMessages[0].Level)
-	assert.Equal(t, logMessages[0].Context[0].Key, "key")
-	assert.Equal(t, logMessages[0].Context[0].String, "value")
-	assert.Equal(t, logMessages[0].Context[1].Key, "argField")
-	assert.Equal(t, logMessages[0].Context[1].String, "argValue")
-
-	logger.Error("msg", zap.String("argField", "argValue"))
-	logMessages = logs.TakeAll()
-	assert.Len(t, logMessages, 1)
-	assert.Equal(t, zap.ErrorLevel, logMessages[0].Level)
-	assert.Equal(t, logMessages[0].Context[0].Key, "key")
-	assert.Equal(t, logMessages[0].Context[0].String, "value")
-	assert.Equal(t, logMessages[0].Context[1].Key, "argField")
-	assert.Equal(t, logMessages[0].Context[1].String, "argValue")
-
-	assert.Panics(t, func() {
-		logger.Panic("msg", zap.String("argField", "argValue"))
-		logMessages = logs.TakeAll()
-		assert.Len(t, logMessages, 1)
-		assert.Equal(t, zap.ErrorLevel, logMessages[0].Level)
-		assert.Equal(t, logMessages[0].Context[0].Key, "key")
-		assert.Equal(t, logMessages[0].Context[0].String, "value")
-		assert.Equal(t, logMessages[0].Context[1].Key, "argField")
-		assert.Equal(t, logMessages[0].Context[1].String, "argValue")
-	})
-
-	ce := logger.Check(zap.DebugLevel, "msg")
-	assert.NotNil(t, ce)
 }

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -115,13 +115,13 @@ func TestGetRequestUUIDFromCtx(t *testing.T) {
 	uid := uuid.NewUUID()
 	ctx := withRequestUUID(context.TODO(), uid)
 
-	requestUUID := GetRequestUUIDFromCtx(ctx)
+	requestUUID := RequestUUIDFromCtx(ctx)
 
 	assert.NotNil(t, ctx)
 	assert.Equal(t, uid, requestUUID)
 
 	// Test Default Scenario where no uuid exists in the context
-	requestUUID = GetRequestUUIDFromCtx(context.TODO())
+	requestUUID = RequestUUIDFromCtx(context.TODO())
 	assert.Nil(t, requestUUID)
 }
 

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -100,7 +100,7 @@ func TestGetScopeTagsFromCtx(t *testing.T) {
 }
 
 func TestWithRequestFields(t *testing.T) {
-	uid := uuid.NewUUID()
+	uid := uuid.New()
 	ctx := withRequestUUID(context.TODO(), uid)
 
 	u := ctx.Value(requestUUIDKey)
@@ -112,7 +112,7 @@ func TestWithRequestFields(t *testing.T) {
 }
 
 func TestGetRequestUUIDFromCtx(t *testing.T) {
-	uid := uuid.NewUUID()
+	uid := uuid.New()
 	ctx := withRequestUUID(context.TODO(), uid)
 
 	requestUUID := RequestUUIDFromCtx(ctx)
@@ -122,7 +122,7 @@ func TestGetRequestUUIDFromCtx(t *testing.T) {
 
 	// Test Default Scenario where no uuid exists in the context
 	requestUUID = RequestUUIDFromCtx(context.TODO())
-	assert.Nil(t, requestUUID)
+	assert.Equal(t, "", requestUUID)
 }
 
 func TestWithRoutingDelegate(t *testing.T) {

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -200,13 +200,11 @@ func TestExtractScopeTag(t *testing.T) {
 	}}
 
 	expected := map[string]string{"region-id": "san_francisco"}
-	contextExtractors := &ContextExtractors{}
-	for _, scopeExtractor := range contextScopeExtractors {
-		contextExtractors.AddContextScopeTagsExtractor(scopeExtractor)
+	extractors := &ContextExtractors{
+		ScopeTagsExtractors: contextScopeExtractors,
 	}
 
-	contextExtractor := contextExtractors.MakeContextExtractor()
-	tags := contextExtractor.ExtractScopeTags(ctx)
+	tags := extractors.ExtractScopeTags(ctx)
 	assert.Equal(t, tags, expected)
 }
 
@@ -222,13 +220,10 @@ func TestExtractLogField(t *testing.T) {
 
 	var expected []zap.Field
 	expected = append(expected, zap.String("region-id", "san_francisco"))
-	contextExtractors := &ContextExtractors{}
-	for _, logFieldExtractor := range contextLogFieldsExtractor {
-		contextExtractors.AddContextLogFieldsExtractor(logFieldExtractor)
+	extractors := &ContextExtractors{
+		LogFieldsExtractors: contextLogFieldsExtractor,
 	}
-
-	contextExtractor := contextExtractors.MakeContextExtractor()
-	fields := contextExtractor.ExtractLogFields(ctx)
+	fields := extractors.ExtractLogFields(ctx)
 	assert.Equal(t, expected, fields)
 }
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -70,6 +70,11 @@ type Options struct {
 	LogWriter                 zapcore.WriteSyncer
 	GetContextScopeExtractors func() []ContextScopeTagsExtractor
 	GetContextFieldExtractors func() []ContextLogFieldsExtractor
+
+	// If present, request uuid is retrieved from the incoming request
+	// headers using the key, and put on the context. Otherwise, a new
+	// uuid is created for the incoming request.
+	RequestUUIDHeaderKey string
 }
 
 // Gateway type
@@ -105,7 +110,8 @@ type Gateway struct {
 	localHTTPServer *HTTPServer
 	tchannelServer  *tchannel.Channel
 	tracerCloser    io.Closer
-	//	- process reporter ?
+
+	requestUUIDHeaderKey string
 }
 
 // DefaultDependencies are the common dependencies for all modules
@@ -177,6 +183,8 @@ func CreateGateway(
 		ContextExtractor: extractors,
 		logWriter:        logWriter,
 		metricsBackend:   metricsBackend,
+
+		requestUUIDHeaderKey: opts.RequestUUIDHeaderKey,
 	}
 
 	gateway.setupConfig(config)

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -130,8 +130,8 @@ func CreateGateway(
 ) (*Gateway, error) {
 	var metricsBackend tally.CachedStatsReporter
 	var logWriter zapcore.WriteSyncer
-	var scopeExtractors []ContextScopeTagsExtractor
-	var fieldExtractors []ContextLogFieldsExtractor
+	var scopeTagsExtractors []ContextScopeTagsExtractor
+	var logFieldsExtractors []ContextLogFieldsExtractor
 	if opts == nil {
 		opts = &Options{}
 	}
@@ -142,21 +142,30 @@ func CreateGateway(
 		logWriter = opts.LogWriter
 	}
 
-	contextExtractors := &ContextExtractors{}
 	if opts.GetContextScopeExtractors != nil {
-		scopeExtractors = opts.GetContextScopeExtractors()
-
-		for _, scopeExtractor := range scopeExtractors {
-			contextExtractors.AddContextScopeTagsExtractor(scopeExtractor)
-		}
+		scopeTagsExtractors = opts.GetContextScopeExtractors()
+	} else {
+		scopeTagsExtractors = []ContextScopeTagsExtractor{GetEndpointRequestHeadersFromCtx}
 	}
 
 	if opts.GetContextFieldExtractors != nil {
-		fieldExtractors = opts.GetContextFieldExtractors()
-
-		for _, fieldExtractor := range fieldExtractors {
-			contextExtractors.AddContextLogFieldsExtractor(fieldExtractor)
+		logFieldsExtractors = opts.GetContextFieldExtractors()
+	} else {
+		logFieldsExtractors = []ContextLogFieldsExtractor{
+			func(ctx context.Context) []zap.Field {
+				reqHeaders := GetEndpointRequestHeadersFromCtx(ctx)
+				fields := make([]zap.Field, 0, len(reqHeaders))
+				for k, v := range reqHeaders {
+					fields = append(fields, zap.String(k, v))
+				}
+				return fields
+			},
 		}
+	}
+
+	extractors := &ContextExtractors{
+		ScopeTagsExtractors: scopeTagsExtractors,
+		LogFieldsExtractors: logFieldsExtractors,
 	}
 
 	gateway := &Gateway{
@@ -165,7 +174,7 @@ func CreateGateway(
 		ServiceName:      config.MustGetString("serviceName"),
 		WaitGroup:        &sync.WaitGroup{},
 		Config:           config,
-		ContextExtractor: contextExtractors.MakeContextExtractor(),
+		ContextExtractor: extractors,
 		logWriter:        logWriter,
 		metricsBackend:   metricsBackend,
 	}

--- a/runtime/http_client.go
+++ b/runtime/http_client.go
@@ -85,7 +85,7 @@ func NewHTTPClientContext(
 	for _, methodName := range methodNames {
 		loggers[methodName] = logger.With(
 			zap.String("clientID", clientID),
-			zap.String("methodName", methodName),
+			zap.String("clientMethod", methodName),
 		)
 	}
 	return &HTTPClient{

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -75,9 +75,8 @@ func NewServerHTTPRequest(
 	// put request log fields on context
 	logFields := []zap.Field{
 		zap.String(logFieldEndpointID, endpoint.EndpointName),
-		zap.String(logFieldHandlerID, endpoint.HandlerName),
+		zap.String(logFieldEndpointHandler, endpoint.HandlerName),
 	}
-	logger := newLoggerWithFields(endpoint.logger, logFields)
 
 	// put request scope tags on context
 	scopeTags := map[string]string{
@@ -115,7 +114,7 @@ func NewServerHTTPRequest(
 		Method:       httpRequest.Method,
 		Params:       params,
 		Header:       NewServerHTTPHeader(r.Header),
-		logger:       logger,
+		logger:       endpoint.logger,
 		scope:        scope,
 	}
 

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -34,7 +34,6 @@ import (
 	"github.com/buger/jsonparser"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
-	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 )
@@ -71,14 +70,10 @@ func NewServerHTTPRequest(
 	params url.Values,
 	endpoint *RouterEndpoint,
 ) *ServerHTTPRequest {
-	// put request uuid and endpoint name on context
-	requestUUID := uuid.NewUUID()
-	ctx := withRequestUUID(r.Context(), requestUUID)
-	ctx = WithEndpointField(ctx, endpoint.EndpointName)
+	ctx := r.Context()
 
 	// put request log fields on context
 	logFields := []zap.Field{
-		zap.String(logFieldRequestUUID, requestUUID.String()),
 		zap.String(logFieldEndpointID, endpoint.EndpointName),
 		zap.String(logFieldHandlerID, endpoint.HandlerName),
 	}

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1511,7 +1511,7 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 		ContextLogger: bgateway.ActualGateway.ContextLogger,
 		Tracer:        bgateway.ActualGateway.Tracer,
 	}
-	bgateway.ActualGateway.HTTPRouter.Handle(
+	err = bgateway.ActualGateway.HTTPRouter.Handle(
 		"GET", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
 			bgateway.ActualGateway.ContextExtractor,
 			deps,
@@ -1525,6 +1525,7 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 			},
 		).HandleRequest),
 	)
+	assert.NoError(t, err)
 
 	_, err = gateway.MakeRequest("GET", "/foo?bar=bar", nil, nil)
 	assert.NoError(t, err)
@@ -1549,19 +1550,18 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 	}
 
 	expectedValues := map[string]interface{}{
-		"msg":                            "Finished an incoming server HTTP request",
-		"env":                            "test",
-		"level":                          "info",
-		"zone":                           "unknown",
-		"service":                        "example-gateway",
-		"method":                         "GET",
-		"pathname":                       "/foo?bar=bar",
-		"statusCode":                     float64(200),
-		"Response-Header-Content-Type":   "application/json",
-		"Request-Header-Accept-Encoding": "gzip",
-		"Request-Header-User-Agent":      "Go-http-client/1.1",
-		"handlerID":                      "foo",
-		"endpointID":                     "foo",
+		"msg":             "Finished an incoming server HTTP request",
+		"env":             "test",
+		"level":           "info",
+		"zone":            "unknown",
+		"service":         "example-gateway",
+		"method":          "GET",
+		"pathname":        "/foo?bar=bar",
+		"statusCode":      float64(200),
+		"Accept-Encoding": "gzip",
+		"User-Agent":      "Go-http-client/1.1",
+		"handlerID":       "foo",
+		"endpointID":      "foo",
 	}
 	for actualKey, actualValue := range tags {
 		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1560,7 +1560,7 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 		"statusCode":      float64(200),
 		"Accept-Encoding": "gzip",
 		"User-Agent":      "Go-http-client/1.1",
-		"handlerID":       "foo",
+		"endpointHandler": "foo",
 		"endpointID":      "foo",
 	}
 	for actualKey, actualValue := range tags {

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -85,7 +85,7 @@ func TestInvalidStatusCode(t *testing.T) {
 
 	assert.Equal(t, "true", string(bytes))
 
-	logLines := bgateway.Logs("error", "Could not emit statusCode metric")
+	logLines := bgateway.Logs("error", "Unknown status code")
 
 	assert.NotNil(t, logLines)
 	assert.Equal(t, 1, len(logLines))

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -31,6 +31,16 @@ import (
 	netContext "golang.org/x/net/context"
 )
 
+const (
+	logFieldClientID = "clientID"
+	// thrift service::method of client thrift spec
+	logFieldClientThriftMethod = "clientThriftMethod"
+	// the backend service corresponding to the client
+	logFieldClientService = "clientService"
+	// the method name for a particular client method call
+	logFieldClientMethod = "clientMethod"
+)
+
 // TChannelClientOption is used when creating a new TChannelClient
 type TChannelClientOption struct {
 	ServiceName       string
@@ -102,10 +112,10 @@ func NewTChannelClientContext(
 
 	for serviceMethod, methodName := range opt.MethodNames {
 		loggers[serviceMethod] = logger.With(
-			zap.String("clientID", opt.ClientID),
-			zap.String("methodName", methodName),
-			zap.String("serviceName", opt.ServiceName),
-			zap.String("serviceMethod", serviceMethod),
+			zap.String(logFieldClientID, opt.ClientID),
+			zap.String(logFieldClientService, opt.ServiceName),
+			zap.String(logFieldClientMethod, methodName),
+			zap.String(logFieldClientThriftMethod, serviceMethod),
 		)
 	}
 

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 )
 
 func TestNilCallReferenceForLogger(t *testing.T) {
@@ -41,13 +42,18 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 		reqHeaders:    headers,
 		resHeaders:    headers,
 	}
+	ctx := context.TODO()
+	ctx = WithLogFields(ctx, zap.String("foo", "bar"))
 
-	fields := outboundCall.logFields(context.TODO())
+	fields := outboundCall.logFields(ctx)
 
 	// one field for each of the:
 	// timestamp-started, timestamp-finished, remoteAddr, requestHeader, responseHeader
-	assert.Len(t, fields, 5)
+	assert.Len(t, fields, 4)
 	assert.Equal(t, fields[0].Key, "remoteAddr")
 	// nil call should cause remoteAddr to be set to unknown
 	assert.Equal(t, fields[0].String, "unknown")
+
+	assert.Equal(t, fields[3].Key, "foo")
+	assert.Equal(t, fields[3].String, "bar")
 }

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -21,6 +21,7 @@
 package zanzibar
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -41,7 +42,7 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 		resHeaders:    headers,
 	}
 
-	fields := outboundCall.logFields()
+	fields := outboundCall.logFields(context.TODO())
 
 	// one field for each of the:
 	// timestamp-started, timestamp-finished, remoteAddr, requestHeader, responseHeader

--- a/runtime/tchannel_inbound_call.go
+++ b/runtime/tchannel_inbound_call.go
@@ -84,7 +84,7 @@ func (c *tchannelInboundCall) logFields(ctx context.Context) []zap.Field {
 		zap.Time("timestamp-started", c.startTime),
 		zap.Time("timestamp-finished", c.finishTime),
 	}
-	fields = append(fields, getLogFieldsFromCtx(ctx)...)
+	fields = append(fields, logFieldsFromCtx(ctx)...)
 	return fields
 }
 

--- a/runtime/tchannel_inbound_call.go
+++ b/runtime/tchannel_inbound_call.go
@@ -68,7 +68,7 @@ func (c *tchannelInboundCall) finish(ctx context.Context, err error) {
 	c.scope.Timer(endpointLatency).Record(c.finishTime.Sub(c.startTime))
 	c.scope.Counter(endpointRequest).Inc(1)
 
-	fields := c.logFields()
+	fields := c.logFields(ctx)
 	if err == nil {
 		c.logger.Info("Finished an incoming server TChannel request", fields...)
 	} else {
@@ -77,21 +77,14 @@ func (c *tchannelInboundCall) finish(ctx context.Context, err error) {
 	}
 }
 
-func (c *tchannelInboundCall) logFields() []zap.Field {
+func (c *tchannelInboundCall) logFields(ctx context.Context) []zap.Field {
 	fields := []zap.Field{
 		zap.String("remoteAddr", c.call.RemotePeer().HostPort),
 		zap.String("calling-service", c.call.CallerName()),
 		zap.Time("timestamp-started", c.startTime),
 		zap.Time("timestamp-finished", c.finishTime),
 	}
-
-	for k, v := range c.reqHeaders {
-		fields = append(fields, zap.String("Request-Header-"+k, v))
-	}
-	for k, v := range c.resHeaders {
-		fields = append(fields, zap.String("Response-Header-"+k, v))
-	}
-
+	fields = append(fields, getLogFieldsFromCtx(ctx)...)
 	return fields
 }
 

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -88,6 +88,7 @@ func (c *tchannelOutboundCall) logFields(ctx context.Context) []zapcore.Field {
 		zap.Time("timestamp-finished", c.finishTime),
 	}
 
+	// TODO: log client request headers and differentiate with endpoint headers
 	fields = append(fields, logFieldsFromCtx(ctx)...)
 	return fields
 }

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -66,6 +66,7 @@ func TestCallMetrics(t *testing.T) {
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	headers := make(map[string]string)
+	headers["x-uuid"] = "uuid"
 	headers["regionname"] = "san_francisco"
 	headers["device"] = "ios"
 	headers["deviceversion"] = "carbon"
@@ -208,6 +209,7 @@ func TestCallMetrics(t *testing.T) {
 		"url",
 		"timestamp-finished",
 		"Request-Header-Uber-Trace-Id",
+		"Request-Header-X-Request-Uuid",
 		"Response-Header-Content-Length",
 		"timestamp-started",
 		"Response-Header-Date",
@@ -229,22 +231,23 @@ func TestCallMetrics(t *testing.T) {
 		"Response-Header-Content-Type": "text/plain; charset=utf-8",
 
 		"level":                      "info",
-		"methodName":                 "Normal",
-		"method":                     "POST",
+		"clientMethod":               "Normal",
+		"clientHTTPMethod":           "POST",
 		"Request-Header-X-Client-Id": "bar",
 
-		"zone":          "unknown",
-		"service":       "example-gateway",
-		"endpointID":    "bar",
-		"handlerID":     "normal",
-		"regionname":    "san_francisco",
-		"device":        "ios",
-		"deviceversion": "carbon",
+		"zone":            "unknown",
+		"service":         "example-gateway",
+		"endpointID":      "bar",
+		"endpointHandler": "normal",
+		"x-uuid":          "uuid",
+		"regionname":      "san_francisco",
+		"device":          "ios",
+		"deviceversion":   "carbon",
 	}
 	for actualKey, actualValue := range logMsg {
-		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected field %q", actualKey)
 	}
 	for expectedKey, expectedValue := range expectedValues {
-		assert.Equal(t, expectedValue, logMsg[expectedKey], "unexpected header %q", expectedKey)
+		assert.Equal(t, expectedValue, logMsg[expectedKey], "unexpected field %q", expectedKey)
 	}
 }

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -75,8 +75,11 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 
 	ctx := context.Background()
 	reqHeaders := map[string]string{
-		"x-token": "token",
-		"x-uuid":  "uuid",
+		"x-token":       "token",
+		"x-uuid":        "uuid",
+		"Regionname":    "sf",
+		"Device":        "ios",
+		"Deviceversion": "1.0",
 	}
 	args := &endpointsBaz.SimpleService_Call_Args{
 		Arg: &endpointsBaz.BazRequest{
@@ -107,7 +110,7 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	assert.Equal(t, 1, len(allLogs["Finished an outgoing client TChannel request"]))
 	assert.Equal(t, 1, len(allLogs["Finished an incoming server TChannel request"]))
 
-	tags := allLogs["Finished an incoming server TChannel request"][0]
+	logs := allLogs["Finished an incoming server TChannel request"][0]
 	dynamicHeaders := []string{
 		"requestUUID",
 		"timestamp-started",
@@ -118,65 +121,71 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 		"pid",
 	}
 	for _, dynamicValue := range dynamicHeaders {
-		assert.Contains(t, tags, dynamicValue)
-		delete(tags, dynamicValue)
+		assert.Contains(t, logs, dynamicValue)
+		delete(logs, dynamicValue)
 	}
 
-	expectedValues := map[string]interface{}{
-		"level":                           "info",
-		"env":                             "test",
-		"service":                         "example-gateway",
-		"msg":                             "Finished an incoming server TChannel request",
-		"endpointID":                      "bazTChannel",
-		"handlerID":                       "call",
-		"method":                          "SimpleService::Call",
-		"Request-Header-x-token":          "token",
-		"Request-Header-x-uuid":           "uuid",
-		"Response-Header-some-res-header": "something",
-		"calling-service":                 "test-gateway",
-		"zone":                            "unknown",
+	expectedValues := map[string]string{
+		"level":                "info",
+		"msg":                  "Finished an incoming server TChannel request",
+		"env":                  "test",
+		"service":              "example-gateway",
+		"endpointID":           "bazTChannel",
+		"endpointHandler":      "call",
+		"endpointThriftMethod": "SimpleService::Call",
+		"x-uuid":               "uuid",
+		"calling-service":      "test-gateway",
+		"zone":                 "unknown",
+		"regionname":           "sf",
+		"device":               "ios",
+		"deviceversion":        "1.0",
 	}
-	for actualKey, actualValue := range tags {
-		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+	for actualKey, actualValue := range logs {
+		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected field %q", actualKey)
 	}
 	for expectedKey, expectedValue := range expectedValues {
-		assert.Equal(t, expectedValue, tags[expectedKey], "unexpected header %q", expectedKey)
+		assert.Equal(t, expectedValue, logs[expectedKey], "unexpected field %q", expectedKey)
 	}
 
-	tags = allLogs["Finished an outgoing client TChannel request"][0]
+	logs = allLogs["Finished an outgoing client TChannel request"][0]
 	dynamicHeaders = []string{
+		"requestUUID",
 		"remoteAddr",
 		"timestamp-started",
 		"ts",
 		"hostname",
 		"pid",
 		"timestamp-finished",
-		"Request-Header-$tracing$uber-trace-id",
 	}
 	for _, dynamicValue := range dynamicHeaders {
-		assert.Contains(t, tags, dynamicValue)
-		delete(tags, dynamicValue)
+		assert.Contains(t, logs, dynamicValue)
+		delete(logs, dynamicValue)
 	}
 
-	expectedValues = map[string]interface{}{
-		"msg":                             "Finished an outgoing client TChannel request",
-		"env":                             "test",
-		"clientID":                        "baz",
-		"level":                           "info",
-		"serviceName":                     "bazService",
-		"serviceMethod":                   "SimpleService::call",
-		"methodName":                      "Call",
-		"zone":                            "unknown",
-		"service":                         "example-gateway",
-		"Request-Header-x-uuid":           "uuid",
-		"Request-Header-x-token":          "token",
-		"Response-Header-some-res-header": "something",
+	expectedValues = map[string]string{
+		"msg":                  "Finished an outgoing client TChannel request",
+		"env":                  "test",
+		"level":                "info",
+		"zone":                 "unknown",
+		"service":              "example-gateway",
+		"clientID":             "baz",
+		"clientService":        "bazService",
+		"clientThriftMethod":   "SimpleService::call",
+		"clientMethod":         "Call",
+		"endpointID":           "bazTChannel",
+		"endpointThriftMethod": "SimpleService::Call",
+		"endpointHandler":      "call",
+		"x-uuid":               "uuid",
+		//"Response-Header-some-res-header": "something",
+		"deviceversion": "1.0",
+		"device":        "ios",
+		"regionname":    "sf",
 	}
-	for actualKey, actualValue := range tags {
-		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected header %q", actualKey)
+	for actualKey, actualValue := range logs {
+		assert.Equal(t, expectedValues[actualKey], actualValue, "unexpected field %q", actualKey)
 	}
 	for expectedKey, expectedValue := range expectedValues {
-		assert.Equal(t, expectedValue, tags[expectedKey], "unexpected header %q", expectedKey)
+		assert.Equal(t, expectedValue, logs[expectedKey], "unexpected field %q", expectedKey)
 	}
 }
 

--- a/test/lib/test_backend/test_tchannel_backend.go
+++ b/test/lib/test_backend/test_tchannel_backend.go
@@ -144,7 +144,6 @@ func CreateTChannelBackend(port int32, serviceName string) (*TestTChannelBackend
 		return nil, err
 	}
 
-	contextExtractors := &zanzibar.ContextExtractors{}
 	scopeExtractor := func(ctx context.Context) map[string]string {
 		tags := map[string]string{}
 		headers := zanzibar.GetEndpointRequestHeadersFromCtx(ctx)
@@ -154,13 +153,14 @@ func CreateTChannelBackend(port int32, serviceName string) (*TestTChannelBackend
 
 		return tags
 	}
+	contextExtractors := &zanzibar.ContextExtractors{
+		ScopeTagsExtractors: []zanzibar.ContextScopeTagsExtractor{scopeExtractor},
+	}
 
-	contextExtractors.AddContextScopeTagsExtractor(scopeExtractor)
-	extractor := contextExtractors.MakeContextExtractor()
 	gateway := zanzibar.Gateway{
 		Logger:           testLogger,
 		RootScope:        tally.NoopScope,
-		ContextExtractor: extractor,
+		ContextExtractor: contextExtractors,
 		ContextMetrics:   zanzibar.NewContextMetrics(tally.NoopScope),
 	}
 

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -206,7 +206,6 @@ func CreateGateway(
 		},
 	)
 
-	contextExtractors := &zanzibar.ContextExtractors{}
 	scopeExtractor := func(ctx context.Context) map[string]string {
 		tags := map[string]string{}
 		headers := zanzibar.GetEndpointRequestHeadersFromCtx(ctx)
@@ -217,8 +216,9 @@ func CreateGateway(
 		return tags
 	}
 
-	contextExtractors.AddContextScopeTagsExtractor(scopeExtractor)
-	extractor := contextExtractors.MakeContextExtractor()
+	extractors := &zanzibar.ContextExtractors{
+		ScopeTagsExtractors: []zanzibar.ContextScopeTagsExtractor{scopeExtractor},
+	}
 
 	testGateway := &ChildProcessGateway{
 		channel:     channel,
@@ -239,7 +239,7 @@ func CreateGateway(
 		backendsHTTP:     backendsHTTP,
 		backendsTChannel: backendsTChannel,
 		MetricsWaitGroup: lib.WaitAtLeast{},
-		ContextExtractor: extractor,
+		ContextExtractor: extractors,
 		ContextMetrics:   zanzibar.NewContextMetrics(tally.NoopScope),
 	}
 


### PR DESCRIPTION
This PR does a few things:
- log endpoint request headers with user-provided filter function
- inherent request uuid if it is present in upstream request
- propogate endpoint request uuid to client request uuid
- rename a few log fields to avoid ambiguity