### PR TITLE
Allow req body to be modified

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -651,6 +651,25 @@ func (req *ServerHTTPRequest) UnmarshalBody(
 	return true
 }
 
+// WriteBytesBody replace the request body
+// we only change things cached in this layer, not in the raw httpRequest
+// Assumption is that encoding does not change
+func (req *ServerHTTPRequest) WriteBytesBody(
+	body []byte) bool {
+	if body == nil {
+		req.logger.Error("Could not serialize nil pointer body")
+		return false
+	}
+
+	// Replace the cached body bytes and fix dependent header
+	req.rawBody = body
+	if _, ok := req.Header.Get("Content-Length"); ok {
+		req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	}
+
+	return true
+}
+
 // GetSpan returns the http request span
 func (req *ServerHTTPRequest) GetSpan() opentracing.Span {
 	return req.span

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1448,6 +1448,65 @@ func TestPeekBody(t *testing.T) {
 	assert.Equal(t, "200 OK", resp.Status)
 }
 
+func TestWriteBytesBody(t *testing.T) {
+	gateway, err := benchGateway.CreateGateway(
+		defaultTestConfig,
+		defaultTestOptions,
+		exampleGateway.CreateGateway,
+	)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer gateway.Close()
+
+	bgateway := gateway.(*benchGateway.BenchGateway)
+	deps := &zanzibar.DefaultDependencies{
+		Scope:         bgateway.ActualGateway.RootScope,
+		Logger:        bgateway.ActualGateway.Logger,
+		ContextLogger: bgateway.ActualGateway.ContextLogger,
+		Tracer:        bgateway.ActualGateway.Tracer,
+	}
+	err = bgateway.ActualGateway.HTTPRouter.Handle(
+		"POST", "/foo", http.HandlerFunc(zanzibar.NewRouterEndpoint(
+			bgateway.ActualGateway.ContextExtractor,
+			deps,
+			"foo", "foo",
+			func(
+				ctx context.Context,
+				req *zanzibar.ServerHTTPRequest,
+				res *zanzibar.ServerHTTPResponse,
+			) {
+				_, success := req.ReadAll()
+				assert.True(t, success)
+				assert.NotEqual(t, 0, len(req.GetRawBody()))
+
+				value, vType, err := req.PeekBody("arg1", "b1", "c1")
+				assert.NoError(t, err, "do not expect error")
+				assert.Equal(t, []byte("result"), value)
+				assert.Equal(t, jsonparser.String, vType)
+
+				success = req.WriteBytesBody([]byte(`{"arg1":{"b2":"foo"}}`))
+				assert.True(t, success)
+				_, _, err = req.PeekBody("arg1", "b1")
+				assert.Error(t, err, "expected this to have been replaced already")
+				value, vType, err = req.PeekBody("arg1", "b2")
+				assert.NoError(t, err, "do not expect error")
+				assert.Equal(t, []byte("foo"), value)
+				assert.Equal(t, jsonparser.String, vType)
+				res.WriteJSONBytes(200, nil, []byte(`{"ok":true}`))
+			},
+		).HandleRequest),
+	)
+	assert.NoError(t, err)
+
+	resp, err := gateway.MakeRequest("POST", "/foo?foo=bar", nil, bytes.NewReader([]byte(`{"arg1":{"b1":{"c1":"result","d1":"efg"}}}`)))
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, "200 OK", resp.Status)
+}
+
 func TestSpanCreated(t *testing.T) {
 	gateway, err := benchGateway.CreateGateway(
 		defaultTestConfig,


### PR DESCRIPTION
This is useful for middlewares that may want to modify the body in-flight