### PR TITLE
Fix the cover.sh to work in all cases

### DIFF
--- a/scripts/cover.sh
+++ b/scripts/cover.sh
@@ -34,7 +34,7 @@ echo "Starting coverage tests:"
 
 for file in "${FILES_ARR[@]}"; do
 
-	if grep -q -v $file <<<$REAL_TEST_FILES; then
+	if ! grep -q $file <<<$REAL_TEST_FILES; then
 		continue
 	fi
 


### PR DESCRIPTION
"grep -v" always returns success in some shells.  A better check is to have this alternative.