### PR TITLE
Replace Timer metrics with Histogram as default

### DIFF
--- a/coverage.tmp
+++ b/coverage.tmp
@@ -1,1 +1,0 @@
-mode: set

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -172,7 +172,7 @@ func (res *ClientHTTPResponse) finish() {
 	logFn := res.req.ContextLogger.Info
 
 	// emit metrics
-	res.req.metrics.RecordTimer(res.req.ctx, clientLatency, res.finishTime.Sub(res.req.startTime))
+	res.req.metrics.RecordHistogramDuration(res.req.ctx, clientLatency, res.finishTime.Sub(res.req.startTime))
 	_, known := knownStatusCodes[res.StatusCode]
 	if !known {
 		res.req.Logger.Error(

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -303,7 +303,9 @@ type Logger interface {
 // ContextMetrics emit metrics with tags extracted from context.
 type ContextMetrics interface {
 	IncCounter(ctx context.Context, name string, value int64)
-	RecordTimer(ctx context.Context, name string, d time.Duration)
+	// @deprecated -- use Histogram instead
+	// RecordTimer(ctx context.Context, name string, d time.Duration)
+	RecordHistogramDuration(ctx context.Context, name string, d time.Duration)
 }
 
 type contextMetrics struct {
@@ -319,12 +321,16 @@ func NewContextMetrics(scope tally.Scope) ContextMetrics {
 
 // IncCounter increments the counter with current tags from context
 func (c *contextMetrics) IncCounter(ctx context.Context, name string, value int64) {
-	tags := GetScopeTagsFromCtx(ctx)
-	c.scope.Tagged(tags).Counter(name).Inc(value)
+	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Counter(name).Inc(value)
 }
 
+// @deprecated
 // RecordTimer records the duration with current tags from context
-func (c *contextMetrics) RecordTimer(ctx context.Context, name string, d time.Duration) {
-	tags := GetScopeTagsFromCtx(ctx)
-	c.scope.Tagged(tags).Timer(name).Record(d)
+//func (c *contextMetrics) RecordTimer(ctx context.Context, name string, d time.Duration) {
+//	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Timer(name).Record(d)
+//}
+
+// RecordHistogram records the duration with current tags from context
+func (c *contextMetrics) RecordHistogramDuration(ctx context.Context, name string, d time.Duration) {
+	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Histogram(name, tally.DefaultBuckets).RecordDuration(d)
 }

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -303,8 +303,6 @@ type Logger interface {
 // ContextMetrics emit metrics with tags extracted from context.
 type ContextMetrics interface {
 	IncCounter(ctx context.Context, name string, value int64)
-	// @deprecated -- use Histogram instead
-	// RecordTimer(ctx context.Context, name string, d time.Duration)
 	RecordHistogramDuration(ctx context.Context, name string, d time.Duration)
 }
 
@@ -323,12 +321,6 @@ func NewContextMetrics(scope tally.Scope) ContextMetrics {
 func (c *contextMetrics) IncCounter(ctx context.Context, name string, value int64) {
 	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Counter(name).Inc(value)
 }
-
-// @deprecated
-// RecordTimer records the duration with current tags from context
-//func (c *contextMetrics) RecordTimer(ctx context.Context, name string, d time.Duration) {
-//	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Timer(name).Record(d)
-//}
 
 // RecordHistogram records the duration with current tags from context
 func (c *contextMetrics) RecordHistogramDuration(ctx context.Context, name string, d time.Duration) {

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -322,7 +322,7 @@ func (c *contextMetrics) IncCounter(ctx context.Context, name string, value int6
 	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Counter(name).Inc(value)
 }
 
-// RecordHistogram records the duration with current tags from context
+// RecordHistogramDuration records the duration with current tags from context
 func (c *contextMetrics) RecordHistogramDuration(ctx context.Context, name string, d time.Duration) {
 	c.scope.Tagged(GetScopeTagsFromCtx(ctx)).Histogram(name, tally.DefaultBuckets).RecordDuration(d)
 }

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -549,6 +549,7 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		tally.ScopeOptions{
 			Tags:            defaultTags,
 			CachedReporter:  gateway.metricsBackend,
+			DefaultBuckets:  tally.MustMakeExponentialDurationBuckets(10*time.Millisecond, 4, 6), // Range: 10ms - 10s
 			Separator:       tally.DefaultSeparator,
 			SanitizeOptions: &m3.DefaultSanitizerOpts,
 		},

--- a/runtime/grpc_client.go
+++ b/runtime/grpc_client.go
@@ -124,7 +124,7 @@ func (c *callHelper) Start() {
 // This method emits latency and error metric as well as logging in case of error.
 func (c *callHelper) Finish(ctx context.Context, err error) context.Context {
 	c.finishTime = time.Now()
-	c.metrics.RecordTimer(ctx, clientLatency, c.finishTime.Sub(c.startTime))
+	c.metrics.RecordHistogramDuration(ctx, clientLatency, c.finishTime.Sub(c.startTime))
 	fields := []zapcore.Field{
 		zap.Time(logFieldRequestStartTime, c.startTime),
 		zap.Time(logFieldRequestFinishedTime, c.finishTime),

--- a/runtime/plugins/m3_aggregator.go
+++ b/runtime/plugins/m3_aggregator.go
@@ -89,13 +89,16 @@ func (g *M3Collector) incrementCounterMetric(prefix string, i float64) {
 	if i == 0 {
 		return
 	}
-	c := g.scope.Counter(prefix)
-	c.Inc(int64(i))
+	g.scope.Counter(prefix).Inc(int64(i))
 }
 
-func (g *M3Collector) updateTimerMetric(prefix string, dur time.Duration) {
-	c := g.scope.Timer(prefix)
-	c.Record(dur)
+// @deprecated in favor of Histogram. Reopen ONLY if there is a need to
+//func (g *M3Collector) updateTimerMetric(prefix string, dur time.Duration) {
+//	g.scope.Timer(prefix).Record(dur)
+//}
+
+func (g *M3Collector) updateHistogramMetric(prefix string, dur time.Duration) {
+	g.scope.Histogram(prefix, tally.DefaultBuckets).RecordDuration(dur)
 }
 
 // Update is a callback by hystrix lib to relay the metrics to m3
@@ -109,8 +112,8 @@ func (g *M3Collector) Update(r metricCollector.MetricResult) {
 	g.incrementCounterMetric(g.timeoutsPrefix, r.Timeouts)
 	g.incrementCounterMetric(g.fallbackSuccessesPrefix, r.FallbackSuccesses)
 	g.incrementCounterMetric(g.fallbackFailuresPrefix, r.FallbackFailures)
-	g.updateTimerMetric(g.totalDurationPrefix, r.TotalDuration)
-	g.updateTimerMetric(g.runDurationPrefix, r.RunDuration)
+	g.updateHistogramMetric(g.totalDurationPrefix, r.TotalDuration)
+	g.updateHistogramMetric(g.runDurationPrefix, r.RunDuration)
 }
 
 // Reset is a noop operation in this collector.

--- a/runtime/plugins/m3_aggregator.go
+++ b/runtime/plugins/m3_aggregator.go
@@ -92,11 +92,6 @@ func (g *M3Collector) incrementCounterMetric(prefix string, i float64) {
 	g.scope.Counter(prefix).Inc(int64(i))
 }
 
-// @deprecated in favor of Histogram. Reopen ONLY if there is a need to
-//func (g *M3Collector) updateTimerMetric(prefix string, dur time.Duration) {
-//	g.scope.Timer(prefix).Record(dur)
-//}
-
 func (g *M3Collector) updateHistogramMetric(prefix string, dur time.Duration) {
 	g.scope.Histogram(prefix, tally.DefaultBuckets).RecordDuration(dur)
 }

--- a/runtime/runtime_metrics.go
+++ b/runtime/runtime_metrics.go
@@ -65,7 +65,7 @@ type runtimeMetrics struct {
 	// number of completed GC cycles
 	numGC tally.Counter
 	// GC pause time
-	gcPauseMs tally.Timer
+	gcPauseMs tally.Histogram
 }
 
 // runtimeCollector keeps the current state of runtime metrics
@@ -123,7 +123,7 @@ func NewRuntimeMetricsCollector(
 
 			// GC
 			numGC:     scope.Counter("memory.num-gc"),
-			gcPauseMs: scope.Timer("memory.gc-pause-ms"),
+			gcPauseMs: scope.Histogram("memory.gc-pause-ms", tally.DefaultBuckets),
 		},
 		running:   false,
 		stop:      make(chan struct{}),
@@ -217,7 +217,7 @@ func (r *runtimeCollector) collectGCMetrics(memStats *runtime.MemStats) {
 
 		for i := lastNum; i != num; i++ {
 			pause := memStats.PauseNs[i%uint32(len(memStats.PauseNs))]
-			r.metrics.gcPauseMs.Record(time.Duration(pause))
+			r.metrics.gcPauseMs.RecordDuration(time.Duration(pause))
 		}
 	}
 

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -94,7 +94,7 @@ func (res *ServerHTTPResponse) finish(ctx context.Context) {
 	// no need to put this tag on the context because this is the end of response life cycle
 	statusTag := map[string]string{scopeTagStatus: fmt.Sprintf("%d", res.StatusCode)}
 	tagged := res.scope.Tagged(statusTag)
-	tagged.Timer(endpointLatency).Record(res.finishTime.Sub(res.Request.startTime))
+	tagged.Histogram(endpointLatency, tally.DefaultBuckets).RecordDuration(res.finishTime.Sub(res.Request.startTime))
 	if !known {
 		res.logger.Error(
 			"Unknown status code",

--- a/runtime/tchannel_inbound_call.go
+++ b/runtime/tchannel_inbound_call.go
@@ -66,7 +66,7 @@ func (c *tchannelInboundCall) finish(ctx context.Context, err error) {
 	} else {
 		c.scope.Counter(endpointSuccess).Inc(1)
 	}
-	c.scope.Timer(endpointLatency).Record(c.finishTime.Sub(c.startTime))
+	c.scope.Histogram(endpointLatency, tally.DefaultBuckets).RecordDuration(c.finishTime.Sub(c.startTime))
 	c.scope.Counter(endpointRequest).Inc(1)
 
 	fields := c.logFields(ctx)

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -64,7 +64,7 @@ func (c *tchannelOutboundCall) finish(ctx context.Context, err error) {
 	} else {
 		c.metrics.IncCounter(ctx, clientSuccess, 1)
 	}
-	c.metrics.RecordTimer(ctx, clientLatency, c.finishTime.Sub(c.startTime))
+	c.metrics.RecordHistogramDuration(ctx, clientLatency, c.finishTime.Sub(c.startTime))
 
 	// write logs
 	fields := c.logFields(ctx)


### PR DESCRIPTION
Histograms give a better aggregation capability across DCs.  Switching to Histograms from Timers for the latency metrics.