### PR TITLE
Fix entries in build.yaml being order dependent

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -641,21 +641,21 @@ func (system *ModuleSystem) ResolveModules(
 					)
 				}
 			}
+		}
 
-			// Resolve dependencies for all classes
-			resolveErr := system.populateResolvedDependencies(
-				resolvedModules[className],
-				resolvedModules,
-			)
-			if resolveErr != nil {
-				return nil, resolveErr
-			}
+		// Resolve dependencies for all classes
+		resolveErr := system.populateResolvedDependencies(
+			resolvedModules[className],
+			resolvedModules,
+		)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
 
-			// Resolved recursive dependencies for all classes
-			recursiveErr := system.populateRecursiveDependencies(resolvedModules[className])
-			if recursiveErr != nil {
-				return nil, recursiveErr
-			}
+		// Resolved recursive dependencies for all classes
+		recursiveErr := system.populateRecursiveDependencies(resolvedModules[className])
+		if recursiveErr != nil {
+			return nil, recursiveErr
 		}
 	}
 


### PR DESCRIPTION
Because we are populating resolved dependencies inside the loop over
each glob pattern, we introduce an ordering dependency. If a module
that is matched by early glob pattern depends on something that is
matched by a later glob pattern, we will fail to find the module in
the list of resolved modules so far. Instead we should wait to
populate resolved dependencies until all of the glob patterns have
been evaluated.