### PR TITLE
Fixing nil pointer dereference for optional fields

### DIFF
--- a/codegen/method.go
+++ b/codegen/method.go
@@ -802,7 +802,7 @@ func (ms *MethodSpec) setClientRequestHeaderFields(
 					// Note header values are always string
 					headerNameValuePair = "headers[%q]= string(r%s)"
 				} else {
-					headerNameValuePair = "if r != nil {" +
+					headerNameValuePair = "if r%s != nil {" +
 						"headers[%q]= string(*r%s)" + "}"
 				}
 				if len(seenOptStructs) == 0 {

--- a/codegen/method.go
+++ b/codegen/method.go
@@ -802,7 +802,8 @@ func (ms *MethodSpec) setClientRequestHeaderFields(
 					// Note header values are always string
 					headerNameValuePair = "headers[%q]= string(r%s)"
 				} else {
-					headerNameValuePair = "headers[%q]= string(*r%s)"
+					headerNameValuePair = "if r != nil {" +
+						"headers[%q]= string(*r%s)" + "}"
 				}
 				if len(seenOptStructs) == 0 {
 					statements.appendf(headerNameValuePair,

--- a/codegen/method.go
+++ b/codegen/method.go
@@ -802,14 +802,9 @@ func (ms *MethodSpec) setClientRequestHeaderFields(
 					// Note header values are always string
 					headerNameValuePair = "headers[%q]= string(r%s)"
 				} else {
-					headerNameValuePair = "if r%s != nil {" +
-						"headers[%q]= string(*r%s)" + "}"
+					headerNameValuePair = "headers[%q]= string(*r%s)"
 				}
-				if len(seenOptStructs) == 0 {
-					statements.appendf(headerNameValuePair,
-						headerName, bodyIdentifier,
-					)
-				} else {
+				if len(seenOptStructs) != 0 {
 					closeFunction := ""
 					for seenStruct := range seenOptStructs {
 						if strings.HasPrefix(longFieldName, seenStruct) {
@@ -817,10 +812,16 @@ func (ms *MethodSpec) setClientRequestHeaderFields(
 							closeFunction = closeFunction + "}"
 						}
 					}
+					statements.append(closeFunction)
+				}
+				if field.Required {
 					statements.appendf(headerNameValuePair,
 						headerName, bodyIdentifier,
 					)
-					statements.append(closeFunction)
+				} else {
+					statements.appendf("if r%s != nil {", bodyIdentifier)
+					statements.appendf(headerNameValuePair, headerName, bodyIdentifier)
+					statements.append("}")
 				}
 			}
 		}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -419,7 +419,7 @@ func (c *barClient) ArgWithHeaders(
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithHeaders", "Bar::argWithHeaders", c.httpClient)
 
 	headers["name"] = string(r.Name)
-	if r != nil {
+	if r.UserUUID != nil {
 		headers["x-uuid"] = string(*r.UserUUID)
 	}
 

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -419,7 +419,9 @@ func (c *barClient) ArgWithHeaders(
 	req := zanzibar.NewClientHTTPRequest(ctx, c.clientID, "ArgWithHeaders", "Bar::argWithHeaders", c.httpClient)
 
 	headers["name"] = string(r.Name)
-	headers["x-uuid"] = string(*r.UserUUID)
+	if r != nil {
+		headers["x-uuid"] = string(*r.UserUUID)
+	}
 
 	// Generate full URL.
 	fullURL := c.httpClient.BaseURL + "/bar" + "/argWithHeaders"


### PR DESCRIPTION
Optional fields should check before dereferencing the header value