### PR TITLE
Make config file a parameter for mocks

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -233,6 +233,7 @@ func NewDefaultModuleSystemWithMockHook(
 	clientsMock bool,
 	workflowMock bool,
 	serviceMock bool,
+	configFile string,
 	hooks ...PostGenHook,
 ) (*ModuleSystem, error) {
 	t, err := NewDefaultTemplate()
@@ -255,7 +256,7 @@ func NewDefaultModuleSystemWithMockHook(
 	}
 
 	if serviceMock {
-		serviceMockGenHook = ServiceMockGenHook(h, t)
+		serviceMockGenHook = ServiceMockGenHook(h, t, configFile)
 		hooks = append(hooks, serviceMockGenHook)
 	}
 

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -223,7 +223,7 @@ func ClientMockGenHook(h *PackageHelper, t *Template) (PostGenHook, error) {
 }
 
 // ServiceMockGenHook returns a PostGenHook to generate service mocks
-func ServiceMockGenHook(h *PackageHelper, t *Template) PostGenHook {
+func ServiceMockGenHook(h *PackageHelper, t *Template, configFile string) PostGenHook {
 	return func(instances map[string][]*ModuleInstance) error {
 		mockCount := len(instances["service"])
 		fmt.Printf("Generating %d service mocks:\n", mockCount)
@@ -250,7 +250,7 @@ func ServiceMockGenHook(h *PackageHelper, t *Template) PostGenHook {
 				}
 				files.Store(filepath.Join(genDir, "mock_init.go"), mockInit)
 
-				mockService, err := generateServiceMock(instance, h, t)
+				mockService, err := generateServiceMock(instance, h, t, configFile)
 				if err != nil {
 					ec <- errors.Wrapf(
 						err,
@@ -314,8 +314,8 @@ func generateMockInitializer(instance *ModuleInstance, h *PackageHelper, t *Temp
 }
 
 // generateServiceMock generates mock service
-func generateServiceMock(instance *ModuleInstance, h *PackageHelper, t *Template) ([]byte, error) {
-	configPath := path.Join(strings.Replace(instance.Directory, "services", "config", 1), "test.yaml")
+func generateServiceMock(instance *ModuleInstance, h *PackageHelper, t *Template, configFile string) ([]byte, error) {
+	configPath := path.Join(strings.Replace(instance.Directory, "services", "config", 1), configFile)
 	if _, err := os.Stat(filepath.Join(h.ConfigRoot(), configPath)); err != nil {
 		if os.IsNotExist(err) {
 			configPath = "config/test.yaml"

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -142,7 +142,7 @@ func main() {
 	}
 	var moduleSystem *codegen.ModuleSystem
 	if genMock {
-		moduleSystem, err = codegen.NewDefaultModuleSystemWithMockHook(packageHelper, true, true, true)
+		moduleSystem, err = codegen.NewDefaultModuleSystemWithMockHook(packageHelper, true, true, true, "test.json")
 	} else {
 		moduleSystem, err = codegen.NewDefaultModuleSystem(packageHelper)
 	}


### PR DESCRIPTION
For mocks generation, the config file was always configured to be test.yaml. This has now been updated to provide a custom config path (yaml or JSON) as required by the gateway service. 