### PR TITLE
Add application/json too all requests by default

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1253,6 +1253,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.defaultHeaders", &defaultHeaders)
 	}
@@ -1567,7 +1570,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 11911, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 12051, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -78,6 +78,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -231,6 +231,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.bar.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.bar.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -68,6 +68,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.contacts.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.contacts.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -74,6 +74,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.corge-http.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.corge-http.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -68,6 +68,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.google-now.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.google-now.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -66,6 +66,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.multi.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.multi.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -63,6 +63,9 @@ func NewClient(deps *module.Dependencies) Client {
 		timeoutVal,
 	)
 	defaultHeaders := make(map[string]string)
+	if deps.Default.Config.ContainsKey("http.defaultHeaders") {
+		deps.Default.Config.MustGetStruct("http.defaultHeaders", &defaultHeaders)
+	}
 	if deps.Default.Config.ContainsKey("clients.withexceptions.defaultHeaders") {
 		deps.Default.Config.MustGetStruct("clients.withexceptions.defaultHeaders", &defaultHeaders)
 	}

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -66,6 +66,9 @@ tchannel.port: 7784
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
+http.defaultHeaders:
+  Accept: application/json
+  Content-Type: application/json
 useDatacenter: false
 clients.baz.alternates:
   routingConfigs:

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -46,6 +46,9 @@ clients.withexceptions.timeout: 10000
 clients.withexceptions.maxConcurrentRequests: 1000
 clients.withexceptions.errorPercentThreshold: 20
 envVarsToTagInRootScope: []
+http.defaultHeaders:
+  Accept: application/json
+  Content-Type: application/json
 http.port: 7783
 http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /var/log/example-gateway/example-gateway.log
@@ -66,9 +69,6 @@ tchannel.port: 7784
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
-http.defaultHeaders:
-  Accept: application/json
-  Content-Type: application/json
 useDatacenter: false
 clients.baz.alternates:
   routingConfigs:

--- a/examples/example-gateway/config/test.yaml
+++ b/examples/example-gateway/config/test.yaml
@@ -67,6 +67,9 @@ tchannel.port: 0
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
+http.defaultHeaders:
+  Accept: application/json
+  Content-Type: application/json
 useDatacenter: false
 clients.baz.alternates:
   routingConfigs:

--- a/examples/example-gateway/config/test.yaml
+++ b/examples/example-gateway/config/test.yaml
@@ -45,6 +45,9 @@ clients.withexceptions.maxConcurrentRequests: 1000
 clients.withexceptions.errorPercentThreshold: 20
 env: test
 envVarsToTagInRootScope: []
+http.defaultHeaders:
+  Accept: application/json
+  Content-Type: application/json
 http.port: 0
 http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /tmp/example-gateway.log
@@ -67,9 +70,6 @@ tchannel.port: 0
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
-http.defaultHeaders:
-  Accept: application/json
-  Content-Type: application/json
 useDatacenter: false
 clients.baz.alternates:
   routingConfigs:

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -34,6 +34,13 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	acceptHeader = "Accept"
+	contentTypeHeader = "Content-Type"
+	acceptHeaderValue = "application/json"
+	contentTypeHeaderValue = "application/json"
+)
+
 var metricNormalizer = strings.NewReplacer("::", "--")
 
 // ClientHTTPRequest is the struct for making a single client request using an outbound http client.
@@ -160,22 +167,19 @@ func (req *ClientHTTPRequest) WriteJSON(
 		httpReq.Header.Set(headerKey, headerValue)
 	}
 
-	acceptTypePresent := false
 	for k := range headers {
-		if k == "Accept" {
-			acceptTypePresent = true
-		}
 		httpReq.Header.Set(k, headers[k])
 	}
 
 	if body != nil {
-		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set(http.CanonicalHeaderKey(contentTypeHeader), contentTypeHeaderValue)
 	}
 
