### PR TITLE
Swap out julienschmidt/httprouter

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -77,8 +77,6 @@ imports:
   version: c0795c8afcf41dd1d786bebce68636c199b3bb45
 - name: github.com/jteeuwen/go-bindata
   version: 6025e8de665b31fa74ab1a66f2cddd8c0abf887e
-- name: github.com/julienschmidt/httprouter
-  version: 26a05976f9bf5c3aa992cc20e8588c359418ee58
 - name: github.com/kardianos/osext
   version: 2bc1f35cddc0cc527b4bc3dce8578fc2a6c11384
 - name: github.com/kisielk/errcheck

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,9 +16,6 @@ import:
   version: ^1.3.0
 - package: github.com/uber-go/tally
   version: ^3.3.8
-# update to master since the last semver release is 2 years old
-- package: github.com/julienschmidt/httprouter
-  version: master
 - package: github.com/kardianos/osext
   version: master
 - package: go.uber.org/thriftrw

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -178,13 +178,6 @@ func NewHTTPRouter(gateway *Gateway) HTTPRouter {
 
 // Register register a handler function.
 func (router *httpRouter) Handle(method, prefix string, handler http.Handler) (err error) {
-	defer func() {
-		recoveredValue := recover()
-		if recoveredValue != nil {
-			err = fmt.Errorf("caught error when registering %s %s: %+v", method, prefix, recoveredValue)
-		}
-	}()
-
 	h := func(w http.ResponseWriter, r *http.Request) {
 		reqUUID := r.Header.Get(router.requestUUIDHeaderKey)
 		if reqUUID == "" {

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -25,11 +25,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/uber-go/tally"
+	zrouter "github.com/uber/zanzibar/runtime/router"
 	"go.uber.org/zap"
 	"net/url"
 )
@@ -61,9 +61,9 @@ type HTTPRouter interface {
 
 // ParamsFromContext extracts the URL parameters that are embedded in the context by the Zanzibar HTTP router implementation.
 func ParamsFromContext(ctx context.Context) url.Values {
-	julienParams := httprouter.ParamsFromContext(ctx)
+	params := zrouter.ParamsFromContext(ctx)
 	urlValues := make(url.Values)
-	for _, paramValue := range julienParams {
+	for _, paramValue := range params {
 		urlValues.Add(paramValue.Key, paramValue.Value)
 	}
 	return urlValues
@@ -131,7 +131,7 @@ func (endpoint *RouterEndpoint) HandleRequest(
 // httpRouter data structure to handle and register endpoints
 type httpRouter struct {
 	gateway                  *Gateway
-	httpRouter               *httprouter.Router
+	httpRouter               *zrouter.Router
 	notFoundEndpoint         *RouterEndpoint
 	methodNotAllowedEndpoint *RouterEndpoint
 	panicCount               tally.Counter
@@ -167,8 +167,7 @@ func NewHTTPRouter(gateway *Gateway) HTTPRouter {
 		requestUUIDHeaderKey: gateway.requestUUIDHeaderKey,
 	}
 
-	router.httpRouter = &httprouter.Router{
-		RedirectTrailingSlash:  true,
+	router.httpRouter = &zrouter.Router{
 		HandleMethodNotAllowed: true,
 		NotFound:               http.HandlerFunc(router.handleNotFound),
 		MethodNotAllowed:       http.HandlerFunc(router.handleMethodNotAllowed),
@@ -197,8 +196,7 @@ func (router *httpRouter) Handle(method, prefix string, handler http.Handler) (e
 		handler.ServeHTTP(w, r)
 	}
 
-	router.httpRouter.Handler(method, prefix, http.HandlerFunc(h))
-	return err
+	return router.httpRouter.Handle(method, prefix, http.HandlerFunc(h))
 }
 
 // ServeHTTP implements the http.Handle as a convenience to allow HTTPRouter to be invoked by the standard library HTTP server.

--- a/runtime/router/router.go
+++ b/runtime/router/router.go
@@ -31,8 +31,10 @@ import (
 // It implements a similar interface to the one in github.com/julienschmidt/httprouter,
 // the main differences are:
 // 1. this router does not treat "/a/:b" and "/a/b/c" as conflicts (https://github.com/julienschmidt/httprouter/issues/175)
-// 2. this router does not allow "/a/:b" and "/a/:c" as different routes and therefore does not allow them to be registered at the same time (https://github.com/julienschmidt/httprouter/issues/6)
+// 2. this router does not treat "/a/:b" and "/a/:c" as different routes and therefore does not allow them to be registered at the same time (https://github.com/julienschmidt/httprouter/issues/6)
 // 3. this router does not treat "/a" and "/a/" as different routes
+// Also the `*` pattern is greedy, if a handler is register for `/a/*`, then no handler
+// can be further registered for any path that starts with `/a/`
 type Router struct {
 	tries map[string]*Trie
 

--- a/runtime/router/router.go
+++ b/runtime/router/router.go
@@ -31,7 +31,7 @@ import (
 // It implements a similar interface to the one in github.com/julienschmidt/httprouter,
 // the main differences are:
 // 1. this router does not treat "/a/:b" and "/a/b/c" as conflicts (https://github.com/julienschmidt/httprouter/issues/175)
-// 2. this router does not treat "/a/:b" and "/a/:c" as different routes (https://github.com/julienschmidt/httprouter/issues/6)
+// 2. this router does not allow "/a/:b" and "/a/:c" as different routes and therefore does not allow them to be registered at the same time (https://github.com/julienschmidt/httprouter/issues/6)
 // 3. this router does not treat "/a" and "/a/" as different routes
 type Router struct {
 	tries map[string]*Trie

--- a/runtime/router/router_test.go
+++ b/runtime/router/router_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandle(t *testing.T) {
+	r := &Router{}
+
+	handled := false
+	err := r.Handle("GET", "/*",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	r.ServeHttp(nil, req)
+	assert.True(t, handled)
+}
+
+func TestParamsFromContext(t *testing.T) {
+	r := &Router{}
+
+	handled := false
+	err := r.Handle("GET", "/:var",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			params := ParamsFromContext(req.Context())
+			assert.Equal(t, 1, len(params))
+			assert.Equal(t, "var", params[0].Key)
+			assert.Equal(t, "foo", params[0].Value)
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	r.ServeHttp(nil, req)
+	assert.True(t, handled)
+}
+
+func TestPanicHandler(t *testing.T) {
+	handled := false
+	r := &Router{
+		PanicHandler: func(writer http.ResponseWriter, req *http.Request, i interface{}) {
+			handled = true
+		},
+	}
+
+	err := r.Handle("GET", "/foo",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			panic("something went wrong")
+		}))
+	assert.NoError(t, err, "unexpected error")
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	r.ServeHttp(nil, req)
+	assert.True(t, handled)
+}
+
+func TestMethodNotAllowedDefault(t *testing.T) {
+	r := &Router{HandleMethodNotAllowed: true}
+
+	handled := false
+	err := r.Handle("GET", "/foo",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+	err = r.Handle("PUT", "/bar",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+
+	req, _ := http.NewRequest("PUT", "/foo", nil)
+	res := httptest.NewRecorder()
+	r.ServeHttp(res, req)
+	assert.False(t, handled)
+	assert.Equal(t, http.StatusMethodNotAllowed, res.Result().StatusCode)
+	assert.Equal(t, "GET", res.Result().Header.Get("Allow"))
+}
+
+func TestMethodNotAllowedCustom(t *testing.T) {
+	r := &Router{
+		HandleMethodNotAllowed: true,
+		MethodNotAllowed: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.Header().Set("life", "42")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}),
+	}
+
+	handled := false
+	err := r.Handle("GET", "/foo",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+	err = r.Handle("POST", "/foo",
+		http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			handled = true
+		}))
+	assert.NoError(t, err, "unexpected error")
+
+	req, _ := http.NewRequest("PUT", "/foo", nil)
+	res := httptest.NewRecorder()
+	r.ServeHttp(res, req)
+	assert.False(t, handled)
+	assert.Equal(t, "42", res.Result().Header.Get("life"))
+	assert.Equal(t, "GET, POST", res.Result().Header.Get("Allow"))
+}
+
+func TestNotFoundDefault(t *testing.T) {
+	r := &Router{}
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	res := httptest.NewRecorder()
+	r.ServeHttp(res, req)
+	assert.Equal(t, http.StatusNotFound, res.Result().StatusCode)
+}
+
+func TestNotFoundCustom(t *testing.T) {
+	handled := false
+	r := &Router{
+		NotFound: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			handled = true
+		}),
+	}
+
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	res := httptest.NewRecorder()
+	r.ServeHttp(res, req)
+	assert.True(t, handled)
+	assert.Equal(t, http.StatusNotFound, res.Result().StatusCode)
+}

--- a/runtime/router/router_test.go
+++ b/runtime/router/router_test.go
@@ -39,7 +39,7 @@ func TestHandle(t *testing.T) {
 	assert.NoError(t, err, "unexpected error")
 
 	req, _ := http.NewRequest("GET", "/foo", nil)
-	r.ServeHttp(nil, req)
+	r.ServeHTTP(nil, req)
 	assert.True(t, handled)
 }
 
@@ -58,7 +58,7 @@ func TestParamsFromContext(t *testing.T) {
 	assert.NoError(t, err, "unexpected error")
 
 	req, _ := http.NewRequest("GET", "/foo", nil)
-	r.ServeHttp(nil, req)
+	r.ServeHTTP(nil, req)
 	assert.True(t, handled)
 }
 
@@ -77,7 +77,7 @@ func TestPanicHandler(t *testing.T) {
 	assert.NoError(t, err, "unexpected error")
 
 	req, _ := http.NewRequest("GET", "/foo", nil)
-	r.ServeHttp(nil, req)
+	r.ServeHTTP(nil, req)
 	assert.True(t, handled)
 }
 
@@ -98,7 +98,7 @@ func TestMethodNotAllowedDefault(t *testing.T) {
 
 	req, _ := http.NewRequest("PUT", "/foo", nil)
 	res := httptest.NewRecorder()
-	r.ServeHttp(res, req)
+	r.ServeHTTP(res, req)
 	assert.False(t, handled)
 	assert.Equal(t, http.StatusMethodNotAllowed, res.Result().StatusCode)
 	assert.Equal(t, "GET", res.Result().Header.Get("Allow"))
@@ -127,7 +127,7 @@ func TestMethodNotAllowedCustom(t *testing.T) {
 
 	req, _ := http.NewRequest("PUT", "/foo", nil)
 	res := httptest.NewRecorder()
-	r.ServeHttp(res, req)
+	r.ServeHTTP(res, req)
 	assert.False(t, handled)
 	assert.Equal(t, "42", res.Result().Header.Get("life"))
 	assert.Equal(t, "GET, POST", res.Result().Header.Get("Allow"))
@@ -138,7 +138,7 @@ func TestNotFoundDefault(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	res := httptest.NewRecorder()
-	r.ServeHttp(res, req)
+	r.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusNotFound, res.Result().StatusCode)
 }
 
@@ -153,7 +153,7 @@ func TestNotFoundCustom(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	res := httptest.NewRecorder()
-	r.ServeHttp(res, req)
+	r.ServeHTTP(res, req)
 	assert.True(t, handled)
 	assert.Equal(t, http.StatusNotFound, res.Result().StatusCode)
 }

--- a/runtime/router/trie.go
+++ b/runtime/router/trie.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package router
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var (
+	errPath     = errors.New("bad path")
+	errExist    = errors.New("path value already set")
+	errNotFound = errors.New("not found")
+)
+
+type paramMismatch struct {
+	expected, actual string
+	existingPath     string
+}
+
+// Error returns the error string
+func (e *paramMismatch) Error() string {
+	return fmt.Sprintf("param key mismatch: expected is %s but got %s", e.expected, e.actual)
+}
+
+// Param is a url parameter where key is the url segment pattern (without :) and
+// value is the actual segment of a matched url.
+// e.g. url /foo/123 matches /foo/:id, the url param has key "id" and value "123"
+type Param struct {
+	Key, Value string
+}
+
+// Trie is a radix trie to store string value at given url path,
+// a trie node corresponds to an arbitrary path substring.
+type Trie struct {
+	root *tnode
+}
+
+type tnode struct {
+	key      string
+	value    http.Handler
+	children []*tnode
+}
+
+// NewTrie creates a new trie.
+func NewTrie() *Trie {
+	return &Trie{
+		root: &tnode{
+			key: "",
+		},
+	}
+}
+
+// Set sets the value for given path, returns error if path already set
+func (t *Trie) Set(path string, value http.Handler) error {
+	if path == "" || strings.Contains(path, "//") {
+		return errPath
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	// ignore trailing slash
+	path = strings.TrimSuffix(path, "/")
+
+	// validate "*"
+	if strings.Contains(path, "*") && !strings.HasSuffix(path, "/*") {
+		return errors.New("/* must be the last path segment")
+	}
+	if strings.Count(path, "*") > 1 {
+		return errors.New("path can not contain more than one *")
+	}
+
+	err := t.root.set(path, value)
+	if e, ok := err.(*paramMismatch); ok {
+		return fmt.Errorf("path %q has a different param key %q, it should be the same key %q as in existing path %q", path, e.actual, e.expected, e.existingPath)
+	}
+	return err
+}
+
+// Get returns the value for given path, returns error if not found
+func (t *Trie) Get(path string) (http.Handler, []Param, error) {
+	if path == "" || strings.Contains(path, "//") {
+		return nil, nil, errPath
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	// ignore trailing slash
+	path = strings.TrimSuffix(path, "/")
+	return t.root.get(path)
+}
+
+func (t *tnode) set(path string, value http.Handler) error {
+	// find the longest common prefix
+	var l, i int
+	m, n := len(t.key), len(path)
+	if m > n {
+		l = n
+	} else {
+		l = m
+	}
+	for i < l && t.key[i] == path[i] {
+		i++
+	}
+
+	// find index j, k in key and path to which they match,
+	// j and k is only useful to check if there is conflict,
+	// they are not where splits happen, splits happen at index i.
+	var j, k int
+	for j < m && k < n {
+		if t.key[j] == ':' || path[k] == ':' {
+			oj, ok := j, k
+			same := t.key[j] == path[k]
+			for j < m && t.key[j] != '/' {
+				j++
+			}
+			for k < n && path[k] != '/' {
+				k++
+			}
+			if same && (j-oj) != (k-ok) {
+				return &paramMismatch{
+					t.key[oj:j],
+					path[ok:k],
+					t.key,
+				}
+			}
+		} else if t.key[j] == path[k] {
+			j++
+			k++
+		} else {
+			break
+		}
+	}
+
+	// conflicts caused by ":" is only possible when j == m
+	if j == m {
+		for _, c := range t.children {
+			if c.key[0] == path[k] || c.key[0] == ':' || path[k] == ':' {
+				if _, _, err := c.get(path[k:]); err == nil {
+					return errExist
+				}
+			}
+		}
+	}
+
+	// node ley is longer than longest common prefix
+	if i < m {
+		// key/path suffix being "*" means a conflict
+		if path[i:] == "*" || t.key[i:] == "*" {
+			return errExist
+		}
+
+		// split the node key, add new node with node key minus longest common prefix
+		split := &tnode{
+			key:      t.key[i:],
+			value:    t.value,
+			children: t.children,
+		}
+		t.key = t.key[:i]
+		t.value = nil
+		t.children = []*tnode{split}
+
+		// path is equal to longest common prefix
+		// set value on current node after split
+		if i == n {
+			t.value = value
+		} else {
+			// path is longer than longest common prefix
+			// add new node with path minus longest common prefix
+			newNode := &tnode{
+				key:   path[i:],
+				value: value,
+			}
+			t.children = append(t.children, newNode)
+		}
+	}
+
+	// node key is equal to longest common prefix
+	if i == m {
+		// path is equal to longest common prefix
+		if i == n {
+			// node is guaranteed to have zero value,
+			// otherwise it would have caused errExist earlier
+			t.value = value
+		} else {
+			// path is longer than node key, try to recurse on node children
+			for _, c := range t.children {
+				if c.key[0] == path[i] {
+					err := c.set(path[i:], value)
+					if e, ok := err.(*paramMismatch); ok {
+						e.existingPath = t.key + e.existingPath
+						return e
+					}
+					return err
+				}
+			}
+			// no children to recurse, add node with path minus longest common path
+			newNode := &tnode{
+				key:   path[i:],
+				value: value,
+			}
+			t.children = append(t.children, newNode)
+		}
+	}
+
+	return nil
+}
+
+func (t *tnode) get(path string) (http.Handler, []Param, error) {
+	m, n := len(t.key), len(path)
+	var params []Param
+
+	// find the longest matched prefix
+	var j, k int
+	for j < m && k < n {
+		if t.key[j] == ':' {
+			oj, ok := j+1, k
+			for j < m && t.key[j] != '/' {
+				j++
+			}
+			for k < n && path[k] != '/' {
+				k++
+			}
+			params = append(params, Param{t.key[oj:j], path[ok:k]})
+		} else if path[k] == ':' { // necessary for conflict check used in set call
+			for j < m && t.key[j] != '/' {
+				j++
+			}
+			for k < n && path[k] != '/' {
+				k++
+			}
+		} else if t.key[j] == path[k] {
+			j++
+			k++
+		} else {
+			break
+		}
+	}
+
+	if j < m {
+		// path matches up to node key's second to last character,
+		// the last char of node key is "*" and path is no shorter than longest matched prefix
+		if t.key[j:] == "*" && k < n {
+			return t.value, params, nil
+		}
+		return nil, nil, errNotFound
+	}
+
+	// ':' in path matches '*' in node key
+	if j > 0 && t.key[j-1] == '*' {
+		return t.value, params, nil
+	}
+
+	// longest matched prefix matches up to node key length and path length
+	if k == n {
+		if t.value != nil {
+			return t.value, params, nil
+		}
+		return nil, nil, errNotFound
+	}
+
+	// TODO: recursion to iteration for speed
+	// longest matched prefix matches up to node key length but not path length
+	for _, c := range t.children {
+		if c.key[0] == path[k] || c.key[0] == ':' || path[k] == ':' {
+			if v, ps, err := c.get(path[k:]); err == nil {
+				return v, append(params, ps...), nil
+			}
+		}
+	}
+
+	return nil, nil, errNotFound
+}

--- a/runtime/router/trie_test.go
+++ b/runtime/router/trie_test.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package router
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	get = "get"
+	set = "set"
+)
+
+type ts struct {
+	op             string
+	path           string
+	value          string
+	errMsg         string
+	expectedValue  string
+	expectedParams []Param
+}
+
+type namedHandler struct {
+	id string
+}
+
+func (n namedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {}
+
+func runTrieTests(t *testing.T, trie *Trie, tests []ts) {
+	for _, test := range tests {
+		if test.op == set {
+			err := trie.Set(test.path, namedHandler{id: test.value})
+			if test.errMsg == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.errMsg)
+			}
+		}
+		if test.op == get {
+			v, ps, err := trie.Get(test.path)
+			if test.errMsg == "" {
+				assert.NoError(t, err, test.path)
+				assert.Equal(t, test.expectedValue, v.(namedHandler).id)
+				assert.Equal(t, test.expectedParams, ps)
+			} else {
+				assert.EqualError(t, err, test.errMsg)
+			}
+		}
+	}
+	//printTrie(trie)
+}
+
+func TestTrieLiteralPath(t *testing.T) {
+	tree := NewTrie()
+	tests := []ts{
+		// test blank path
+		{op: set, path: "", value: "foo", errMsg: errPath.Error()},
+		{op: get, path: "", errMsg: errPath.Error()},
+		// test root path
+		{op: set, path: "/", value: "foo"},
+		{op: get, path: "/", expectedValue: "foo"},
+		// test set
+		{op: set, path: "/a/b", value: "bar"},
+		{op: set, path: "/a/b/c", value: "bar"},
+		// test set conflict
+		{op: set, path: "/a/b/c", value: "baz", errMsg: errExist.Error()},
+		// test trailing slash when set
+		{op: set, path: "/a/b/c/", value: "baz", errMsg: errExist.Error()},
+		// test not found
+		{op: get, path: "/a", errMsg: errNotFound.Error()},
+		{op: get, path: "/a/b/d", errMsg: errNotFound.Error()},
+		// test get
+		{op: get, path: "/a/b", expectedValue: "bar"},
+		{op: get, path: "/a/b/c", expectedValue: "bar"},
+		// test trailing slash when get
+		{op: get, path: "/a/b/c/", expectedValue: "bar"},
+		// test missing starting slash
+		{op: set, path: "a", value: "foo"},
+		{op: get, path: "a", expectedValue: "foo"},
+		// test branching
+		{op: set, path: "/a/e/f", value: "quxx"},
+		{op: get, path: "/a/e/f", expectedValue: "quxx"},
+		// test segment overlap
+		{op: set, path: "/a/good", value: "good"},
+		{op: set, path: "/a/goto", value: "goto"},
+		{op: get, path: "/a/good", expectedValue: "good"},
+		{op: get, path: "/a/goto", expectedValue: "goto"},
+	}
+
+	runTrieTests(t, tree, tests)
+}
+
+func TestTriePathsWithPatten(t *testing.T) {
+	trie := NewTrie()
+	tests := []ts{
+		// test setting "/*/a" is not allowed
+		{op: set, path: "/*/a", value: "foo", errMsg: "/* must be the last path segment"},
+		// test setting path with multiple "*" is not allowed
+		{op: set, path: "/*/*", value: "foo", errMsg: "path can not contain more than one *"},
+		// test "/a" does not collide with "/a/*"
+		{op: set, path: "/a", value: "foo"},
+		// test "/a/*" match all paths starts with "/a/"
+		{op: set, path: "/a/*", value: "bar"},
+		{op: get, path: "a", expectedValue: "foo"},
+		{op: get, path: "/a/b", expectedValue: "bar"},
+		{op: get, path: "/a/b/c/d", expectedValue: "bar"},
+		{op: get, path: "/a/b/c/d", expectedValue: "bar"},
+		// test paths starts with "/a/" collides with "/a/*"
+		{op: set, path: "/a/b/", value: "baz", errMsg: errExist.Error()},
+		{op: set, path: "/a/b/c", value: "baz", errMsg: errExist.Error()},
+		{op: set, path: "/a/:b", value: "baz", errMsg: errExist.Error()},
+		// test "/*" collides with "/a"
+		{op: set, path: "/*", value: "baz", errMsg: errExist.Error()},
+		// test "/:" collides with "/a"
+		{op: set, path: "/:x", value: "baz", errMsg: errExist.Error()},
+		// test "/:/b" collides with "/a/*"
+		{op: set, path: "/:x/b", value: "baz", errMsg: errExist.Error()},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// test "/a" does not collide with "/:a/b"
+		{op: set, path: "/:a/b", value: "foo"},
+		{op: set, path: "/a", value: "bar"},
+		{op: get, path: "/a", expectedValue: "bar"},
+		{op: get, path: "/x/b/", expectedValue: "foo", expectedParams: []Param{{"a", "x"}}},
+		{op: get, path: "/a/", expectedValue: "bar"},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// test "/:a/b" does not collide with "/a"
+		{op: set, path: "/a", value: "bar"},
+		{op: set, path: "/:a/b", value: "foo"},
+		{op: get, path: "/a", expectedValue: "bar"},
+		{op: get, path: "/x/b/", expectedValue: "foo", expectedParams: []Param{{"a", "x"}}},
+		{op: get, path: "/a/", expectedValue: "bar"},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// test "/b" collides with "/:"
+		{op: set, path: "/:a", value: "foo"},
+		{op: set, path: "/b", errMsg: errExist.Error()},
+		{op: get, path: "/a/", expectedValue: "foo", expectedParams: []Param{{"a", "a"}}},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// test "/:" collides with "/b"
+		{op: set, path: "/b", value: "foo"},
+		{op: set, path: "/:a", errMsg: errExist.Error()},
+		{op: get, path: "/b/", expectedValue: "foo"},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// more ":" tests
+		{op: set, path: "/a/b", value: "1"},
+		{op: set, path: "/a/b/:cc/d", value: "2"},
+		{op: set, path: "/a/b/:x/e", errMsg: "path \"/a/b/:x/e\" has a different param key \":x\", it should be the same key \":cc\" as in existing path \"/a/b/:cc/d\""},
+		{op: set, path: "/a/b/c/x", value: "2.1"},
+		{op: set, path: "/a/b/:cc/:d/e", value: "3"},
+		{op: set, path: "/a/b/c/d/f", value: "4"},
+		{op: set, path: "/a/:b/c/d", errMsg: errExist.Error()},
+		{op: get, path: "/a/b/some/d", expectedValue: "2", expectedParams: []Param{{"cc", "some"}}},
+		{op: get, path: "/a/b/c/x", expectedValue: "2.1"},
+		{op: get, path: "/a/b/other/data/e", expectedValue: "3",
+			expectedParams: []Param{
+				{"cc", "other"},
+				{"d", "data"},
+			}},
+		{op: get, path: "/a/b/c/d/f", expectedValue: "4"},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// more ":" tests
+		{op: set, path: "/a/b", value: "1"},
+		{op: set, path: "/a/b/ccc/x", value: "2"},
+		{op: set, path: "/a/b/c/dope/f", value: "3"},
+		{op: set, path: "/a/b/ccc/:", errMsg: errExist.Error()},
+		{op: set, path: "/a/b/c/:/:/", errMsg: errExist.Error()},
+		{op: get, path: "/a/b/ccc", errMsg: errNotFound.Error()},
+		{op: get, path: "/a/b/:", errMsg: errNotFound.Error()},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		// more ":" tests
+		{op: set, path: "/a/:b/c", value: "1"},
+		{op: set, path: "/a/:b/d", value: "2"},
+		{op: get, path: "/a/b/c", expectedValue: "1", expectedParams: []Param{{"b", "b"}}},
+		{op: get, path: "/a/b/d", expectedValue: "2", expectedParams: []Param{{"b", "b"}}},
+	}
+	runTrieTests(t, trie, tests)
+}
+
+// simple test for coverage
+func TestParamMismatch(t *testing.T) {
+	pm := paramMismatch{
+		expected: "foo",
+		actual:   "bar",
+	}
+	assert.Equal(t, "param key mismatch: expected is foo but got bar", pm.Error())
+}
+
+// utilities for debugging
+func printTrie(t *Trie) {
+	buf := new(bytes.Buffer)
+	var levelsEnded []int
+	printNodes(buf, t.root.children, 0, levelsEnded)
+	fmt.Println(string(buf.Bytes()))
+}
+
+func printNodes(w io.Writer, nodes []*tnode, level int, levelsEnded []int) {
+	for i, node := range nodes {
+		edge := "├──"
+		if i == len(nodes)-1 {
+			levelsEnded = append(levelsEnded, level)
+			edge = "└──"
+		}
+		printNode(w, node, level, levelsEnded, edge)
+		if len(node.children) > 0 {
+			printNodes(w, node.children, level+1, levelsEnded)
+		}
+	}
+}
+
+func printNode(w io.Writer, node *tnode, level int, levelsEnded []int, edge string) {
+	for i := 0; i < level; i++ {
+		isEnded := false
+		for _, l := range levelsEnded {
+			if l == i {
+				isEnded = true
+				break
+			}
+		}
+		if isEnded {
+			_, _ = fmt.Fprint(w, "    ")
+		} else {
+			_, _ = fmt.Fprint(w, "│   ")
+		}
+	}
+	if node.value != nil {
+		_, _ = fmt.Fprintf(w, "%s %v (%v)\n", edge, node.key, node.value)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s %v\n", edge, node.key)
+	}
+}

--- a/runtime/router/trie_test.go
+++ b/runtime/router/trie_test.go
@@ -144,6 +144,27 @@ func TestTriePathsWithPatten(t *testing.T) {
 
 	trie = NewTrie()
 	tests = []ts{
+		// test ":a" is not treated as a pattern when queried as a url
+		{op: set, path: "/a", value: "foo"},
+		{op: get, path: "/:a", errMsg: errNotFound.Error()},
+
+		{op: set, path: "/a:b", value: "bar"},
+		{op: set, path: "/a:c", value: "baz"},
+		{op: get, path: "/a:b", expectedValue: "bar"},
+		{op: get, path: "/ac", errMsg: errNotFound.Error()},
+		{op: get, path: "/a:", errMsg: errNotFound.Error()},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
+		{op: set, path: "/:a", value: "foo"},
+		{op: get, path: "/:a", expectedValue: "foo", expectedParams: []Param{{"a", ":a"}}},
+	}
+	runTrieTests(t, trie, tests)
+
+	trie = NewTrie()
+	tests = []ts{
 		// test "/a" does not collide with "/:a/b"
 		{op: set, path: "/:a/b", value: "foo"},
 		{op: set, path: "/a", value: "bar"},

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -81,8 +81,8 @@ func (s *routerSuite) TestRouter() {
 	}{
 		{"GET", "/notfound", nil, http.StatusNotFound, []byte("404 page not found\n")},
 		{"GET", "/noslash", nil, http.StatusOK, []byte("noslash\n")},
-		{"GET", "/noslash/", nil, http.StatusMovedPermanently, []byte(`<a href="/noslash">Moved Permanently</a>.` + "\n\n")},
-		{"GET", "/withslash", nil, http.StatusMovedPermanently, []byte(`<a href="/withslash/">Moved Permanently</a>.` + "\n\n")},
+		{"GET", "/noslash/", nil, http.StatusOK, []byte("noslash\n")},
+		{"GET", "/withslash", nil, http.StatusOK, []byte("withslash\n")},
 		{"GET", "/withslash/", nil, http.StatusOK, []byte("withslash\n")},
 		{"GET", "/postonly", nil, http.StatusMethodNotAllowed, []byte("Method Not Allowed\n")},
 		{"GET", "/panicerror", nil, http.StatusInternalServerError, []byte("Internal Server Error\n")},

--- a/test/lib/test_backend/test_http_backend.go
+++ b/test/lib/test_backend/test_http_backend.go
@@ -25,8 +25,8 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/julienschmidt/httprouter"
 	"github.com/uber/zanzibar/runtime"
+	zrouter "github.com/uber/zanzibar/runtime/router"
 	"go.uber.org/zap"
 )
 
@@ -38,7 +38,7 @@ type TestHTTPBackend struct {
 	RealPort  int32
 	RealAddr  string
 	WaitGroup *sync.WaitGroup
-	router    *httprouter.Router
+	router    *zrouter.Router
 }
 
 // BuildHTTPBackends returns a map of backends based on config
@@ -83,7 +83,7 @@ func (backend *TestHTTPBackend) Bootstrap() error {
 func (backend *TestHTTPBackend) HandleFunc(
 	method string, path string, handler http.HandlerFunc,
 ) {
-	backend.router.HandlerFunc(method, path, handler)
+	_ = backend.router.Handle(method, path, handler)
 }
 
 // Close ...
@@ -103,7 +103,7 @@ func CreateHTTPBackend(port int32) *TestHTTPBackend {
 		IP:        "127.0.0.1",
 		Port:      port,
 		WaitGroup: &sync.WaitGroup{},
-		router: &httprouter.Router{
+		router: &zrouter.Router{
 			HandleMethodNotAllowed: true,
 		},
 	}


### PR DESCRIPTION
This PR swaps out [julienschmidt/httprouter](https://github.com/julienschmidt/httprouter) with an inhouse router implementation that has similar interface to httprouter. The rationale is to overcome the limitations of https://github.com/julienschmidt/httprouter/issues/6 and https://github.com/julienschmidt/httprouter/issues/175.