### PR TITLE
use clientConfig struct for unmarshalling yarpc clients instead of generic classConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ for config_file in ${config_files}; do
 	dir=$(dirname "$config_file")
 	yaml_files=$(find "$dir" -name "*.yaml")
 	for yaml_file in ${yaml_files}; do
-		thrift_file=$(yq -r '.. | .thriftFile? | select(strings | endswith(".thrift"))' "$yaml_file")
+		thrift_file=$(yq -r '.. | .idlFile? | select(strings | endswith(".thrift"))' "$yaml_file")
 		[[ -z ${thrift_file} ]] && continue
 		[[ ${THRIFTRW_SRCS} == *${thrift_file}* ]] && continue
         THRIFTRW_SRCS+=" $CONFIG_DIR/idl/$thrift_file"

--- a/codegen/client.go
+++ b/codegen/client.go
@@ -44,6 +44,16 @@ type ClientThriftConfig struct {
 	Fixture        *Fixture          `yaml:"fixture,omitempty" json:"fixture"`
 }
 
+// ClientIDLConfig is the "config" field in the client-config.yaml for gRPC clients.
+// This struct is generic and can be used to replace HTTP/TChannel client config as well.
+type ClientIDLConfig struct {
+	ExposedMethods map[string]string `yaml:"exposedMethods" json:"exposedMethods" validate:"exposedMethods"`
+	IDLFile        string            `yaml:"idlFile" json:"idlFile" validate:"nonzero"`
+	IDLFileSha     string            `yaml:"idlFileSha,omitempty" json:"idlFileSha"`
+	SidecarRouter  string            `yaml:"sidecarRouter" json:"sidecarRouter"`
+	Fixture        *Fixture          `yaml:"fixture,omitempty" json:"fixture"`
+}
+
 // Fixture specifies client fixture import path and all scenarios
 type Fixture struct {
 	// ImportPath is the package where the user-defined Fixture global variable is contained.
@@ -222,6 +232,13 @@ func (c *CustomClientConfig) NewClientSpec(
 	}
 
 	return spec, nil
+}
+
+// GRPCClientConfig represents the "config" field for a gRPC client-config.yaml.
+type GRPCClientConfig struct {
+	ClassConfigBase `yaml:",inline" json:",inline"`
+	Dependencies    Dependencies     `yaml:"dependencies,omitempty" json:"dependencies"`
+	Config          *ClientIDLConfig `yaml:"config" json:"config" validate:"nonzero"`
 }
 
 func clientType(raw []byte) (string, error) {

--- a/codegen/client.go
+++ b/codegen/client.go
@@ -34,18 +34,8 @@ type clientConfig interface {
 		h *PackageHelper) (*ClientSpec, error)
 }
 