-	/* Only unmarshal JSON today so set this as default if none present */
-	if !acceptTypePresent {
-		httpReq.Header.Set("Accept", "application/json")
+	/* Only unmarshal JSON is supported today so set this as default if none present */
+	if _, ok := headers[http.CanonicalHeaderKey(acceptHeader)]; !ok{
+		httpReq.Header.Set(acceptHeader, acceptHeaderValue)
 	}
+
 	req.httpReq = httpReq
 	req.ctx = WithLogFields(req.ctx,
 		zap.String(logFieldClientHTTPMethod, method),

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -171,15 +171,6 @@ func (req *ClientHTTPRequest) WriteJSON(
 		httpReq.Header.Set(k, headers[k])
 	}
 
-	if body != nil {
-		httpReq.Header.Set(http.CanonicalHeaderKey(contentTypeHeader), contentTypeHeaderValue)
-	}
-
-	/* Only unmarshal JSON is supported today so set this as default if none present */
-	if _, ok := headers[http.CanonicalHeaderKey(acceptHeader)]; !ok {
-		httpReq.Header.Set(acceptHeader, acceptHeaderValue)
-	}
-
 	req.httpReq = httpReq
 	req.ctx = WithLogFields(req.ctx,
 		zap.String(logFieldClientHTTPMethod, method),

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -34,13 +34,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	acceptHeader           = "Accept"
-	contentTypeHeader      = "Content-Type"
-	acceptHeaderValue      = "application/json"
-	contentTypeHeaderValue = "application/json"
-)
-
 var metricNormalizer = strings.NewReplacer("::", "--")
 
 // ClientHTTPRequest is the struct for making a single client request using an outbound http client.

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -160,7 +160,11 @@ func (req *ClientHTTPRequest) WriteJSON(
 		httpReq.Header.Set(headerKey, headerValue)
 	}
 
+	acceptTypePresent := false
 	for k := range headers {
+		if k == "Accept" {
+			acceptTypePresent = true
+		}
 		httpReq.Header.Set(k, headers[k])
 	}
 
@@ -168,6 +172,10 @@ func (req *ClientHTTPRequest) WriteJSON(
 		httpReq.Header.Set("Content-Type", "application/json")
 	}
 
+	/* Only unmarshal JSON today so set this as default if none present */
+	if !acceptTypePresent {
+		httpReq.Header.Set("Accept", "application/json")
+	}
 	req.httpReq = httpReq
 	req.ctx = WithLogFields(req.ctx,
 		zap.String(logFieldClientHTTPMethod, method),

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	acceptHeader =           "Accept"
-	contentTypeHeader =      "Content-Type"
-	acceptHeaderValue =      "application/json"
+	acceptHeader           = "Accept"
+	contentTypeHeader      = "Content-Type"
+	acceptHeaderValue      = "application/json"
 	contentTypeHeaderValue = "application/json"
 )
 

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	acceptHeader = "Accept"
-	contentTypeHeader = "Content-Type"
-	acceptHeaderValue = "application/json"
+	acceptHeader =           "Accept"
+	contentTypeHeader =      "Content-Type"
+	acceptHeaderValue =      "application/json"
 	contentTypeHeaderValue = "application/json"
 )
 
@@ -176,7 +176,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 	}
 
 	/* Only unmarshal JSON is supported today so set this as default if none present */
-	if _, ok := headers[http.CanonicalHeaderKey(acceptHeader)]; !ok{
+	if _, ok := headers[http.CanonicalHeaderKey(acceptHeader)]; !ok {
 		httpReq.Header.Set(acceptHeader, acceptHeaderValue)
 	}
 

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -145,6 +145,7 @@ func TestMakingClientCallWithHeaders(t *testing.T) {
 			_, _ = w.Write([]byte(r.Header.Get("Example-Header")))
 			// Check that the default header got set and actually sent to the server.
 			assert.Equal(t, r.Header.Get("X-Client-ID"), "bar")
+			assert.Equal(t, r.Header.Get("Accept"), "application/test+json")
 		},
 	)
 
@@ -160,6 +161,7 @@ func TestMakingClientCallWithHeaders(t *testing.T) {
 		client.BaseURL+"/bar-path",
 		map[string]string{
 			"Example-Header": "Example-Value",
+			"Accept": "application/test+json",
 		},
 		nil,
 	)

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -284,6 +284,7 @@ func TestMakingClientCallWithRespHeaders(t *testing.T) {
 		"clientHTTPMethod":                 "POST",
 		"Client-Req-Header-X-Client-Id":    "bar",
 		"Client-Req-Header-Content-Type":   "application/json",
+		"Client-Req-Header-Accept":         "application/json",
 		"Client-Res-Header-Example-Header": "Example-Value",
 		"Client-Res-Header-Content-Type":   "text/plain; charset=utf-8",
 	}

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -161,7 +161,7 @@ func TestMakingClientCallWithHeaders(t *testing.T) {
 		client.BaseURL+"/bar-path",
 		map[string]string{
 			"Example-Header": "Example-Value",
-			"Accept": "application/test+json",
+			"Accept":         "application/test+json",
 		},
 		nil,
 	)

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -220,6 +220,7 @@ func TestCallMetrics(t *testing.T) {
 		"clientHTTPMethod":               "POST",
 		"Client-Req-Header-X-Client-Id":  "bar",
 		"Client-Req-Header-Content-Type": "application/json",
+		"Client-Req-Header-Accept":       "application/json",
 		"Client-Res-Header-Content-Type": "text/plain; charset=utf-8",
 
 		"zone":            "unknown",


### PR DESCRIPTION
This adds Accept:application/json headers to all requests if Accept header is not already set. We unmarshal on application/json so it's essential to pass this to the downstream. 