### PR TITLE
Check if input is a thrift file in scripts/resolve_thrift/main.go

### DIFF
--- a/scripts/resolve_thrift/main.go
+++ b/scripts/resolve_thrift/main.go
@@ -23,6 +23,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/uber/zanzibar/codegen"
 	"go.uber.org/thriftrw/compile"
@@ -36,6 +37,11 @@ import (
 // 4. the exception struct, generated from given thrift or its includes;
 func main() {
 	thriftFile := os.Args[1]
+	if !strings.HasSuffix(thriftFile, ".thrift") {
+		fmt.Printf("Skipping compilation: %s is not a thrift file", thriftFile)
+		return
+	}
+
 	module, err := compile.Compile(thriftFile)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to parse thrift file: %s", thriftFile))


### PR DESCRIPTION
We had an error from a user creating METADATA files where the thrifts are stored.