### PR TITLE
yaml parser in PR#626 renders lines as dead code

### DIFF
--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -142,9 +142,6 @@ func (conf *StaticConfig) MustGetFloat(key string) float64 {
 	}
 
 	if value, contains := conf.configValues[key]; contains {
-		if v, ok := value.(int); ok {
-			return float64(v)
-		}
 		return value.(float64)
 	}
 
@@ -157,9 +154,6 @@ func mustConvertableToInt(value interface{}, key string) int64 {
 		if v != float64(int64(v)) {
 			panic(errors.Errorf("Key (%s) is a float", key))
 		}
-		return int64(v)
-	}
-	if v, ok := value.(int); ok {
 		return int64(v)
 	}
 	return value.(int64)


### PR DESCRIPTION
initially when we moved from JSON -> YAML, there were some changes
needed on how to read Float but those are rendered useless as part of
PR# 626.

This dead code is causing coverage to drop. Since this code path is not
taken, a unit test can't be implemented either.

Deleting this deadcode here also helps coverage come back up
to 100% for ./runtime/* dir