### PR TITLE
Add URL logging to server_http_request

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -76,6 +76,7 @@ func NewServerHTTPRequest(
 	logFields := []zap.Field{
 		zap.String(logFieldEndpointID, endpoint.EndpointName),
 		zap.String(logFieldEndpointHandler, endpoint.HandlerName),
+		zap.String(logFieldRequestURL, r.URL.Path),
 	}
 
 	// put request scope tags on context

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1665,6 +1665,7 @@ func TestIncomingHTTPRequestServerLog(t *testing.T) {
 		"statusCode":      float64(200),
 		"endpointHandler": "foo",
 		"endpointID":      "foo",
+		"url":             "/foo",
 
 		"Accept-Encoding":         "gzip",
 		"User-Agent":              "Go-http-client/1.1",


### PR DESCRIPTION
When our service gets a request for a URL we dont handle, we only see in the logs that it was handled by our 404handler and not what the URL itself was. This makes debugging hard.