### PR TITLE
Add ability to configure the log level of the gateway logger

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -544,7 +544,17 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 func (gateway *Gateway) setupLogger(config *StaticConfig) error {
 	var output zapcore.WriteSyncer
 	logEncoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+
 	logLevel := zap.InfoLevel
+	if config.ContainsKey("logger.level") {
+		levelString := config.MustGetString("logger.level")
+		var ok bool
+		logLevel, ok = levelMap[levelString]
+		if !ok {
+			return errors.Errorf("unknown log level for gateway logger: %s", logLevel)
+		}
+	}
+
 	tempLogger := zap.New(
 		zapcore.NewCore(
 			logEncoder,

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -551,7 +551,7 @@ func (gateway *Gateway) setupLogger(config *StaticConfig) error {
 		var ok bool
 		logLevel, ok = levelMap[levelString]
 		if !ok {
-			return errors.Errorf("unknown log level for gateway logger: %s", logLevel)
+			return errors.Errorf("unknown log level for gateway logger: %s", levelString)
 		}
 	}
 

--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreatGatewayLoggingConfig(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
+		"logger.fileName": "foober",
+		"logger.output":   "",
+		"env":             "local",
+		"datacenter":      "phx2",
+		"serviceName":     "foozabar",
+		"logger.level":    "fatal",
+	})
+
+	g := Gateway{
+		Config: cfg,
+	}
+
+	err := g.setupLogger(cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, zap.NewAtomicLevelAt(zap.FatalLevel), *g.atomLevel)
+}
+
+func TestCreatGatewayBadLoggingConfig(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
+		"logger.level": "invalid",
+	})
+
+	g := Gateway{
+		Config: cfg,
+	}
+
+	err := g.setupLogger(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown log level for gateway logger: invalid")
+}

--- a/test/bootstrap_test.go
+++ b/test/bootstrap_test.go
@@ -65,3 +65,14 @@ func TestBootstrapError(t *testing.T) {
 		assert.Fail(t, "got weird error")
 	}
 }
+
+func TestBootstrapWithBadLogLevel(t *testing.T) {
+	gateway, err := testGateway.CreateGateway(t, map[string]interface{}{
+		"logger.level": "invalid",
+	}, &testGateway.Options{
+		TestBinary:  util.DefaultMainFile("example-gateway"),
+		ConfigFiles: util.DefaultConfigFiles("example-gateway"),
+	})
+	assert.Error(t, err, "got bootstrap err")
+	assert.Nil(t, gateway)
+}


### PR DESCRIPTION
The gateway logger is used to log mos requests and responses. In order to provide clients the ability to control the default log level for these logs, we add a new configuration value, `logger.level` and default to the previous `zap.InfoLevel` if no level is provided