### PR TITLE
fix header propagate bug

### DIFF
--- a/codegen/header_propagate.go
+++ b/codegen/header_propagate.go
@@ -100,7 +100,7 @@ func typeSwitch(key, gotype string, field *compile.FieldSpec) []string {
 		assignVal = "v"
 	case "int16":
 		typeParse = "strconv.ParseInt(key, 10, 16)"
-		assignVal = "v"
+		assignVal = "val"
 		typeCast = "val := int16(v)\n"
 	case "int32":
 		typeParse = "strconv.ParseInt(key, 10, 32)"

--- a/codegen/header_propagate_test.go
+++ b/codegen/header_propagate_test.go
@@ -403,13 +403,13 @@ func TestPrimaryType(t *testing.T) {
 		if key, ok := headers.Get("x-int"); ok {
 			if v, err := strconv.ParseInt(key,10,16); err == nil {
 				val:=int16(v)
-				in.I5=v
+				in.I5=val
 			}
 		}
 		if key, ok := headers.Get("x-int"); ok {
 			if v, err := strconv.ParseInt(key,10,16); err == nil {
 				val:=int16(v)
-				in.I6=&v
+				in.I6=&val
 			}
 		}
 		if key, ok := headers.Get("x-string"); ok {


### PR DESCRIPTION
In the typeSwitch function `assignVal` should be set to `val` for int16 case. 
For the int64 case `assignVal = "v"` is correct because `ParseInt` returns an int64. Hence, no type cast is necessary. However for the int16 case a type cast is necessary. 

Here is a concrete example of generated code without this change
```
if v, err := strconv.ParseInt(key, 10, 16); err == nil {
    val := int16(v)
    in.Request.CityId = &v
}
```
and the error
```
cannot use &v (type *int64) as type *int16 in assignment
```