### PR TITLE
Add more context in codegen panic message

### DIFF
--- a/codegen/method.go
+++ b/codegen/method.go
@@ -1058,14 +1058,14 @@ func getQueryMethodForType(typeSpec compile.TypeSpec) string {
 			queryMethod = "GetQueryValues"
 		default:
 			panic(fmt.Sprintf(
-				"Unsupported list value type (%T) %v for query string parameter",
-				t.ValueSpec, t.ValueSpec,
+				"Unsupported list value type (%T) for %s as query string parameter",
+				t.ValueSpec, t.ValueSpec.ThriftName(),
 			))
 		}
 	default:
 		panic(fmt.Sprintf(
-			"Unknown type (%T) %v for query string parameter",
-			typeSpec, typeSpec,
+			"Unsupported type (%T) for %s as query string parameter",
+			typeSpec, typeSpec.ThriftName(),
 		))
 	}
 
@@ -1147,14 +1147,14 @@ func getQueryEncodeExpression(
 			}
 		default:
 			panic(fmt.Sprintf(
-				"Unsupported list value type (%T) %v for query string parameter",
-				t.ValueSpec, t.ValueSpec,
+				"Unsupported list value type (%T) for %s as query string parameter",
+				t.ValueSpec, t.ValueSpec.ThriftName(),
 			))
 		}
 	default:
 		panic(fmt.Sprintf(
-			"Unknown type (%T) %v for query string parameter",
-			typeSpec, typeSpec,
+			"Unsupported type (%T) for %s as query string parameter",
+			typeSpec, typeSpec.ThriftName(),
 		))
 	}
 

--- a/codegen/thrift.go
+++ b/codegen/thrift.go
@@ -77,7 +77,7 @@ func GoType(p PackageNameResolver, spec compile.TypeSpec) (string, error) {
 	case *compile.EnumSpec, *compile.StructSpec, *compile.TypedefSpec:
 		return goCustomType(p, spec)
 	default:
-		panic(fmt.Sprintf("Unknown type (%T) %v", spec, spec))
+		panic(fmt.Sprintf("Unknown type (%T) for %s", spec, spec.ThriftName()))
 	}
 }
 
@@ -156,8 +156,8 @@ func pointerMethodType(typeSpec compile.TypeSpec) string {
 		pointerMethod = "Int32"
 	default:
 		panic(fmt.Sprintf(
-			"Unknown type (%T) %v for allocating a pointer",
-			typeSpec, typeSpec,
+			"Unknown type (%T) for %s for allocating a pointer",
+			typeSpec, typeSpec.ThriftName(),
 		))
 	}
 

--- a/codegen/thrift_test.go
+++ b/codegen/thrift_test.go
@@ -59,7 +59,7 @@ func (f *fakePackageNameResover) TypePackageName(string) (string, error) {
 func TestGoTypeUnknownType(t *testing.T) {
 	s := &fakeSpec{}
 	p := &fakePackageNameResover{}
-	assert.PanicsWithValue(t, "Unknown type (*codegen_test.fakeSpec) &{}", func() {
+	assert.PanicsWithValue(t, "Unknown type (*codegen_test.fakeSpec) for fake", func() {
 		_, _ = codegen.GoType(p, s)
 	})
 


### PR DESCRIPTION
The panic messages due to codegen failures did not indicate which thrift structure was
the one with the issue.  This prevented easy debugging.  With this, we print out the
offending thrift structure's name so it can be tracked down.