-// ClientThriftConfig is the "config" field in the client-config.yaml for http
-// client and tchannel client.
-type ClientThriftConfig struct {
-	ExposedMethods map[string]string `yaml:"exposedMethods" json:"exposedMethods" validate:"exposedMethods"`
-	ThriftFile     string            `yaml:"thriftFile" json:"thriftFile" validate:"nonzero"`
-	ThriftFileSha  string            `yaml:"thriftFileSha,omitempty" json:"thriftFileSha"`
-	SidecarRouter  string            `yaml:"sidecarRouter" json:"sidecarRouter"`
-	Fixture        *Fixture          `yaml:"fixture,omitempty" json:"fixture"`
-}
-
-// ClientIDLConfig is the "config" field in the client-config.yaml for gRPC clients.
-// This struct is generic and can be used to replace HTTP/TChannel client config as well.
+// ClientIDLConfig is the "config" field in the client-config.yaml for
+// HTTP/TChannel/gRPC clients.
 type ClientIDLConfig struct {
 	ExposedMethods map[string]string `yaml:"exposedMethods" json:"exposedMethods" validate:"exposedMethods"`
 	IDLFile        string            `yaml:"idlFile" json:"idlFile" validate:"nonzero"`
@@ -95,8 +85,8 @@ func validateExposedMethods(v interface{}, param string) error {
 // HTTPClientConfig represents the "config" field for a HTTP client-config.yaml
 type HTTPClientConfig struct {
 	ClassConfigBase `yaml:",inline" json:",inline"`
-	Dependencies    Dependencies        `yaml:"dependencies,omitempty" json:"dependencies"`
-	Config          *ClientThriftConfig `yaml:"config" json:"config" validate:"nonzero"`
+	Dependencies    Dependencies     `yaml:"dependencies,omitempty" json:"dependencies"`
+	Config          *ClientIDLConfig `yaml:"config" json:"config" validate:"nonzero"`
 }
 
 func newHTTPClientConfig(raw []byte) (*HTTPClientConfig, error) {
@@ -117,12 +107,12 @@ func newHTTPClientConfig(raw []byte) (*HTTPClientConfig, error) {
 
 func newClientSpec(
 	clientType string,
-	config *ClientThriftConfig,
+	config *ClientIDLConfig,
 	instance *ModuleInstance,
 	h *PackageHelper,
 	annotate bool,
 ) (*ClientSpec, error) {
-	thriftFile := filepath.Join(h.ThriftIDLPath(), config.ThriftFile)
+	thriftFile := filepath.Join(h.ThriftIDLPath(), config.IDLFile)
 	mspec, err := NewModuleSpec(thriftFile, annotate, false, h)
 
 	if err != nil {
@@ -161,8 +151,8 @@ func (c *HTTPClientConfig) NewClientSpec(
 // TChannelClientConfig represents the "config" field for a TChannel client-config.yaml
 type TChannelClientConfig struct {
 	ClassConfigBase `yaml:",inline" json:",inline"`
-	Dependencies    Dependencies        `yaml:"dependencies,omitempty" json:"dependencies"`
-	Config          *ClientThriftConfig `yaml:"config" json:"config" validate:"nonzero"`
+	Dependencies    Dependencies     `yaml:"dependencies,omitempty" json:"dependencies"`
+	Config          *ClientIDLConfig `yaml:"config" json:"config" validate:"nonzero"`
 }
 
 func newTChannelClientConfig(raw []byte) (*TChannelClientConfig, error) {

--- a/codegen/client_test.go
+++ b/codegen/client_test.go
@@ -37,8 +37,8 @@ dependencies:
     - a
     - b
 config:
-  thriftFileSha: thriftFileSha
-  thriftFile: clients/bar/bar.thrift
+  idlFileSha: idlFileSha
+  idlFile: clients/bar/bar.thrift
   customImportPath: path
   sidecarRouter: sidecar
   fixture:
@@ -59,8 +59,8 @@ dependencies:
     - a
     - b
 config:
-  thriftFileSha: thriftFileSha
-  thriftFile: clients/bar/bar.thrift
+  idlFileSha: idlFileSha
+  idlFile: clients/bar/bar.thrift
   customImportPath: path
   sidecarRouter: sidecar
   fixture:
@@ -142,8 +142,8 @@ func doThriftFileMissingTest(t *testing.T, clientType string) {
 name: test
 type: %s
 config:
-  thriftFileSha: thriftFileSha
-  # thriftFile is missing
+  idlFileSha: idlFileSha
+  # idlFile is missing
 `, clientType)
 
 	_, err := newClientConfig([]byte(configYAML))
@@ -164,8 +164,8 @@ func doThriftFileShaMissingTest(t *testing.T, clientType string) {
 name: test
 type: %s
 config:
-  # thriftFileSha is missing
-  thriftFile: thriftFile
+  # idlFileSha is missing
+  idlFile: idlFile
 `, clientType)
 
 	_, err := newClientConfig([]byte(configYAML))
@@ -182,7 +182,7 @@ func TestCustomClientRequiresCustomImportPath(t *testing.T) {
 name: test
 type: custom
 config:
-  thriftFileSha: thriftFileSha
+  idlFileSha: idlFileSha
   # CustomImportPath is missing
 `
 	_, err := newCustomClientConfig([]byte(configYAML))
@@ -196,8 +196,8 @@ func doDuplicatedExposedMethodsTest(t *testing.T, clientType string) {
 name: test
 type: %s
 config:
-  thriftFileSha: thriftFileSha
-  thriftFile: thriftFile
+  idlFileSha: idlFileSha
+  idlFile: idlFile
   exposedMethods:
     a: method
     b: method
@@ -241,7 +241,7 @@ func TestNewClientConfigTypeError(t *testing.T) {
 name: test
 type: : # malformated type
 config:
-  thriftFileSha: thriftFileSha
+  idlFileSha: idlFileSha
 `
 
 	_, err := newClientConfig([]byte(configYAML))
@@ -255,7 +255,7 @@ func TestNewClientConfigUnknownClientType(t *testing.T) {
 name: test
 type: unknown
 config:
-  thriftFileSha: thriftFileSha
+  idlFileSha: idlFileSha
 `
 	_, err := newClientConfig([]byte(configYAML))
 	expectedErr := "Unknown client type \"unknown\""
@@ -277,7 +277,7 @@ func TestNewClientConfigGetHTTPClient(t *testing.T) {
 			ExposedMethods: map[string]string{
 				"a": "method",
 			},
-			IDLFileSha:    "thriftFileSha",
+			IDLFileSha:    "idlFileSha",
 			IDLFile:       "clients/bar/bar.thrift",
 			SidecarRouter: "sidecar",
 			Fixture: &Fixture{
@@ -306,7 +306,7 @@ func TestNewClientConfigGetTChannelClient(t *testing.T) {
 			ExposedMethods: map[string]string{
 				"a": "method",
 			},
-			IDLFileSha:    "thriftFileSha",
+			IDLFileSha:    "idlFileSha",
 			IDLFile:       "clients/bar/bar.thrift",
 			SidecarRouter: "sidecar",
 			Fixture: &Fixture{
@@ -376,8 +376,8 @@ func TestHTTPClientNewClientSpecFailedWithThriftCompilation(t *testing.T) {
 name: test
 type: http
 config:
-  thriftFileSha: thriftFileSha
-  thriftFile: NOT_EXIST
+  idlFileSha: idlFileSha
+  idlFile: NOT_EXIST
   exposedMethods:
     a: method
 `
@@ -405,7 +405,7 @@ func doNewClientSpecTest(t *testing.T, rawConfig []byte, clientType string) {
 	}
 	h := newTestPackageHelper(t)
 
-	thriftFile := filepath.Join(h.ThriftIDLPath(), "clients/bar/bar.thrift")
+	idlFile := filepath.Join(h.ThriftIDLPath(), "clients/bar/bar.thrift")
 	expectedSpec := &ClientSpec{
 		ModuleSpec:         nil,
 		YAMLFile:           instance.YAMLFileName,
@@ -415,7 +415,7 @@ func doNewClientSpecTest(t *testing.T, rawConfig []byte, clientType string) {
 		ImportPackageAlias: instance.PackageInfo.ImportPackageAlias(),
 		ExportName:         instance.PackageInfo.ExportName,
 		ExportType:         instance.PackageInfo.ExportType,
-		ThriftFile:         thriftFile,
+		ThriftFile:         idlFile,
 		ClientID:           instance.InstanceName,
 		ClientName:         instance.PackageInfo.QualifiedInstanceName,
 		ExposedMethods: map[string]string{

--- a/codegen/client_test.go
+++ b/codegen/client_test.go
@@ -150,7 +150,7 @@ config:
 	assert.Error(t, err)
 	assert.Equal(
 		t,
-		fmt.Sprintf("%s client config validation failed: Config.ThriftFile: zero value", clientType),
+		fmt.Sprintf("%s client config validation failed: Config.IDLFile: zero value", clientType),
 		err.Error())
 }
 
@@ -273,12 +273,12 @@ func TestNewClientConfigGetHTTPClient(t *testing.T) {
 		Dependencies: Dependencies{
 			Client: []string{"a", "b"},
 		},
-		Config: &ClientThriftConfig{
+		Config: &ClientIDLConfig{
 			ExposedMethods: map[string]string{
 				"a": "method",
 			},
-			ThriftFileSha: "thriftFileSha",
-			ThriftFile:    "clients/bar/bar.thrift",
+			IDLFileSha:    "thriftFileSha",
+			IDLFile:       "clients/bar/bar.thrift",
 			SidecarRouter: "sidecar",
 			Fixture: &Fixture{
 				ImportPath: "import",
@@ -302,12 +302,12 @@ func TestNewClientConfigGetTChannelClient(t *testing.T) {
 		Dependencies: Dependencies{
 			Client: []string{"a", "b"},
 		},
-		Config: &ClientThriftConfig{
+		Config: &ClientIDLConfig{
 			ExposedMethods: map[string]string{
 				"a": "method",
 			},
-			ThriftFileSha: "thriftFileSha",
-			ThriftFile:    "clients/bar/bar.thrift",
+			IDLFileSha:    "thriftFileSha",
+			IDLFile:       "clients/bar/bar.thrift",
 			SidecarRouter: "sidecar",
 			Fixture: &Fixture{
 				ImportPath: "import",

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -805,7 +805,7 @@ func (g *YarpcClientGenerator) ComputeSpec(
 func (g *YarpcClientGenerator) Generate(
 	instance *ModuleInstance,
 ) (*BuildResult, error) {
-	clientConfig := &ClassConfig{}
+	clientConfig := &GRPCClientConfig{}
 	if err := yaml.Unmarshal(instance.YAMLFileRaw, &clientConfig); err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -821,15 +821,7 @@ func (g *YarpcClientGenerator) Generate(
 		Instance: instance,
 	}
 
-	v, ok := clientConfig.Config["protoFile"]
-	if !ok {
-		return nil, errors.Errorf(
-			"Missing \"protoFile\" field in %q YAML config",
-			instance.InstanceName,
-		)
-	}
-	protoFile := v.(string)
-	parts := strings.Split(protoFile, "/")
+	parts := strings.Split(clientConfig.Config.IDLFile, "/")
 	genDir := strings.Join(parts[0:len(parts)-1], "/")
 
 	data.GenPkg = path.Join(

--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -144,6 +144,7 @@ for config_file in ${config_files}; do
 		fi
 
 		thrift_file=$(${processor} -r '.. | .thriftFile? | select(strings | endswith(".thrift"))' "$yaml_file")
+		thrift_file+=$(${processor} -r '.. | .idlFile? | select(strings | endswith(".thrift"))' "$yaml_file")
 
 		# process .proto files
 		proto_file=$(${processor} -r '.. | .idlFile? | select(strings | endswith(".proto"))' "$yaml_file")

--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -91,7 +91,7 @@ for config_file in ${config_files}; do
 			processor="jq"
 		fi
 
-		proto_file=$(${processor} -r '.. | .protoFile? | select(strings | endswith(".proto"))' "$yaml_file")
+		proto_file=$(${processor} -r '.. | .idlFile? | select(strings | endswith(".proto"))' "$yaml_file")
 		if [[ ! -z ${proto_file} ]] && [[ ${found_protos} != *${proto_file}* ]]; then
 			found_protos+=" $proto_file"
 			proto_dir=$(dirname "$proto_file")
@@ -146,7 +146,7 @@ for config_file in ${config_files}; do
 		thrift_file=$(${processor} -r '.. | .thriftFile? | select(strings | endswith(".thrift"))' "$yaml_file")
 
 		# process .proto files
-		proto_file=$(${processor} -r '.. | .protoFile? | select(strings | endswith(".proto"))' "$yaml_file")
+		proto_file=$(${processor} -r '.. | .idlFile? | select(strings | endswith(".proto"))' "$yaml_file")
 		if [[ ! -z ${proto_file} ]] && [[ ${found_protos} != *${proto_file}* ]]; then
 			found_protos+=" $proto_file"
 			proto_file="$IDL_DIR/$proto_file"

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -915,7 +915,7 @@ func (c *TypeConverter) genStructConverter(
 			// 	toField.Type.TypeCode().String(), toField.Name,
 			// )
 
-			// pkgName, err := h.TypePackageName(toField.Type.ThriftFile())
+			// pkgName, err := h.TypePackageName(toField.Type.IDLFile())
 			// if err != nil {
 			// 	return nil, err
 			// }

--- a/docs/client_config_schema.json
+++ b/docs/client_config_schema.json
@@ -25,14 +25,14 @@
 		"config": {
 			"type": "object",
 			"properties": {
-				"thriftFile": {
+				"idlFile": {
 					"type": "string",
 					"description": "Path to client thrift file, relative to idl path",
 					"examples": [
 						"clients/contacts/contacts.thrift"
 					]
 				},
-				"thriftFileSha": {
+				"idlFileSha": {
 					"type": "string",
 					"description": "Sha of the thrift file, reserved but currently not used",
 					"examples": [

--- a/examples/example-gateway/clients/bar/client-config.json
+++ b/examples/example-gateway/clients/bar/client-config.json
@@ -2,8 +2,8 @@
 	"name": "bar",
 	"type": "http",
 	"config": {
-		"thriftFile": "clients/bar/bar.thrift",
-		"thriftFileSha": "{{placeholder}}",
+		"idlFile": "clients/bar/bar.thrift",
+		"idlFileSha": "{{placeholder}}",
 		"exposedMethods": {
 			"Normal": "Bar::normal",
 			"NormalRecur": "Bar::normalRecur",

--- a/examples/example-gateway/clients/baz/client-config.yaml
+++ b/examples/example-gateway/clients/baz/client-config.yaml
@@ -27,8 +27,8 @@ config:
     TransHeadersNoReq: SimpleService::transHeadersNoReq
     TransHeadersType: SimpleService::transHeadersType
     URLTest: SimpleService::urlTest
-  thriftFile: clients/baz/baz.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/baz/baz.thrift
+  idlFileSha: '{{placeholder}}'
   genTestServer: true
 name: baz
 type: tchannel

--- a/examples/example-gateway/clients/contacts/client-config.yaml
+++ b/examples/example-gateway/clients/contacts/client-config.yaml
@@ -7,7 +7,7 @@ config:
     scenarios:
       SaveContacts:
       - success
-  thriftFile: clients/contacts/contacts.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/contacts/contacts.thrift
+  idlFileSha: '{{placeholder}}'
 name: contacts
 type: http

--- a/examples/example-gateway/clients/corge-http/client-config.yaml
+++ b/examples/example-gateway/clients/corge-http/client-config.yaml
@@ -2,7 +2,7 @@ config:
   exposedMethods:
     EchoString: Corge::echoString
   sidecarRouter: default
-  thriftFile: clients/corge/corge.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/corge/corge.thrift
+  idlFileSha: '{{placeholder}}'
 name: corge-http
 type: http

--- a/examples/example-gateway/clients/corge/client-config.yaml
+++ b/examples/example-gateway/clients/corge/client-config.yaml
@@ -2,7 +2,7 @@ config:
   exposedMethods:
     EchoString: Corge::echoString
   sidecarRouter: default
-  thriftFile: clients/corge/corge.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/corge/corge.thrift
+  idlFileSha: '{{placeholder}}'
 name: corge
 type: tchannel

--- a/examples/example-gateway/clients/echo/client-config.yaml
+++ b/examples/example-gateway/clients/echo/client-config.yaml
@@ -1,4 +1,4 @@
 name: echo
 type: grpc
 config:
-  protoFile: clients/echo/echo.proto
+  idlFile: clients/echo/echo.proto

--- a/examples/example-gateway/clients/google-now/client-config.yaml
+++ b/examples/example-gateway/clients/google-now/client-config.yaml
@@ -2,7 +2,7 @@ config:
   exposedMethods:
     AddCredentials: GoogleNowService::addCredentials
     CheckCredentials: GoogleNowService::checkCredentials
-  thriftFile: clients/googlenow/googlenow.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/googlenow/googlenow.thrift
+  idlFileSha: '{{placeholder}}'
 name: google-now
 type: http

--- a/examples/example-gateway/clients/multi/client-config.yaml
+++ b/examples/example-gateway/clients/multi/client-config.yaml
@@ -2,7 +2,7 @@ config:
   exposedMethods:
     HelloA: ServiceABack::hello
     HelloB: ServiceBBack::hello
-  thriftFile: clients/multi/multi.thrift
-  thriftFileSha: '{{placeholder}}'
+  idlFile: clients/multi/multi.thrift
+  idlFileSha: '{{placeholder}}'
 name: multi
 type: http

--- a/examples/example-gateway/clients/withexceptions/client-config.json
+++ b/examples/example-gateway/clients/withexceptions/client-config.json
@@ -2,8 +2,8 @@
 	"name": "withexceptions",
 	"type": "http",
 	"config": {
-		"thriftFile": "clients/withexceptions/withexceptions.thrift",
-		"thriftFileSha": "{{placeholder}}",
+		"idlFile": "clients/withexceptions/withexceptions.thrift",
+		"idlFileSha": "{{placeholder}}",
 		"exposedMethods": {
 			"Func1": "WithExceptions::Func1"
 		}


### PR DESCRIPTION
- There are additional configurations such as exposed methods, sidecar router, etc. that need to be configured in the Gateway and the generic ClassConfig doesn't provide a strict contract for those to be present.
- Using ClientConfig makes the implementation for the various Clients consistent in implementation.
- ClientConfig always assumes thriftFile whereas YARPC clients use protoFiles, migrating clientConfig to a IDL agnostic idlFile naming

This is a breaking change for existing users of Zanzibar due to the name change and probably requires a version bump.

The scope of this diff is to only handle the client-side changes to unify Thrift vs. Proto struct to unblock other development that depends on this struct. Will be following up with a thorough cleanup of thriftFile -> idlFile for the endpoint as well as all other references and implement non-nil SpecGenerator impl for YARPC Client.