### PR TITLE
Remove timeouts for test server

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2027,9 +2027,6 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
-
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
 		server.Logger,
@@ -2037,8 +2034,6 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		&zanzibar.TChannelClientOption{
 			ServiceName:       server.ServiceName,
 			ClientID:          "TestClient",
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
 		},
 	)
 
@@ -2135,7 +2130,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 5283, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 5097, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -99,9 +99,6 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
-
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
 		server.Logger,
@@ -109,8 +106,6 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		&zanzibar.TChannelClientOption{
 			ServiceName:       server.ServiceName,
 			ClientID:          "TestClient",
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
 		},
 	)
 

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -31,7 +31,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/uber/zanzibar/config"
@@ -115,18 +114,13 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
-
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
 		server.Logger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       server.ServiceName,
-			ClientID:          "TestClient",
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
+			ServiceName: server.ServiceName,
+			ClientID:    "TestClient",
 		},
 	)
 

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -31,7 +31,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/uber/zanzibar/config"
@@ -115,18 +114,13 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
-
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
 		server.Logger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       server.ServiceName,
-			ClientID:          "TestClient",
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
+			ServiceName: server.ServiceName,
+			ClientID:    "TestClient",
 		},
 	)
 

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -31,7 +31,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/uber/zanzibar/config"
@@ -115,18 +114,13 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
-
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
 		server.Logger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
-			ServiceName:       server.ServiceName,
-			ClientID:          "TestClient",
-			Timeout:           timeout,
-			TimeoutPerAttempt: timeoutPerAttempt,
+			ServiceName: server.ServiceName,
+			ClientID:    "TestClient",
 		},
 	)
 


### PR DESCRIPTION
If we have hard coded timeouts for test server clients, then tests
using these clients are flaky. Remove the timeout to fall back to
default behavior which is no timeout.