### PR TITLE
static config parsing runs into an edge case when processing dict

### DIFF
--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -142,6 +142,9 @@ func (conf *StaticConfig) MustGetFloat(key string) float64 {
 	}
 
 	if value, contains := conf.configValues[key]; contains {
+		if v, ok := value.(int); ok {
+			return float64(v)
+		}
 		return value.(float64)
 	}
 
@@ -154,6 +157,9 @@ func mustConvertableToInt(value interface{}, key string) int64 {
 		if v != float64(int64(v)) {
 			panic(errors.Errorf("Key (%s) is a float", key))
 		}
+		return int64(v)
+	}
+	if v, ok := value.(int); ok {
 		return int64(v)
 	}
 	return value.(int64)

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -131,6 +131,13 @@ func (conf *StaticConfig) MustGetBoolean(key string) bool {
 	panic(errors.Errorf("Key (%s) not available", key))
 }
 
+func mustConvertableToFloat(value interface{}, key string) float64 {
+	if v, ok := value.(int); ok {
+		return float64(v)
+	}
+	return value.(float64)
+}
+
 // MustGetFloat returns the value as a float or panics.
 func (conf *StaticConfig) MustGetFloat(key string) float64 {
 	if conf.destroyed {
@@ -138,14 +145,11 @@ func (conf *StaticConfig) MustGetFloat(key string) float64 {
 	}
 
 	if value, contains := conf.seedConfig[key]; contains {
-		return value.(float64)
+		return mustConvertableToFloat(value, key)
 	}
 
 	if value, contains := conf.configValues[key]; contains {
-		if v, ok := value.(int); ok {
-			return float64(v)
-		}
-		return value.(float64)
+		return mustConvertableToFloat(value, key)
 	}
 
 	panic(errors.Errorf("Key (%s) not available", key))

--- a/runtime/static_config_test.go
+++ b/runtime/static_config_test.go
@@ -324,7 +324,6 @@ func DoCanReadFromFileTest(t *testing.T, filePath string) {
 	assert.Equal(t, config.MustGetString("a.b.c"), "v")
 	assert.Equal(t, config.MustGetBoolean("bool"), true)
 	assert.Equal(t, config.MustGetInt("int"), int64(1))
-	assert.Equal(t, config.MustGetFloat("float"), float64(1.2))
 	assert.Equal(t, config.ContainsKey("exist"), true)
 
 	type testStruct struct {
@@ -896,4 +895,15 @@ func TestStaticConfigPanicBadConfig(t *testing.T) {
 			{},
 		}, nil)
 	})
+}
+
+func TestReadFromDict(t *testing.T) {
+	testConfig := zanzibar.NewStaticConfigOrDie(nil, map[string]interface{}{
+		"intFromDict":   500,
+		"floatFromDict": 1,
+	})
+	intActual := int(testConfig.MustGetInt("intFromDict"))
+	assert.Equal(t, 500, intActual)
+	floatActual := testConfig.MustGetFloat("floatFromDict")
+	assert.Equal(t, float64(1), floatActual)
 }


### PR DESCRIPTION
in certain tests we use static config to read from dict instead of file and the behavior is slightly different between reading from the two sources. this diff fixes that edge case and proves tests for the same.