### PR TITLE
Fix query-param handling on the client side

### DIFF
--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -678,7 +678,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 	}
 	if r.Request.AuthUUID2 != nil {
 		requestMyuuidQuery := *r.Request.AuthUUID2
-		queryValues.Set("request.myuuid", requestMyuuidQuery)
+		queryValues.Set("myuuid", requestMyuuidQuery)
 	}
 	for _, value := range r.Request.Foo {
 		queryValues.Add("request.foo", value)

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -149,7 +149,13 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 	}
 	requestBody.Request.Foo = requestFooQuery
 
-	if req.HasQueryPrefix("opt") || requestBody.Opt != nil {
+	var _queryNeeded bool
+	for _, _pfx := range []string{"opt", "opt.name", "opt.useruuid", "opt.authuuid", "opt.authuuid2"} {
+		if _queryNeeded = req.HasQueryPrefix(_pfx); _queryNeeded {
+			break
+		}
+	}
+	if _queryNeeded {
 		if requestBody.Opt == nil {
 			requestBody.Opt = &endpointsBarBar.QueryParamsOptsStruct{}
 		}

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithuntaggednestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithuntaggednestedqueryparams.go
@@ -156,7 +156,13 @@ func (h *BarArgWithUntaggedNestedQueryParamsHandler) HandleRequest(
 	}
 	requestBody.Request.Foos = requestFoosQuery
 
-	if req.HasQueryPrefix("opt") || requestBody.Opt != nil {
+	var _queryNeeded bool
+	for _, _pfx := range []string{"opt", "opt.name", "opt.useruuid", "opt.count", "opt.optcount", "opt.foos"} {
+		if _queryNeeded = req.HasQueryPrefix(_pfx); _queryNeeded {
+			break
+		}
+	}
+	if _queryNeeded {
 		if requestBody.Opt == nil {
 			requestBody.Opt = &endpointsBarBar.QueryParamsUntaggedOptStruct{}
 		}

--- a/examples/example-gateway/idl/clients/bar/bar.thrift
+++ b/examples/example-gateway/idl/clients/bar/bar.thrift
@@ -53,19 +53,19 @@ struct BarResponseRecur {
 }
 
 struct QueryParamsStruct {
-    1: required string name	(zanzibar.http.ref = "query.name")
-    2: optional string userUUID	(zanzibar.http.ref = "query.userUUID")
+    1: required string name
+    2: optional string userUUID
     // TODO: support header annotation
-    3: optional string authUUID	(zanzibar.http.ref = "query.authUUID")
+    3: optional string authUUID
     4: optional string authUUID2 (zanzibar.http.ref = "query.myuuid")
-    5: required list<string> foo	(zanzibar.http.ref = "query.foo")
+    5: required list<string> foo
 }
 
 struct QueryParamsOptsStruct {
-    1: required string name	(zanzibar.http.ref = "query.name")
-    2: optional string userUUID	(zanzibar.http.ref = "query.userUUID")
-    3: optional string authUUID	(zanzibar.http.ref = "query.authUUID")
-    4: optional string authUUID2	(zanzibar.http.ref = "query.authUUID2")
+    1: required string name
+    2: optional string userUUID
+    3: optional string authUUID
+    4: optional string authUUID2
 }
 
 struct QueryParamsUntaggedStruct {

--- a/examples/example-gateway/idl/endpoints/bar/bar.thrift
+++ b/examples/example-gateway/idl/endpoints/bar/bar.thrift
@@ -44,18 +44,18 @@ struct BarResponse {
 }
 
 struct QueryParamsStruct {
-    1: required string name	(zanzibar.http.ref = "query.name")
-    2: optional string userUUID	(zanzibar.http.ref = "query.userUUID")
+    1: required string name
+    2: optional string userUUID
     3: optional string authUUID (zanzibar.http.ref="headers.x-uuid")
     4: optional string authUUID2 (zanzibar.http.ref="headers.x-uuid2")
-    5: required list<string> foo	(zanzibar.http.ref = "query.foo")
+    5: required list<string> foo
 }
 
 struct QueryParamsOptsStruct {
-    1: required string name	(zanzibar.http.ref = "query.name")
-    2: optional string userUUID	(zanzibar.http.ref = "query.userUUID")
-    3: optional string authUUID	(zanzibar.http.ref = "query.authUUID")
-    4: optional string authUUID2	(zanzibar.http.ref = "query.authUUID2")
+    1: required string name
+    2: optional string userUUID
+    3: optional string authUUID
+    4: optional string authUUID2
 }
 
 struct QueryParamsUntaggedStruct {

--- a/test/endpoints/bar/bar_arg_with_query_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_query_params_test.go
@@ -817,7 +817,7 @@ func TestBarWithNestedQueryParams(t *testing.T) {
 		"GET", "/bar/argWithNestedQueryParams",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t,
-				"request.authUUID=auth-uuid&request.foo=hi&request.myuuid=auth-uuid2"+
+				"myuuid=auth-uuid2&request.authUUID=auth-uuid&request.foo=hi"+
 					"&request.name=a-name&request.userUUID=a-uuid",
 				r.URL.RawQuery,
 			)
@@ -871,9 +871,8 @@ func TestBarWithNestedQueryParamsWithOpts(t *testing.T) {
 		"GET", "/bar/argWithNestedQueryParams",
 		func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t,
-				"opt.name=b-name&opt.userUUID=b-uuid&request.authUUID=auth-uuid&"+
-					"request.foo=hi&request.myuuid=auth-uuid2&"+
-					"request.name=a-name&request.userUUID=a-uuid",
+				"myuuid=auth-uuid2&opt.name=b-name&opt.userUUID=b-uuid&request.authUUID=auth-uuid&"+
+					"request.foo=hi&request.name=a-name&request.userUUID=a-uuid",
 				r.URL.RawQuery,
 			)
 


### PR DESCRIPTION
There are scenarios where the annotations are ignored when the client thrift actually specifies it.
Similarly on the endpoint thrift, handling had some bugs
  - Optional query param is the only item present in the struct and has an annotation that does not include the struct field's name. We do not handle this correctly.