### PR TITLE
Do not set Content-Type if already present in response

### DIFF
--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -218,18 +218,24 @@ func (res *ServerHTTPResponse) WriteJSON(
 		return
 	}
 
+	contentTypePresent := false
 	if headers != nil {
 		for _, k := range headers.Keys() {
 			v, ok := headers.Get(k)
 			if ok {
+				if k == "Content-Type" {
+					contentTypePresent = true
+				}
 				res.responseWriter.Header().Set(k, v)
 			}
 		}
 	}
 
-	res.responseWriter.Header().
-		Set("content-type", "application/json")
-
+	// Set the content-type to application/json if not already available
+	if !contentTypePresent {
+		res.responseWriter.Header().
+			Set("content-type", "application/json")
+	}
 	res.pendingStatusCode = statusCode
 	res.pendingBodyBytes = bytes
 	res.pendingBodyObj = body


### PR DESCRIPTION
If the downstream sends Content-Type header,  Zanzibar should skip setting Content-Type to "application/json". In that case, we respect the Content-Type sent by the downstream. 