### PR TITLE
Add default endpoint log fields to server request logger

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -103,6 +103,7 @@ func NewServerHTTPRequest(
 	httpRequest := r.WithContext(ctx)
 
 	scope := endpoint.scope.Tagged(scopeTags)
+	logger := endpoint.logger.With(logFields...)
 
 	req := &ServerHTTPRequest{
 		httpRequest:  httpRequest,
@@ -114,7 +115,7 @@ func NewServerHTTPRequest(
 		Method:       httpRequest.Method,
 		Params:       params,
 		Header:       NewServerHTTPHeader(r.Header),
-		logger:       endpoint.logger,
+		logger:       logger,
 		scope:        scope,
 	}
 


### PR DESCRIPTION
This provides better observability for instances where the request's logger is used