### PR TITLE
Set shardkey and routingdelegate in calloptions

### DIFF
--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -254,8 +254,8 @@ func (c *TChannelClient) call(
 
 		call.call, cerr = sc.BeginCall(ctx, call.serviceMethod, &tchannel.CallOptions{
 			Format:       tchannel.Thrift,
-			RequestState: rs,
 			ShardKey: GetShardKeyFromCtx(ctx),
+			RequestState: rs,
 			RoutingDelegate: GetRoutingDelegateFromCtx(ctx),
 		})
 		if cerr != nil {

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -255,6 +255,8 @@ func (c *TChannelClient) call(
 		call.call, cerr = sc.BeginCall(ctx, call.serviceMethod, &tchannel.CallOptions{
 			Format:       tchannel.Thrift,
 			RequestState: rs,
+			ShardKey: GetShardKeyFromCtx(ctx),
+			RoutingDelegate: GetRoutingDelegateFromCtx(ctx),
 		})
 		if cerr != nil {
 			return errors.Wrapf(

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -253,9 +253,9 @@ func (c *TChannelClient) call(
 		}
 
 		call.call, cerr = sc.BeginCall(ctx, call.serviceMethod, &tchannel.CallOptions{
-			Format:       tchannel.Thrift,
-			ShardKey: GetShardKeyFromCtx(ctx),
-			RequestState: rs,
+			Format:          tchannel.Thrift,
+			ShardKey:        GetShardKeyFromCtx(ctx),
+			RequestState:    rs,
 			RoutingDelegate: GetRoutingDelegateFromCtx(ctx),
 		})
 		if cerr != nil {


### PR DESCRIPTION
ShardKey was not getting propagated to the downstream client. 