### PR TITLE
Fallback http client request body serialization to json.Marshal

### DIFF
--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -110,8 +110,8 @@ func (req *ClientHTTPRequest) CheckHeaders(expected []string) error {
 }
 
 // WriteJSON materialize the HTTP request with given method, url, headers and body.
-// Body is serialized to JSON bytes using the custom MarshalJSON method if it is defined,
-// otherwise it is serialized via the Go stdlib json.Marshal function.
+// Body is serialized to JSON bytes using the stdlib json.Marshal function, which
+// calls the `MarshalJSON` method if the body implements the Marshaler interface.
 func (req *ClientHTTPRequest) WriteJSON(
 	method, url string,
 	headers map[string]string,
@@ -120,16 +120,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 	var httpReq *http.Request
 	var httpErr error
 	if body != nil {
-		var rawBody []byte
-		var err error
-
-		mb, ok := body.(json.Marshaler)
-		if ok {
-			rawBody, err = mb.MarshalJSON()
-		} else {
-			rawBody, err = json.Marshal(body)
-		}
-
+		rawBody, err := json.Marshal(body)
 		if err != nil {
 			req.Logger.Error("Could not serialize request json", zap.Error(err))
 			return errors.Wrapf(

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -78,7 +78,7 @@ func TestMakingClientWriteJSONWithBadJSON(t *testing.T) {
 	err = req.WriteJSON("GET", "/foo", nil, &failingJsonObj{})
 	assert.NotNil(t, err)
 	assert.Equal(t,
-		"Could not serialize clientID.DoStuff request json: cannot serialize",
+		"Could not serialize clientID.DoStuff request json: json: error calling MarshalJSON for type *zanzibar_test.failingJsonObj: cannot serialize",
 		err.Error(),
 	)
 

--- a/runtime/client_http_request_write_json_test.go
+++ b/runtime/client_http_request_write_json_test.go
@@ -23,7 +23,6 @@ package zanzibar
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -54,17 +53,15 @@ func (wjs *writeJSONSuit) SetupSuite() {
 
 }
 
-type myType struct {
-	Field string
-}
+type myType struct{}
 
 func (m *myType) MarshalJSON() ([]byte, error) {
-	s := fmt.Sprintf("{\"field\":\"%s\"}", m.Field)
+	s := "{\"field\":\"hello\"}"
 	return []byte(s), nil
 }
 
 func (wjs *writeJSONSuit) TestWriteJSONCustomMarshaler() {
-	m := &myType{"hello"}
+	m := &myType{}
 	err := wjs.req.WriteJSON("POST", "test", nil, m)
 	assert.NoError(wjs.T(), err)
 	assert.Equal(wjs.T(), wjs.expectedRawBody, wjs.req.rawBody)
@@ -81,7 +78,7 @@ func (m *myTypeError) MarshalJSON() ([]byte, error) {
 func (wjs *writeJSONSuit) TestWriteJSONCustomMarshalerError() {
 	m := &myTypeError{"hello"}
 	err := wjs.req.WriteJSON("POST", "test", nil, m)
-	assert.EqualError(wjs.T(), err, "Could not serialize foo.bar request json: can not marshal")
+	assert.EqualError(wjs.T(), err, "Could not serialize foo.bar request json: json: error calling MarshalJSON for type *zanzibar.myTypeError: can not marshal")
 }
 
 type myTypeDefault struct {

--- a/runtime/client_http_request_write_json_test.go
+++ b/runtime/client_http_request_write_json_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+)
+
+type writeJSONSuit struct {
+	suite.Suite
+	req             *ClientHTTPRequest
+	expectedRawBody []byte
+}
+
+func (wjs *writeJSONSuit) SetupSuite() {
+	client := NewHTTPClient(
+		zap.NewNop(),
+		tally.NewTestScope("", nil),
+		"foo",
+		[]string{"bar"},
+		"test",
+		nil,
+		time.Microsecond*time.Duration(20),
+	)
+	wjs.req = NewClientHTTPRequest(context.TODO(), "foo", "bar", client)
+	wjs.expectedRawBody = []byte("{\"field\":\"hello\"}")
+
+}
+
+type myType struct {
+	Field string
+}
+
+func (m *myType) MarshalJSON() ([]byte, error) {
+	s := fmt.Sprintf("{\"field\":\"%s\"}", m.Field)
+	return []byte(s), nil
+}
+
+func (wjs *writeJSONSuit) TestWriteJSONCustomMarshaler() {
+	m := &myType{"hello"}
+	err := wjs.req.WriteJSON("POST", "test", nil, m)
+	assert.NoError(wjs.T(), err)
+	assert.Equal(wjs.T(), wjs.expectedRawBody, wjs.req.rawBody)
+}
+
+type myTypeError struct {
+	Field string
+}
+
+func (m *myTypeError) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("can not marshal")
+}
+
+func (wjs *writeJSONSuit) TestWriteJSONCustomMarshalerError() {
+	m := &myTypeError{"hello"}
+	err := wjs.req.WriteJSON("POST", "test", nil, m)
+	assert.EqualError(wjs.T(), err, "Could not serialize foo.bar request json: can not marshal")
+}
+
+type myTypeDefault struct {
+	Field string `json:"field"`
+}
+
+func (wjs *writeJSONSuit) TestWriteJSONDefaultMarshaler() {
+	m := &myTypeDefault{"hello"}
+	err := wjs.req.WriteJSON("POST", "test", nil, m)
+	assert.NoError(wjs.T(), err)
+	assert.Equal(wjs.T(), wjs.expectedRawBody, wjs.req.rawBody)
+}
+
+func TestWriteJSONSuite(t *testing.T) {
+	suite.Run(t, new(writeJSONSuit))
+}


### PR DESCRIPTION
This PR allows http client request body to be serialized using erither:
- custom `MarshalJSON` method if the body type implements the `json.Marshaler` interface
- default `json.Marshal` function in the std lib