### PR TITLE
borrow pascal casing logic from thriftrw-go

### DIFF
--- a/codegen/type_converter_test.go
+++ b/codegen/type_converter_test.go
@@ -1012,14 +1012,14 @@ func TestConvertMapStringToStruct(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertPrettyEqual(t, trim(`
-out.UUIDMap = make(map[string]*structs.MapValue, len(in.UUIDMap))
-for key1, value2 := range in.UUIDMap {
+out.UuidMap = make(map[string]*structs.MapValue, len(in.UuidMap))
+for key1, value2 := range in.UuidMap {
 	if value2 != nil {
-		out.UUIDMap[key1] = &structs.MapValue{}
-		out.UUIDMap[key1].One = string(in.UUIDMap[key1].One)
-		out.UUIDMap[key1].Two = (*string)(in.UUIDMap[key1].Two)
+		out.UuidMap[key1] = &structs.MapValue{}
+		out.UuidMap[key1].One = string(in.UuidMap[key1].One)
+		out.UuidMap[key1].Two = (*string)(in.UuidMap[key1].Two)
 	} else {
-		out.UUIDMap[key1] = nil
+		out.UuidMap[key1] = nil
 	}
 }
 	`), lines)
@@ -1051,14 +1051,14 @@ func TestConvertMapTypeDefToStruct(t *testing.T) {
 
 	assert.NoError(t, err)
 	assertPrettyEqual(t, trim(`
-out.UUIDMap = make(map[structs.UUID]*structs.MapValue, len(in.UUIDMap))
-for key1, value2 := range in.UUIDMap {
+out.UuidMap = make(map[structs.UUID]*structs.MapValue, len(in.UuidMap))
+for key1, value2 := range in.UuidMap {
 	if value2 != nil {
-		out.UUIDMap[key1] = &structs.MapValue{}
-		out.UUIDMap[key1].One = string(in.UUIDMap[key1].One)
-		out.UUIDMap[key1].Two = (*string)(in.UUIDMap[key1].Two)
+		out.UuidMap[key1] = &structs.MapValue{}
+		out.UuidMap[key1].One = string(in.UuidMap[key1].One)
+		out.UuidMap[key1].Two = (*string)(in.UuidMap[key1].Two)
 	} else {
-		out.UUIDMap[key1] = nil
+		out.UuidMap[key1] = nil
 	}
 }
 	`), lines)

--- a/examples/example-gateway/build/app/demo/services/xyz/main/main.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/main/main.go
@@ -67,7 +67,7 @@ func createGateway() (*zanzibar.Gateway, error) {
 }
 
 func logAndWait(server *zanzibar.Gateway) {
-	server.Logger.Info("Started AppDemoXyz",
+	server.Logger.Info("Started App/demo/xyz",
 		zap.String("realHTTPAddr", server.RealHTTPAddr),
 		zap.String("realTChannelAddr", server.RealTChannelAddr),
 		zap.Any("config", server.InspectOrDie()),

--- a/examples/example-gateway/build/services/echo-gateway/main/main.go
+++ b/examples/example-gateway/build/services/echo-gateway/main/main.go
@@ -67,7 +67,7 @@ func createGateway() (*zanzibar.Gateway, error) {
 }
 
 func logAndWait(server *zanzibar.Gateway) {
-	server.Logger.Info("Started EchoGateway",
+	server.Logger.Info("Started Echo-gateway",
 		zap.String("realHTTPAddr", server.RealHTTPAddr),
 		zap.String("realTChannelAddr", server.RealTChannelAddr),
 		zap.Any("config", server.InspectOrDie()),

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -67,7 +67,7 @@ func createGateway() (*zanzibar.Gateway, error) {
 }
 
 func logAndWait(server *zanzibar.Gateway) {
-	server.Logger.Info("Started ExampleGateway",
+	server.Logger.Info("Started Example-gateway",
 		zap.String("realHTTPAddr", server.RealHTTPAddr),
 		zap.String("realTChannelAddr", server.RealTChannelAddr),
 		zap.Any("config", server.InspectOrDie()),

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -22,7 +22,6 @@ package zanzibar
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -53,7 +52,7 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 	assert.Len(t, fields, 6)
 
 	var addr, reqKey, resKey, foo bool
-	for i, f := range fields {
+	for _, f := range fields {
 		switch f.Key {
 		case "remoteAddr":
 			assert.Equal(t, f.String, "unknown")

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -22,6 +22,7 @@ package zanzibar
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -50,14 +51,26 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 	// one field for each of the:
 	// timestamp-started, timestamp-finished, remoteAddr, requestHeader, responseHeader
 	assert.Len(t, fields, 6)
-	assert.Equal(t, fields[0].Key, "remoteAddr")
-	// nil call should cause remoteAddr to be set to unknown
-	assert.Equal(t, fields[0].String, "unknown")
 
-	assert.Equal(t, fields[3].Key, "Client-Req-Header-header-key")
-	assert.Equal(t, fields[3].String, "header-value")
-	assert.Equal(t, fields[4].Key, "Client-Res-Header-header-key")
-	assert.Equal(t, fields[4].String, "header-value")
-	assert.Equal(t, fields[5].Key, "foo")
-	assert.Equal(t, fields[5].String, "bar")
+	var addr, reqKey, resKey, foo bool
+	for i, f := range fields {
+		switch f.Key {
+		case "remoteAddr":
+			assert.Equal(t, f.String, "unknown")
+			addr = true
+		case "Client-Req-Header-header-key":
+			assert.Equal(t, f.String, "header-value")
+			reqKey = true
+		case "Client-Res-Header-header-key":
+			assert.Equal(t, f.String, "header-value")
+			resKey = true
+		case "foo":
+			assert.Equal(t, f.String, "bar")
+			foo = true
+		}
+	}
+	assert.True(t, addr, "remoteAddr key not present")
+	assert.True(t, reqKey, "Client-Req-Header-header-key key not present")
+	assert.True(t, resKey, "Client-Res-Header-header-key key not present")
+	assert.True(t, foo, "foo key not present")
 }

--- a/test/endpoints/bar/bar_arg_with_query_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_query_params_test.go
@@ -730,7 +730,7 @@ func TestBarWithManyQueryParamsRequiredCall(t *testing.T) {
 	logs := gateway.AllLogs()
 
 	assert.Equal(t, 1, len(logs["Finished an incoming server HTTP request"]))
-	assert.Equal(t, 1, len(logs["Started ExampleGateway"]))
+	assert.Equal(t, 1, len(logs["Started Example-gateway"]))
 	assert.Equal(t, 1, len(logs["Got request with missing query string value"]))
 
 	assert.Equal(t,

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -202,7 +202,7 @@ func TestPingWithInvalidResponse(t *testing.T) {
 
 	assert.Equal(t, `{"error":"Unexpected server error"}`, string(bytes))
 
-	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
+	assert.Len(t, gateway.Logs("info", "Started Example-gateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 1)
 	assert.Len(t, gateway.Logs("info", "Failed after non-retriable error."), 1)
 	assert.Len(t, gateway.Logs("warn", "Client failure: TChannel client call returned error"), 1)

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -105,7 +105,7 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	assert.True(t, success)
 
 	allLogs := gateway.AllLogs()
-	assert.Equal(t, 1, len(allLogs["Started ExampleGateway"]))
+	assert.Equal(t, 1, len(allLogs["Started Example-gateway"]))
 	assert.Equal(t, 2, len(allLogs["Created new active connection."]))
 	assert.Equal(t, 1, len(allLogs["Finished an outgoing client TChannel request"]))
 	assert.Equal(t, 1, len(allLogs["Finished an incoming server TChannel request"]))
@@ -273,7 +273,7 @@ func TestCallTChannelTimeout(t *testing.T) {
 	assert.Nil(t, resHeaders)
 	assert.False(t, success)
 
-	assert.Len(t, gateway.Logs("info", "Started ExampleGateway"), 1)
+	assert.Len(t, gateway.Logs("info", "Started Example-gateway"), 1)
 	assert.Len(t, gateway.Logs("info", "Created new active connection."), 2)
 
 	// logged from tchannel client runtime


### PR DESCRIPTION
the implementation between thriftrw-go and zanzibar must match otherwise
we run into situationns where thrift-go generated field name and the
requestType/responseType in the endpoint/client template don't match
causing compile time failures.

e.g. to illustrate the current bug encountered:
```
fieldName in thrift | thriftrw-go struct fieldName | generated client
xUuidFoo            | XUuidFoo                     | XUUIDFoo
```

the methods from thriftrw-go are unexported and are in an internal package hence the copies.