### PR TITLE
Add support for physical generated directory

### DIFF
--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -27,8 +27,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -160,13 +158,6 @@ func TestExampleService(t *testing.T) {
 
 	currentDir := getTestDirName()
 	testServiceDir := path.Join(currentDir, "test-service")
-
-	defer func() {
-		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
-		if err != nil {
-			panic(errors.Wrap(err, "error removing serialized module tree"))
-		}
-	}()
 
 	// TODO: this should return a collection of errors if they occur
 	instances, err := moduleSystem.GenerateBuild(
@@ -427,347 +418,6 @@ func TestExampleService(t *testing.T) {
 	}
 }
 
-func TestExampleServiceIncremental(t *testing.T) {
-	moduleSystem := NewModuleSystem(map[string][]string{}, map[string][]string{})
-	var err error
-
-	err = moduleSystem.RegisterClass(ModuleClass{
-		Name:       "client",
-		NamePlural: "clients",
-		ClassType:  MultiModule,
-	})
-	if err != nil {
-		t.Errorf("Unexpected error registering client class: %s", err)
-	}
-
-	err = moduleSystem.RegisterClassType(
-		"client",
-		"http",
-		&TestHTTPClientGenerator{},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error registering http client class type: %s", err)
-	}
-
-	err = moduleSystem.RegisterClassType(
-		"client",
-		"tchannel",
-		&TestTChannelClientGenerator{},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error registering tchannel client class type: %s", err)
-	}
-
-	err = moduleSystem.RegisterClass(ModuleClass{
-		Name:       "endpoint",
-		NamePlural: "endpoints",
-		ClassType:  MultiModule,
-		DependsOn:  []string{"client"},
-	})
-	if err != nil {
-		t.Errorf("Unexpected error registering endpoint class: %s", err)
-	}
-
-	err = moduleSystem.RegisterClassType(
-		"endpoint",
-		"http",
-		&TestHTTPEndpointGenerator{},
-	)
-	if err != nil {
-		t.Errorf("Unexpected error registering http client class type: %s", err)
-	}
-
-	err = moduleSystem.RegisterClassType(
-		"endpoint",
-		"http",
-		&TestHTTPEndpointGenerator{},
-	)
-	if err == nil {
-		t.Errorf("Expected double creation of http endpoint to error")
-	}
-
-	err = moduleSystem.RegisterClass(ModuleClass{
-		Name:       "client",
-		NamePlural: "clients",
-		ClassType:  MultiModule,
-	})
-	if err == nil {
-		t.Errorf("Expected double definition of client class to error")
-	}
-
-	currentDir := getTestDirName()
-	testServiceDir := path.Join(currentDir, "test-service")
-
-	defer func() {
-		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
-		if err != nil {
-			panic(errors.Wrap(err, "error removing serialized module tree"))
-		}
-	}()
-
-	instances, err := moduleSystem.GenerateIncrementalBuild(
-		"github.com/uber/zanzibar/codegen/test-service",
-		testServiceDir,
-		path.Join(testServiceDir, "build"),
-		[]ModuleDependency{
-			{
-				ClassName:    "client",
-				InstanceName: "example",
-			},
-		},
-		true,
-	)
-	if err != nil {
-		t.Errorf("Unexpected error generating build %s", err)
-	}
-
-	expectedClientDependency := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "client",
-		ClassType:     "tchannel",
-		Directory:     "clients/example-dependency",
-		InstanceName:  "example-dependency",
-		JSONFileName:  "",
-		YAMLFileName:  "client-config.yaml",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewClient",
-			ExportType:            "Client",
-			GeneratedPackageAlias: "exampledependencyClientGenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/clients/example-dependency",
-			IsExportGenerated:     true,
-			PackageAlias:          "exampledependencyClientStatic",
-			PackageName:           "exampledependencyClient",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/clients/example-dependency",
-		},
-		Dependencies:          []ModuleDependency{},
-		ResolvedDependencies:  map[string][]*ModuleInstance{},
-		RecursiveDependencies: map[string][]*ModuleInstance{},
-	}
-
-	expectedClientInstance := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "client",
-		ClassType:     "http",
-		Directory:     "clients/example",
-		InstanceName:  "example",
-		JSONFileName:  "",
-		YAMLFileName:  "client-config.yaml",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewClient",
-			ExportType:            "Client",
-			GeneratedPackageAlias: "exampleClientGenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/clients/example",
-			IsExportGenerated:     true,
-			PackageAlias:          "exampleClientStatic",
-			PackageName:           "exampleClient",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/clients/example",
-		},
-		Dependencies: []ModuleDependency{
-			{
-				ClassName:    "client",
-				InstanceName: "example-dependency",
-			},
-		},
-		ResolvedDependencies: map[string][]*ModuleInstance{
-			"client": {
-				&expectedClientDependency,
-			},
-		},
-		RecursiveDependencies: map[string][]*ModuleInstance{
-			"client": {
-				&expectedClientDependency,
-			},
-		},
-	}
-
-	expectedEmbeddedClient := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "client",
-		ClassType:     "http",
-		Directory:     "endpoints/health/embedded-client",
-		InstanceName:  "embedded-client",
-		JSONFileName:  "",
-		YAMLFileName:  "client-config.yaml",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewClient",
-			ExportType:            "Client",
-			GeneratedPackageAlias: "embeddedClientGenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/endpoints/health/embedded-client",
-			IsExportGenerated:     true,
-			PackageAlias:          "embeddedClientStatic",
-			PackageName:           "embeddedClient",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/endpoints/health/embedded-client",
-		},
-		Dependencies:          []ModuleDependency{},
-		ResolvedDependencies:  map[string][]*ModuleInstance{},
-		RecursiveDependencies: map[string][]*ModuleInstance{},
-	}
-
-	expectedHealthEndpointInstance := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "endpoint",
-		ClassType:     "http",
-		Directory:     "endpoints/health",
-		InstanceName:  "health",
-		JSONFileName:  "endpoint-config.json",
-		YAMLFileName:  "",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewEndpoint",
-			ExportType:            "Endpoint",
-			GeneratedPackageAlias: "healthendpointgenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/endpoints/health",
-			IsExportGenerated:     true,
-			PackageAlias:          "healthendpointstatic",
-			PackageName:           "healthendpoint",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/endpoints/health",
-		},
-		Dependencies: []ModuleDependency{
-			{
-				ClassName:    "client",
-				InstanceName: "example",
-			},
-		},
-		ResolvedDependencies: map[string][]*ModuleInstance{
-			"client": {
-				&expectedClientInstance,
-			},
-		},
-		RecursiveDependencies: map[string][]*ModuleInstance{
-			"client": {
-				// Note that the dependencies are ordered
-				&expectedClientDependency,
-				&expectedClientInstance,
-			},
-		},
-	}
-
-	expectedFooEndpointInstance := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "endpoint",
-		ClassType:     "http",
-		Directory:     "more-endpoints/foo",
-		InstanceName:  "more-endpoints/foo",
-		JSONFileName:  "",
-		YAMLFileName:  "endpoint-config.yaml",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewEndpoint",
-			ExportType:            "Endpoint",
-			GeneratedPackageAlias: "fooendpointgenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/more-endpoints/foo",
-			IsExportGenerated:     true,
-			PackageAlias:          "fooendpointstatic",
-			PackageName:           "fooendpoint",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/more-endpoints/foo",
-		},
-		Dependencies: []ModuleDependency{
-			{
-				ClassName:    "client",
-				InstanceName: "example",
-			},
-		},
-		ResolvedDependencies: map[string][]*ModuleInstance{
-			"client": {
-				&expectedClientInstance,
-			},
-		},
-		RecursiveDependencies: map[string][]*ModuleInstance{
-			"client": {
-				// Note that the dependencies are ordered
-				&expectedClientDependency,
-				&expectedClientInstance,
-			},
-		},
-	}
-
-	expectedBarEndpointInstance := ModuleInstance{
-		BaseDirectory: testServiceDir,
-		ClassName:     "endpoint",
-		ClassType:     "http",
-		Directory:     "another/bar",
-		InstanceName:  "bar",
-		JSONFileName:  "",
-		YAMLFileName:  "endpoint-config.yaml",
-		PackageInfo: &PackageInfo{
-			ExportName:            "NewEndpoint",
-			ExportType:            "Endpoint",
-			GeneratedPackageAlias: "barendpointgenerated",
-			GeneratedPackagePath:  "github.com/uber/zanzibar/codegen/test-service/build/another/bar",
-			IsExportGenerated:     true,
-			PackageAlias:          "barendpointstatic",
-			PackageName:           "barendpoint",
-			PackagePath:           "github.com/uber/zanzibar/codegen/test-service/another/bar",
-		},
-		Dependencies: []ModuleDependency{
-			{
-				ClassName:    "client",
-				InstanceName: "example",
-			},
-		},
-		ResolvedDependencies: map[string][]*ModuleInstance{
-			"client": {
-				&expectedClientInstance,
-			},
-		},
-		RecursiveDependencies: map[string][]*ModuleInstance{
-			"client": {
-				// Note that the dependencies are ordered
-				&expectedClientDependency,
-				&expectedClientInstance,
-			},
-		},
-	}
-
-	expectedClients := []*ModuleInstance{
-		&expectedClientInstance,
-		&expectedClientDependency,
-		&expectedEmbeddedClient,
-	}
-	expectedEndpoints := []*ModuleInstance{
-		&expectedHealthEndpointInstance,
-		&expectedFooEndpointInstance,
-		&expectedBarEndpointInstance,
-	}
-
-	for className, classInstances := range instances {
-		if className == "client" {
-			if len(classInstances) != len(expectedClients) {
-				t.Errorf(
-					"Expected %d client class instance but found %d",
-					len(expectedClients),
-					len(classInstances),
-				)
-			}
-
-			for i, instance := range expectedClients {
-				compareInstances(t, instance, expectedClients[i])
-			}
-		} else if className == "endpoint" {
-			if len(classInstances) != len(expectedEndpoints) {
-				t.Errorf(
-					"Expected %d endpoint class instance but found %d",
-					len(expectedEndpoints),
-					len(classInstances),
-				)
-			}
-
-			for i, instance := range classInstances {
-				compareInstances(t, instance, expectedEndpoints[i])
-
-				clientDependency := instance.ResolvedDependencies["client"][0]
-				clientSpec := clientDependency.GeneratedSpec().(*TestClientSpec)
-
-				if clientSpec.Info != instance.ClassType {
-					t.Errorf(
-						"Expected client spec info on generated client spec",
-					)
-				}
-			}
-		} else {
-			t.Errorf("Unexpected resolved class type %s", className)
-		}
-	}
-}
-
 func TestDefaultDependency(t *testing.T) {
 	moduleSystem := NewModuleSystem(
 		map[string][]string{
@@ -823,13 +473,6 @@ func TestDefaultDependency(t *testing.T) {
 
 	currentDir := getTestDirName()
 	testServiceDir := path.Join(currentDir, "test-service")
-
-	defer func() {
-		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
-		if err != nil {
-			panic(errors.Wrap(err, "error removing serialized module tree"))
-		}
-	}()
 
 	instances, err := moduleSystem.GenerateBuild(
 		"github.com/uber/zanzibar/codegen/test-service",
@@ -951,13 +594,6 @@ func TestSingleDefaultDependency(t *testing.T) {
 
 	currentDir := getTestDirName()
 	testServiceDir := path.Join(currentDir, "test-service")
-
-	defer func() {
-		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
-		if err != nil {
-			panic(errors.Wrap(err, "error removing serialized module tree"))
-		}
-	}()
 
 	instances, err := moduleSystem.GenerateBuild(
 		"github.com/uber/zanzibar/codegen/test-service",
@@ -1827,12 +1463,6 @@ func TestModuleSearchDuplicateGlobs(t *testing.T) {
 	currentDir := getTestDirName()
 	testServiceDir := path.Join(currentDir, "test-service")
 
-	defer func() {
-		err := os.Remove(path.Join(testServiceDir, "build", serializedModuleTreePath))
-		if err != nil {
-			panic(errors.Wrap(err, "error removing serialized module tree"))
-		}
-	}()
 	instances, err := moduleSystem.GenerateBuild(
 		"github.com/uber/zanzibar/codegen/test-service",
 		testServiceDir,

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,11 +2,6 @@
 
 set -e
 
-function cleanup {
-	rm -f $PREFIX/build/zanzibar.tree
-}
-trap cleanup EXIT
-
 PREFIX=examples/example-gateway
 ANNOPREFIX=${1:-zanzibar}
 


### PR DESCRIPTION
Decouple the directory in which the output code is generated from the
targetGenDir which is also used to form the generated package name.

This preserves the existing behavior of the deprecated `GenerateBuild` function to build everything, while moving the logic to decide what folder to output into of the core generation logic. 

Removed `serializedModuleTree[Path]` because it's no longer needed. 