### PR TITLE
Bump integration test client timeout

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2027,8 +2027,10 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
+	// TChannel clients must have a timeout defined, so defining a long timeout that should not realistically
+	// be hit in tests.
+	timeout := time.Duration(5) * time.Minute
+	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,
@@ -2135,7 +2137,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 5283, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 5394, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -99,8 +99,10 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
+	// TChannel clients must have a timeout defined, so defining a long timeout that should not realistically
+	// be hit in tests.
+	timeout := time.Duration(5) * time.Minute
+	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -115,8 +115,10 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
+	// TChannel clients must have a timeout defined, so defining a long timeout that should not realistically
+	// be hit in tests.
+	timeout := time.Duration(5) * time.Minute
+	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -115,8 +115,10 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
+	// TChannel clients must have a timeout defined, so defining a long timeout that should not realistically
+	// be hit in tests.
+	timeout := time.Duration(5) * time.Minute
+	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -115,8 +115,10 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 		},
 	}
 
-	timeout := time.Duration(10000) * time.Millisecond
-	timeoutPerAttempt := time.Duration(2000) * time.Millisecond
+	// TChannel clients must have a timeout defined, so defining a long timeout that should not realistically
+	// be hit in tests.
+	timeout := time.Duration(5) * time.Minute
+	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
 		server.Channel,


### PR DESCRIPTION
Makes tests written using the integration test helper less flaky. Bump the integration test client timeout from 1 second to 1 minute. 