### PR TITLE
Fix service file config for mock tests

### DIFF
--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -318,7 +318,7 @@ func generateServiceMock(instance *ModuleInstance, h *PackageHelper, t *Template
 	configPath := path.Join(strings.Replace(instance.Directory, "services", "config", 1), configFile)
 	if _, err := os.Stat(filepath.Join(h.ConfigRoot(), configPath)); err != nil {
 		if os.IsNotExist(err) {
-			configPath = "config/test.yaml"
+			configPath = filepath.Join("config", configFile)
 		}
 	}
 	data := map[string]interface{}{

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -142,7 +142,7 @@ func main() {
 	}
 	var moduleSystem *codegen.ModuleSystem
 	if genMock {
-		moduleSystem, err = codegen.NewDefaultModuleSystemWithMockHook(packageHelper, true, true, true, "test.json")
+		moduleSystem, err = codegen.NewDefaultModuleSystemWithMockHook(packageHelper, true, true, true, "test.yaml")
 	} else {
 		moduleSystem, err = codegen.NewDefaultModuleSystem(packageHelper)
 	}


### PR DESCRIPTION
There was a bug in how files which service config file to look at in when generating service mocks.  This PR fixes that. 