### PR TITLE
Allow query params to be used as a set argument to method

### DIFF
--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -261,7 +261,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 	if !aListUUIDOk {
 		return
 	}
-	aListUUIDQuery, ok := req.GetQueryValues("aListUUID")
+	aListUUIDQuery, ok := req.GetQueryValueList("aListUUID")
 	if !ok {
 		return
 	}
@@ -273,7 +273,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 
 	anOptListUUIDOk := req.HasQueryValue("anOptListUUID")
 	if anOptListUUIDOk {
-		anOptListUUIDQuery, ok := req.GetQueryValues("anOptListUUID")
+		anOptListUUIDQuery, ok := req.GetQueryValueList("anOptListUUID")
 		if !ok {
 			return
 		}
@@ -288,7 +288,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 	if !aStringListOk {
 		return
 	}
-	aStringListQuery, ok := req.GetQueryValues("aStringList")
+	aStringListQuery, ok := req.GetQueryValueList("aStringList")
 	if !ok {
 		return
 	}
@@ -296,7 +296,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 
 	anOptStringListOk := req.HasQueryValue("anOptStringList")
 	if anOptStringListOk {
-		anOptStringListQuery, ok := req.GetQueryValues("anOptStringList")
+		anOptStringListQuery, ok := req.GetQueryValueList("anOptStringList")
 		if !ok {
 			return
 		}
@@ -307,7 +307,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 	if !aUUIDListOk {
 		return
 	}
-	aUUIDListQuery, ok := req.GetQueryValues("aUUIDList")
+	aUUIDListQuery, ok := req.GetQueryValueList("aUUIDList")
 	if !ok {
 		return
 	}
@@ -319,7 +319,7 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 
 	anOptUUIDListOk := req.HasQueryValue("anOptUUIDList")
 	if anOptUUIDListOk {
-		anOptUUIDListQuery, ok := req.GetQueryValues("anOptUUIDList")
+		anOptUUIDListQuery, ok := req.GetQueryValueList("anOptUUIDList")
 		if !ok {
 			return
 		}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -143,7 +143,7 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 	if !requestFooOk {
 		return
 	}
-	requestFooQuery, ok := req.GetQueryValues("request.foo")
+	requestFooQuery, ok := req.GetQueryValueList("request.foo")
 	if !ok {
 		return
 	}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -126,7 +126,7 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 
 	fooOk := req.HasQueryValue("foo")
 	if fooOk {
-		fooQuery, ok := req.GetQueryValues("foo")
+		fooQuery, ok := req.GetQueryValueList("foo")
 		if !ok {
 			return
 		}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_listandenum.go
@@ -109,7 +109,7 @@ func (h *BarListAndEnumHandler) HandleRequest(
 	if !demoIdsOk {
 		return
 	}
-	demoIdsQuery, ok := req.GetQueryValues("demoIds")
+	demoIdsQuery, ok := req.GetQueryValueList("demoIds")
 	if !ok {
 		return
 	}

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -418,6 +418,8 @@ func (req *ServerHTTPRequest) GetQueryFloat64(key string) (float64, bool) {
 	return number, true
 }
 
+// -- Query params as  lists --
+
 // GetQueryBoolList will return a query param as a list of boolean
 func (req *ServerHTTPRequest) GetQueryBoolList(key string) ([]bool, bool) {
 	success := req.parseQueryValues()
@@ -554,6 +556,159 @@ func (req *ServerHTTPRequest) GetQueryValues(key string) ([]string, bool) {
 	}
 
 	return req.queryValues[key], true
+}
+
+// GetQueryValueList will return all query parameters for key.
+func (req *ServerHTTPRequest) GetQueryValueList(key string) ([]string, bool) {
+	return req.GetQueryValues(key)
+}
+
+// -- Query param as set --
+
+// The "value" in the map representation of a set datastructure
+var _nullVal = struct{}{}
+
+// GetQueryBoolSet will return a query param as a set of boolean
+// @argo: Does this method even make sense?
+func (req *ServerHTTPRequest) GetQueryBoolSet(key string) (map[bool]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[bool]struct{}, len(values))
+	for _, value := range values {
+		if value == "true" {
+			ret[true] = _nullVal
+		} else if value == "false" {
+			ret[false] = _nullVal
+		} else {
+			err := &strconv.NumError{
+				Func: "ParseBool",
+				Num:  value,
+				Err:  strconv.ErrSyntax,
+			}
+			req.logAndSendQueryError(err, "bool", key, value)
+			return nil, false
+		}
+	}
+
+	return ret, true
+}
+
+// GetQueryInt8Set will return a query params as set of int8
+func (req *ServerHTTPRequest) GetQueryInt8Set(key string) (map[int8]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[int8]struct{}, len(values))
+	for _, value := range values {
+		number, err := strconv.ParseInt(value, 10, 8)
+		if err != nil {
+			req.logAndSendQueryError(err, "int8", key, value)
+			return nil, false
+		}
+		ret[int8(number)] = _nullVal
+	}
+	return ret, true
+}
+
+// GetQueryInt16Set will return a query params as set of int16
+func (req *ServerHTTPRequest) GetQueryInt16Set(key string) (map[int16]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[int16]struct{}, len(values))
+	for _, value := range values {
+		number, err := strconv.ParseInt(value, 10, 16)
+		if err != nil {
+			req.logAndSendQueryError(err, "int16", key, value)
+			return nil, false
+		}
+		ret[int16(number)] = _nullVal
+	}
+	return ret, true
+}
+
+// GetQueryInt32Set will return a query params as set of int32
+func (req *ServerHTTPRequest) GetQueryInt32Set(key string) (map[int32]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[int32]struct{}, len(values))
+	for _, value := range values {
+		number, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			req.logAndSendQueryError(err, "int32", key, value)
+			return nil, false
+		}
+		ret[int32(number)] = _nullVal
+	}
+	return ret, true
+}
+
+// GetQueryInt64Set will return a query params as set of int64
+func (req *ServerHTTPRequest) GetQueryInt64Set(key string) (map[int64]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[int64]struct{}, len(values))
+	for _, value := range values {
+		number, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			req.logAndSendQueryError(err, "int64", key, value)
+			return nil, false
+		}
+		ret[number] = _nullVal
+	}
+	return ret, true
+}
+
+// GetQueryFloat64Set will return a query params as set of float64
+func (req *ServerHTTPRequest) GetQueryFloat64Set(key string) (map[float64]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	values := req.queryValues[key]
+	ret := make(map[float64]struct{}, len(values))
+	for _, value := range values {
+		number, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			req.logAndSendQueryError(err, "float64", key, value)
+			return nil, false
+		}
+		ret[number] = _nullVal
+	}
+	return ret, true
+}
+
+// GetQueryValueSet will return all query parameters for key as a set
+func (req *ServerHTTPRequest) GetQueryValueSet(key string) (map[string]struct{}, bool) {
+	success := req.parseQueryValues()
+	if !success {
+		return nil, false
+	}
+
+	ret := make(map[string]struct{}, len(req.queryValues[key]))
+	for _, v := range req.queryValues[key] {
+		ret[v] = _nullVal
+	}
+	return ret, true
 }
 
 // HasQueryPrefix will check if any query param starts with key.


### PR DESCRIPTION
With this change, we allow the query params to be marshaled into a set rather than a list as an argument to an endpoint method