### PR TITLE
Temporary solution to support running tests with bazel

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1992,6 +1992,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
 
 		// This is a temporary solution for running tests using bazel
+		// see https://docs.bazel.build/versions/master/test-encyclopedia.html for relevant env vars
 		// TODO: need long term solution to avoid hardcoding bazel specifics
 		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
 
@@ -2131,7 +2132,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 5188, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 5283, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1988,8 +1988,18 @@ type mockService struct {
 // - "config/test.yaml" where current dir is the project root
 func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
 	if len(testConfigPaths) == 0 {
-		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "{{$defaultTestConfigPath}}")
-		testConfigPaths = append(testConfigPaths, defaultPath)
+		configPath := filepath.Join("src", "{{$defaultTestConfigPath}}")
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
+
+		// This is a temporary solution for running tests using bazel
+		// TODO: need long term solution to avoid hardcoding bazel specifics
+		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
+
+		testConfigPaths = append(
+			testConfigPaths,
+			defaultPath,
+			bazelPath,
+		)
 	}
 	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 
@@ -2121,7 +2131,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 4888, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 5188, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -67,6 +67,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
 
 		// This is a temporary solution for running tests using bazel
+		// see https://docs.bazel.build/versions/master/test-encyclopedia.html for relevant env vars
 		// TODO: need long term solution to avoid hardcoding bazel specifics
 		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
 

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -63,8 +63,18 @@ type mockService struct {
 // - "config/test.yaml" where current dir is the project root
 func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
 	if len(testConfigPaths) == 0 {
-		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "{{$defaultTestConfigPath}}")
-		testConfigPaths = append(testConfigPaths, defaultPath)
+		configPath := filepath.Join("src", "{{$defaultTestConfigPath}}")
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
+
+		// This is a temporary solution for running tests using bazel
+		// TODO: need long term solution to avoid hardcoding bazel specifics
+		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
+
+		testConfigPaths = append(
+			testConfigPaths,
+			defaultPath,
+			bazelPath,
+		)
 	}
 	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -79,8 +79,18 @@ type mockService struct {
 // - "config/test.yaml" where current dir is the project root
 func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
 	if len(testConfigPaths) == 0 {
-		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
-		testConfigPaths = append(testConfigPaths, defaultPath)
+		configPath := filepath.Join("src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
+
+		// This is a temporary solution for running tests using bazel
+		// TODO: need long term solution to avoid hardcoding bazel specifics
+		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
+
+		testConfigPaths = append(
+			testConfigPaths,
+			defaultPath,
+			bazelPath,
+		)
 	}
 	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -83,6 +83,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
 
 		// This is a temporary solution for running tests using bazel
+		// see https://docs.bazel.build/versions/master/test-encyclopedia.html for relevant env vars
 		// TODO: need long term solution to avoid hardcoding bazel specifics
 		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
 

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -79,8 +79,18 @@ type mockService struct {
 // - "config/test.yaml" where current dir is the project root
 func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
 	if len(testConfigPaths) == 0 {
-		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
-		testConfigPaths = append(testConfigPaths, defaultPath)
+		configPath := filepath.Join("src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
+
+		// This is a temporary solution for running tests using bazel
+		// TODO: need long term solution to avoid hardcoding bazel specifics
+		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
+
+		testConfigPaths = append(
+			testConfigPaths,
+			defaultPath,
+			bazelPath,
+		)
 	}
 	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -83,6 +83,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
 
 		// This is a temporary solution for running tests using bazel
+		// see https://docs.bazel.build/versions/master/test-encyclopedia.html for relevant env vars
 		// TODO: need long term solution to avoid hardcoding bazel specifics
 		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
 

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -79,8 +79,18 @@ type mockService struct {
 // - "config/test.yaml" where current dir is the project root
 func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService {
 	if len(testConfigPaths) == 0 {
-		defaultPath := filepath.Join(os.Getenv("GOPATH"), "src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
-		testConfigPaths = append(testConfigPaths, defaultPath)
+		configPath := filepath.Join("src", "github.com/uber/zanzibar/examples/example-gateway/config/test.yaml")
+		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
+
+		// This is a temporary solution for running tests using bazel
+		// TODO: need long term solution to avoid hardcoding bazel specifics
+		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
+
+		testConfigPaths = append(
+			testConfigPaths,
+			defaultPath,
+			bazelPath,
+		)
 	}
 	c := config.NewRuntimeConfigOrDie(testConfigPaths, nil)
 

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -83,6 +83,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		defaultPath := filepath.Join(os.Getenv("GOPATH"), configPath)
 
 		// This is a temporary solution for running tests using bazel
+		// see https://docs.bazel.build/versions/master/test-encyclopedia.html for relevant env vars
 		// TODO: need long term solution to avoid hardcoding bazel specifics
 		bazelPath := filepath.Join(os.Getenv("TEST_SRCDIR"), os.Getenv("TEST_WORKSPACE"), configPath)
 


### PR DESCRIPTION
This PR hard codes a temporary solution to support running tests with bazel where accessing to test config files is restricted.
It is obvious that this approach isn't ideal since it tailors to bazel's specific needs, therefore temporary.