### PR TITLE
Allow only system failures to trigger circuit breaker

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1413,7 +1413,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	if (c.circuitBreakerDisabled) {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1573,7 +1573,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 12100, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 12094, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2717,7 +2717,7 @@ type {{$clientName}} struct {
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
 		} else {
-			err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+			hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 				success, respHeaders, err = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
@@ -2773,7 +2773,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 10926, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 10920, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1415,6 +1415,9 @@ func (c *{{$clientName}}) {{$methodName}}(
 	} else {
 		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1570,7 +1573,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 12051, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 12100, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2718,6 +2721,9 @@ type {{$clientName}} struct {
 				success, respHeaders, err = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
+				if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+					return nil
+				}
 				return err
 			}, nil)
 		}
@@ -2767,7 +2773,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 10842, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 10926, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -238,17 +238,19 @@ func (c *{{$clientName}}) {{$methodName}}(
 	if (c.circuitBreakerDisabled) {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -240,6 +240,9 @@ func (c *{{$clientName}}) {{$methodName}}(
 	} else {
 		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -238,13 +238,18 @@ func (c *{{$clientName}}) {{$methodName}}(
 	if (c.circuitBreakerDisabled) {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return {{if eq .ResponseType ""}}nil, err{{else}}defaultRes, nil, err{{end}}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -238,7 +238,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 	if (c.circuitBreakerDisabled) {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -264,7 +264,7 @@ type {{$clientName}} struct {
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
 		} else {
-			err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+			hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 				success, respHeaders, err = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -264,22 +264,23 @@ type {{$clientName}} struct {
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
 		} else {
-			var realErr error
+			// We want hystrix ckt-breaker to count errors only for system issues
+			var clientErr error
 			err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
-				success, respHeaders, err = c.client.Call(
+				success, respHeaders, clientErr = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
-				if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+					// Declare ok if it is not a system-error
 					return nil
 				}
-				return err
+				return clientErr
 			}, nil)
 			if err == nil {
-				// Bad request or equivalent error, bubble it up
-				err = realErr
+				// ckt-breaker was ok, bubble up client error if set
+				err = clientErr
 			}
 		}
-
 
 		if err == nil && !success {
 			switch {

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -268,6 +268,9 @@ type {{$clientName}} struct {
 				success, respHeaders, err = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
+				if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+					return nil
+				}
 				return err
 			}, nil)
 		}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -264,7 +264,8 @@ type {{$clientName}} struct {
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
 		} else {
-			hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
+			var realErr error
+			err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 				success, respHeaders, err = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
@@ -273,6 +274,10 @@ type {{$clientName}} struct {
 				}
 				return err
 			}, nil)
+			if err == nil {
+				// Bad request or equivalent error, bubble it up
+				err = realErr
+			}
 		}
 
 

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -369,7 +369,7 @@ func (c *barClient) ArgNotStruct(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -458,7 +458,7 @@ func (c *barClient) ArgWithHeaders(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -624,7 +624,7 @@ func (c *barClient) ArgWithManyQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -712,7 +712,7 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -824,7 +824,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -895,7 +895,7 @@ func (c *barClient) ArgWithParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -966,7 +966,7 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1037,7 +1037,7 @@ func (c *barClient) ArgWithQueryHeader(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1125,7 +1125,7 @@ func (c *barClient) ArgWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1202,7 +1202,7 @@ func (c *barClient) DeleteFoo(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1278,7 +1278,7 @@ func (c *barClient) DeleteWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1345,7 +1345,7 @@ func (c *barClient) Hello(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1440,7 +1440,7 @@ func (c *barClient) ListAndEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1519,7 +1519,7 @@ func (c *barClient) MissingArg(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1599,7 +1599,7 @@ func (c *barClient) NoRequest(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1680,7 +1680,7 @@ func (c *barClient) Normal(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1761,7 +1761,7 @@ func (c *barClient) NormalRecur(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1841,7 +1841,7 @@ func (c *barClient) TooManyArgs(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -1936,7 +1936,7 @@ func (c *barClient) EchoBinary(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2009,7 +2009,7 @@ func (c *barClient) EchoBool(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2084,7 +2084,7 @@ func (c *barClient) EchoDouble(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2159,7 +2159,7 @@ func (c *barClient) EchoEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2234,7 +2234,7 @@ func (c *barClient) EchoI16(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2309,7 +2309,7 @@ func (c *barClient) EchoI32(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2384,7 +2384,7 @@ func (c *barClient) EchoI32Map(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2459,7 +2459,7 @@ func (c *barClient) EchoI64(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2534,7 +2534,7 @@ func (c *barClient) EchoI8(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2609,7 +2609,7 @@ func (c *barClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2684,7 +2684,7 @@ func (c *barClient) EchoStringList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2759,7 +2759,7 @@ func (c *barClient) EchoStringMap(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2834,7 +2834,7 @@ func (c *barClient) EchoStringSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2909,7 +2909,7 @@ func (c *barClient) EchoStructList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -2984,7 +2984,7 @@ func (c *barClient) EchoStructSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -3059,7 +3059,7 @@ func (c *barClient) EchoTypedef(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -369,13 +369,18 @@ func (c *barClient) ArgNotStruct(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -458,13 +463,18 @@ func (c *barClient) ArgWithHeaders(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -624,13 +634,18 @@ func (c *barClient) ArgWithManyQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -712,13 +727,18 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -824,13 +844,18 @@ func (c *barClient) ArgWithNestedQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -895,13 +920,18 @@ func (c *barClient) ArgWithParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -966,13 +996,18 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1037,13 +1072,18 @@ func (c *barClient) ArgWithQueryHeader(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1125,13 +1165,18 @@ func (c *barClient) ArgWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1202,13 +1247,18 @@ func (c *barClient) DeleteFoo(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -1278,13 +1328,18 @@ func (c *barClient) DeleteWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -1345,13 +1400,18 @@ func (c *barClient) Hello(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1440,13 +1500,18 @@ func (c *barClient) ListAndEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1519,13 +1584,18 @@ func (c *barClient) MissingArg(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1599,13 +1669,18 @@ func (c *barClient) NoRequest(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1680,13 +1755,18 @@ func (c *barClient) Normal(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1761,13 +1841,18 @@ func (c *barClient) NormalRecur(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1841,13 +1926,18 @@ func (c *barClient) TooManyArgs(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -1936,13 +2026,18 @@ func (c *barClient) EchoBinary(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2009,13 +2104,18 @@ func (c *barClient) EchoBool(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2084,13 +2184,18 @@ func (c *barClient) EchoDouble(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2159,13 +2264,18 @@ func (c *barClient) EchoEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2234,13 +2344,18 @@ func (c *barClient) EchoI16(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2309,13 +2424,18 @@ func (c *barClient) EchoI32(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2384,13 +2504,18 @@ func (c *barClient) EchoI32Map(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2459,13 +2584,18 @@ func (c *barClient) EchoI64(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2534,13 +2664,18 @@ func (c *barClient) EchoI8(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2609,13 +2744,18 @@ func (c *barClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2684,13 +2824,18 @@ func (c *barClient) EchoStringList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2759,13 +2904,18 @@ func (c *barClient) EchoStringMap(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2834,13 +2984,18 @@ func (c *barClient) EchoStringSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2909,13 +3064,18 @@ func (c *barClient) EchoStructList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -2984,13 +3144,18 @@ func (c *barClient) EchoStructSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -3059,13 +3224,18 @@ func (c *barClient) EchoTypedef(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -371,6 +371,9 @@ func (c *barClient) ArgNotStruct(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -457,6 +460,9 @@ func (c *barClient) ArgWithHeaders(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -620,6 +626,9 @@ func (c *barClient) ArgWithManyQueryParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -705,6 +714,9 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -814,6 +826,9 @@ func (c *barClient) ArgWithNestedQueryParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -882,6 +897,9 @@ func (c *barClient) ArgWithParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -950,6 +968,9 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1018,6 +1039,9 @@ func (c *barClient) ArgWithQueryHeader(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1103,6 +1127,9 @@ func (c *barClient) ArgWithQueryParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1177,6 +1204,9 @@ func (c *barClient) DeleteFoo(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1250,6 +1280,9 @@ func (c *barClient) DeleteWithQueryParams(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1314,6 +1347,9 @@ func (c *barClient) Hello(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1406,6 +1442,9 @@ func (c *barClient) ListAndEnum(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1482,6 +1521,9 @@ func (c *barClient) MissingArg(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1559,6 +1601,9 @@ func (c *barClient) NoRequest(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1637,6 +1682,9 @@ func (c *barClient) Normal(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1715,6 +1763,9 @@ func (c *barClient) NormalRecur(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1792,6 +1843,9 @@ func (c *barClient) TooManyArgs(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1884,6 +1938,9 @@ func (c *barClient) EchoBinary(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1954,6 +2011,9 @@ func (c *barClient) EchoBool(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2026,6 +2086,9 @@ func (c *barClient) EchoDouble(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2098,6 +2161,9 @@ func (c *barClient) EchoEnum(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2170,6 +2236,9 @@ func (c *barClient) EchoI16(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2242,6 +2311,9 @@ func (c *barClient) EchoI32(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2314,6 +2386,9 @@ func (c *barClient) EchoI32Map(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2386,6 +2461,9 @@ func (c *barClient) EchoI64(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2458,6 +2536,9 @@ func (c *barClient) EchoI8(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2530,6 +2611,9 @@ func (c *barClient) EchoString(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2602,6 +2686,9 @@ func (c *barClient) EchoStringList(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2674,6 +2761,9 @@ func (c *barClient) EchoStringMap(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2746,6 +2836,9 @@ func (c *barClient) EchoStringSet(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2818,6 +2911,9 @@ func (c *barClient) EchoStructList(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2890,6 +2986,9 @@ func (c *barClient) EchoStructSet(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -2962,6 +3061,9 @@ func (c *barClient) EchoTypedef(
 	} else {
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -369,17 +369,19 @@ func (c *barClient) ArgNotStruct(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -463,17 +465,19 @@ func (c *barClient) ArgWithHeaders(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -634,17 +638,19 @@ func (c *barClient) ArgWithManyQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -727,17 +733,19 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -844,17 +852,19 @@ func (c *barClient) ArgWithNestedQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -920,17 +930,19 @@ func (c *barClient) ArgWithParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -996,17 +1008,19 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1072,17 +1086,19 @@ func (c *barClient) ArgWithQueryHeader(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1165,17 +1181,19 @@ func (c *barClient) ArgWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1247,17 +1265,19 @@ func (c *barClient) DeleteFoo(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1328,17 +1348,19 @@ func (c *barClient) DeleteWithQueryParams(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1400,17 +1422,19 @@ func (c *barClient) Hello(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1500,17 +1524,19 @@ func (c *barClient) ListAndEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1584,17 +1610,19 @@ func (c *barClient) MissingArg(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1669,17 +1697,19 @@ func (c *barClient) NoRequest(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1755,17 +1785,19 @@ func (c *barClient) Normal(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1841,17 +1873,19 @@ func (c *barClient) NormalRecur(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -1926,17 +1960,19 @@ func (c *barClient) TooManyArgs(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2026,17 +2062,19 @@ func (c *barClient) EchoBinary(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2104,17 +2142,19 @@ func (c *barClient) EchoBool(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2184,17 +2224,19 @@ func (c *barClient) EchoDouble(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2264,17 +2306,19 @@ func (c *barClient) EchoEnum(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2344,17 +2388,19 @@ func (c *barClient) EchoI16(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2424,17 +2470,19 @@ func (c *barClient) EchoI32(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2504,17 +2552,19 @@ func (c *barClient) EchoI32Map(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2584,17 +2634,19 @@ func (c *barClient) EchoI64(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2664,17 +2716,19 @@ func (c *barClient) EchoI8(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2744,17 +2798,19 @@ func (c *barClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2824,17 +2880,19 @@ func (c *barClient) EchoStringList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2904,17 +2962,19 @@ func (c *barClient) EchoStringMap(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -2984,17 +3044,19 @@ func (c *barClient) EchoStringSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -3064,17 +3126,19 @@ func (c *barClient) EchoStructList(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -3144,17 +3208,19 @@ func (c *barClient) EchoStructSet(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -3224,17 +3290,19 @@ func (c *barClient) EchoTypedef(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -392,19 +392,21 @@ func (c *bazClient) EchoBinary(
 			ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -445,19 +447,21 @@ func (c *bazClient) EchoBool(
 			ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -498,19 +502,21 @@ func (c *bazClient) EchoDouble(
 			ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -551,19 +557,21 @@ func (c *bazClient) EchoEnum(
 			ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -604,19 +612,21 @@ func (c *bazClient) EchoI16(
 			ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -657,19 +667,21 @@ func (c *bazClient) EchoI32(
 			ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -710,19 +722,21 @@ func (c *bazClient) EchoI64(
 			ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -763,19 +777,21 @@ func (c *bazClient) EchoI8(
 			ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -816,19 +832,21 @@ func (c *bazClient) EchoString(
 			ctx, "SecondService", "echoString", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoString", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -869,19 +887,21 @@ func (c *bazClient) EchoStringList(
 			ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -922,19 +942,21 @@ func (c *bazClient) EchoStringMap(
 			ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -975,19 +997,21 @@ func (c *bazClient) EchoStringSet(
 			ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1028,19 +1052,21 @@ func (c *bazClient) EchoStructList(
 			ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1081,19 +1107,21 @@ func (c *bazClient) EchoStructSet(
 			ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1134,19 +1162,21 @@ func (c *bazClient) EchoTypedef(
 			ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1186,19 +1216,21 @@ func (c *bazClient) Call(
 			ctx, "SimpleService", "call", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "call", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1237,19 +1269,21 @@ func (c *bazClient) Compare(
 			ctx, "SimpleService", "compare", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "compare", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1294,19 +1328,21 @@ func (c *bazClient) GetProfile(
 			ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1349,19 +1385,21 @@ func (c *bazClient) HeaderSchema(
 			ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1406,19 +1444,21 @@ func (c *bazClient) Ping(
 			ctx, "SimpleService", "ping", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "ping", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1458,19 +1498,21 @@ func (c *bazClient) DeliberateDiffNoop(
 			ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1510,19 +1552,21 @@ func (c *bazClient) TestUUID(
 			ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1559,19 +1603,21 @@ func (c *bazClient) Trans(
 			ctx, "SimpleService", "trans", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "trans", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1616,19 +1662,21 @@ func (c *bazClient) TransHeaders(
 			ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1673,19 +1721,21 @@ func (c *bazClient) TransHeadersNoReq(
 			ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1728,19 +1778,21 @@ func (c *bazClient) TransHeadersType(
 			ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 
@@ -1784,19 +1836,21 @@ func (c *bazClient) URLTest(
 			ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 		)
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
-			success, respHeaders, err = c.client.Call(
+			success, respHeaders, clientErr = c.client.Call(
 				ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 			)
-			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+			if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				// Declare ok if it is not a system-error
 				return nil
 			}
-			return err
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -396,6 +396,9 @@ func (c *bazClient) EchoBinary(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -441,6 +444,9 @@ func (c *bazClient) EchoBool(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -486,6 +492,9 @@ func (c *bazClient) EchoDouble(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -531,6 +540,9 @@ func (c *bazClient) EchoEnum(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -576,6 +588,9 @@ func (c *bazClient) EchoI16(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -621,6 +636,9 @@ func (c *bazClient) EchoI32(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -666,6 +684,9 @@ func (c *bazClient) EchoI64(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -711,6 +732,9 @@ func (c *bazClient) EchoI8(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -756,6 +780,9 @@ func (c *bazClient) EchoString(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoString", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -801,6 +828,9 @@ func (c *bazClient) EchoStringList(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -846,6 +876,9 @@ func (c *bazClient) EchoStringMap(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -891,6 +924,9 @@ func (c *bazClient) EchoStringSet(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -936,6 +972,9 @@ func (c *bazClient) EchoStructList(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -981,6 +1020,9 @@ func (c *bazClient) EchoStructSet(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1026,6 +1068,9 @@ func (c *bazClient) EchoTypedef(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1070,6 +1115,9 @@ func (c *bazClient) Call(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "call", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1113,6 +1161,9 @@ func (c *bazClient) Compare(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "compare", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1162,6 +1213,9 @@ func (c *bazClient) GetProfile(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1209,6 +1263,9 @@ func (c *bazClient) HeaderSchema(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1258,6 +1315,9 @@ func (c *bazClient) Ping(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "ping", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1302,6 +1362,9 @@ func (c *bazClient) DeliberateDiffNoop(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1346,6 +1409,9 @@ func (c *bazClient) TestUUID(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1387,6 +1453,9 @@ func (c *bazClient) Trans(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "trans", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1436,6 +1505,9 @@ func (c *bazClient) TransHeaders(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1485,6 +1557,9 @@ func (c *bazClient) TransHeadersNoReq(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1532,6 +1607,9 @@ func (c *bazClient) TransHeadersType(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -1580,6 +1658,9 @@ func (c *bazClient) URLTest(
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -392,7 +392,8 @@ func (c *bazClient) EchoBinary(
 			ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 			)
@@ -401,6 +402,10 @@ func (c *bazClient) EchoBinary(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -440,7 +445,8 @@ func (c *bazClient) EchoBool(
 			ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 			)
@@ -449,6 +455,10 @@ func (c *bazClient) EchoBool(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -488,7 +498,8 @@ func (c *bazClient) EchoDouble(
 			ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 			)
@@ -497,6 +508,10 @@ func (c *bazClient) EchoDouble(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -536,7 +551,8 @@ func (c *bazClient) EchoEnum(
 			ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 			)
@@ -545,6 +561,10 @@ func (c *bazClient) EchoEnum(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -584,7 +604,8 @@ func (c *bazClient) EchoI16(
 			ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 			)
@@ -593,6 +614,10 @@ func (c *bazClient) EchoI16(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -632,7 +657,8 @@ func (c *bazClient) EchoI32(
 			ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 			)
@@ -641,6 +667,10 @@ func (c *bazClient) EchoI32(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -680,7 +710,8 @@ func (c *bazClient) EchoI64(
 			ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 			)
@@ -689,6 +720,10 @@ func (c *bazClient) EchoI64(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -728,7 +763,8 @@ func (c *bazClient) EchoI8(
 			ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 			)
@@ -737,6 +773,10 @@ func (c *bazClient) EchoI8(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -776,7 +816,8 @@ func (c *bazClient) EchoString(
 			ctx, "SecondService", "echoString", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoString", reqHeaders, args, &result,
 			)
@@ -785,6 +826,10 @@ func (c *bazClient) EchoString(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -824,7 +869,8 @@ func (c *bazClient) EchoStringList(
 			ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 			)
@@ -833,6 +879,10 @@ func (c *bazClient) EchoStringList(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -872,7 +922,8 @@ func (c *bazClient) EchoStringMap(
 			ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 			)
@@ -881,6 +932,10 @@ func (c *bazClient) EchoStringMap(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -920,7 +975,8 @@ func (c *bazClient) EchoStringSet(
 			ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 			)
@@ -929,6 +985,10 @@ func (c *bazClient) EchoStringSet(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -968,7 +1028,8 @@ func (c *bazClient) EchoStructList(
 			ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 			)
@@ -977,6 +1038,10 @@ func (c *bazClient) EchoStructList(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1016,7 +1081,8 @@ func (c *bazClient) EchoStructSet(
 			ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 			)
@@ -1025,6 +1091,10 @@ func (c *bazClient) EchoStructSet(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1064,7 +1134,8 @@ func (c *bazClient) EchoTypedef(
 			ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 			)
@@ -1073,6 +1144,10 @@ func (c *bazClient) EchoTypedef(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1111,7 +1186,8 @@ func (c *bazClient) Call(
 			ctx, "SimpleService", "call", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "call", reqHeaders, args, &result,
 			)
@@ -1120,6 +1196,10 @@ func (c *bazClient) Call(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1157,7 +1237,8 @@ func (c *bazClient) Compare(
 			ctx, "SimpleService", "compare", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "compare", reqHeaders, args, &result,
 			)
@@ -1166,6 +1247,10 @@ func (c *bazClient) Compare(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1209,7 +1294,8 @@ func (c *bazClient) GetProfile(
 			ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 			)
@@ -1218,6 +1304,10 @@ func (c *bazClient) GetProfile(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1259,7 +1349,8 @@ func (c *bazClient) HeaderSchema(
 			ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 			)
@@ -1268,6 +1359,10 @@ func (c *bazClient) HeaderSchema(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1311,7 +1406,8 @@ func (c *bazClient) Ping(
 			ctx, "SimpleService", "ping", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "ping", reqHeaders, args, &result,
 			)
@@ -1320,6 +1416,10 @@ func (c *bazClient) Ping(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1358,7 +1458,8 @@ func (c *bazClient) DeliberateDiffNoop(
 			ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 			)
@@ -1367,6 +1468,10 @@ func (c *bazClient) DeliberateDiffNoop(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1405,7 +1510,8 @@ func (c *bazClient) TestUUID(
 			ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 			)
@@ -1414,6 +1520,10 @@ func (c *bazClient) TestUUID(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1449,7 +1559,8 @@ func (c *bazClient) Trans(
 			ctx, "SimpleService", "trans", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "trans", reqHeaders, args, &result,
 			)
@@ -1458,6 +1569,10 @@ func (c *bazClient) Trans(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1501,7 +1616,8 @@ func (c *bazClient) TransHeaders(
 			ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 			)
@@ -1510,6 +1626,10 @@ func (c *bazClient) TransHeaders(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1553,7 +1673,8 @@ func (c *bazClient) TransHeadersNoReq(
 			ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 			)
@@ -1562,6 +1683,10 @@ func (c *bazClient) TransHeadersNoReq(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1603,7 +1728,8 @@ func (c *bazClient) TransHeadersType(
 			ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 			)
@@ -1612,6 +1738,10 @@ func (c *bazClient) TransHeadersType(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {
@@ -1654,7 +1784,8 @@ func (c *bazClient) URLTest(
 			ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 			)
@@ -1663,6 +1794,10 @@ func (c *bazClient) URLTest(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -392,7 +392,7 @@ func (c *bazClient) EchoBinary(
 			ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBinary", reqHeaders, args, &result,
 			)
@@ -440,7 +440,7 @@ func (c *bazClient) EchoBool(
 			ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoBool", reqHeaders, args, &result,
 			)
@@ -488,7 +488,7 @@ func (c *bazClient) EchoDouble(
 			ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoDouble", reqHeaders, args, &result,
 			)
@@ -536,7 +536,7 @@ func (c *bazClient) EchoEnum(
 			ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoEnum", reqHeaders, args, &result,
 			)
@@ -584,7 +584,7 @@ func (c *bazClient) EchoI16(
 			ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI16", reqHeaders, args, &result,
 			)
@@ -632,7 +632,7 @@ func (c *bazClient) EchoI32(
 			ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI32", reqHeaders, args, &result,
 			)
@@ -680,7 +680,7 @@ func (c *bazClient) EchoI64(
 			ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI64", reqHeaders, args, &result,
 			)
@@ -728,7 +728,7 @@ func (c *bazClient) EchoI8(
 			ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoI8", reqHeaders, args, &result,
 			)
@@ -776,7 +776,7 @@ func (c *bazClient) EchoString(
 			ctx, "SecondService", "echoString", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoString", reqHeaders, args, &result,
 			)
@@ -824,7 +824,7 @@ func (c *bazClient) EchoStringList(
 			ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringList", reqHeaders, args, &result,
 			)
@@ -872,7 +872,7 @@ func (c *bazClient) EchoStringMap(
 			ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringMap", reqHeaders, args, &result,
 			)
@@ -920,7 +920,7 @@ func (c *bazClient) EchoStringSet(
 			ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStringSet", reqHeaders, args, &result,
 			)
@@ -968,7 +968,7 @@ func (c *bazClient) EchoStructList(
 			ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructList", reqHeaders, args, &result,
 			)
@@ -1016,7 +1016,7 @@ func (c *bazClient) EchoStructSet(
 			ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoStructSet", reqHeaders, args, &result,
 			)
@@ -1064,7 +1064,7 @@ func (c *bazClient) EchoTypedef(
 			ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SecondService", "echoTypedef", reqHeaders, args, &result,
 			)
@@ -1111,7 +1111,7 @@ func (c *bazClient) Call(
 			ctx, "SimpleService", "call", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "call", reqHeaders, args, &result,
 			)
@@ -1157,7 +1157,7 @@ func (c *bazClient) Compare(
 			ctx, "SimpleService", "compare", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "compare", reqHeaders, args, &result,
 			)
@@ -1209,7 +1209,7 @@ func (c *bazClient) GetProfile(
 			ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "getProfile", reqHeaders, args, &result,
 			)
@@ -1259,7 +1259,7 @@ func (c *bazClient) HeaderSchema(
 			ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "headerSchema", reqHeaders, args, &result,
 			)
@@ -1311,7 +1311,7 @@ func (c *bazClient) Ping(
 			ctx, "SimpleService", "ping", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "ping", reqHeaders, args, &result,
 			)
@@ -1358,7 +1358,7 @@ func (c *bazClient) DeliberateDiffNoop(
 			ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "sillyNoop", reqHeaders, args, &result,
 			)
@@ -1405,7 +1405,7 @@ func (c *bazClient) TestUUID(
 			ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "testUuid", reqHeaders, args, &result,
 			)
@@ -1449,7 +1449,7 @@ func (c *bazClient) Trans(
 			ctx, "SimpleService", "trans", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "trans", reqHeaders, args, &result,
 			)
@@ -1501,7 +1501,7 @@ func (c *bazClient) TransHeaders(
 			ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeaders", reqHeaders, args, &result,
 			)
@@ -1553,7 +1553,7 @@ func (c *bazClient) TransHeadersNoReq(
 			ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersNoReq", reqHeaders, args, &result,
 			)
@@ -1603,7 +1603,7 @@ func (c *bazClient) TransHeadersType(
 			ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "transHeadersType", reqHeaders, args, &result,
 			)
@@ -1654,7 +1654,7 @@ func (c *bazClient) URLTest(
 			ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "baz", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "SimpleService", "urlTest", reqHeaders, args, &result,
 			)

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -175,13 +175,18 @@ func (c *contactsClient) SaveContacts(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -244,13 +249,18 @@ func (c *contactsClient) TestURLURL(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -175,17 +175,19 @@ func (c *contactsClient) SaveContacts(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -249,17 +251,19 @@ func (c *contactsClient) TestURLURL(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -175,7 +175,7 @@ func (c *contactsClient) SaveContacts(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -244,7 +244,7 @@ func (c *contactsClient) TestURLURL(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -177,6 +177,9 @@ func (c *contactsClient) SaveContacts(
 	} else {
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -243,6 +246,9 @@ func (c *contactsClient) TestURLURL(
 	} else {
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -189,6 +189,9 @@ func (c *corgeHTTPClient) EchoString(
 	} else {
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -187,7 +187,7 @@ func (c *corgeHTTPClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -187,17 +187,19 @@ func (c *corgeHTTPClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -187,13 +187,18 @@ func (c *corgeHTTPClient) EchoString(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -237,7 +237,8 @@ func (c *corgeClient) EchoString(
 			ctx, "Corge", "echoString", reqHeaders, args, &result,
 		)
 	} else {
-		hystrix.DoC(ctx, "corge", func(ctx context.Context) error {
+		var realErr error
+		err = hystrix.DoC(ctx, "corge", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "Corge", "echoString", reqHeaders, args, &result,
 			)
@@ -246,6 +247,10 @@ func (c *corgeClient) EchoString(
 			}
 			return err
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 
 	if err == nil && !success {

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -237,7 +237,7 @@ func (c *corgeClient) EchoString(
 			ctx, "Corge", "echoString", reqHeaders, args, &result,
 		)
 	} else {
-		err = hystrix.DoC(ctx, "corge", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "corge", func(ctx context.Context) error {
 			success, respHeaders, err = c.client.Call(
 				ctx, "Corge", "echoString", reqHeaders, args, &result,
 			)

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -241,6 +241,9 @@ func (c *corgeClient) EchoString(
 			success, respHeaders, err = c.client.Call(
 				ctx, "Corge", "echoString", reqHeaders, args, &result,
 			)
+			if _, isSysErr := err.(tchannel.SystemError); !isSysErr {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -179,17 +179,19 @@ func (c *googleNowClient) AddCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -256,17 +258,19 @@ func (c *googleNowClient) CheckCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -179,7 +179,7 @@ func (c *googleNowClient) AddCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -251,7 +251,7 @@ func (c *googleNowClient) CheckCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -179,13 +179,18 @@ func (c *googleNowClient) AddCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -251,13 +256,18 @@ func (c *googleNowClient) CheckCredentials(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -181,6 +181,9 @@ func (c *googleNowClient) AddCredentials(
 	} else {
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -250,6 +253,9 @@ func (c *googleNowClient) CheckCredentials(
 	} else {
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -172,17 +172,19 @@ func (c *multiClient) HelloA(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {
@@ -246,17 +248,19 @@ func (c *multiClient) HelloB(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -172,13 +172,18 @@ func (c *multiClient) HelloA(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err
@@ -241,13 +246,18 @@ func (c *multiClient) HelloB(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
-			res, err = req.Do()
+		var realErr error
+		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
+			res, realErr = req.Do()
 			if res.StatusCode < 500 {
 				return nil
 			}
-			return err
+			return realErr
 		}, nil)
+		if err == nil {
+			// Bad request or equivalent error, bubble it up
+			err = realErr
+		}
 	}
 	if err != nil {
 		return defaultRes, nil, err

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -172,7 +172,7 @@ func (c *multiClient) HelloA(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil
@@ -241,7 +241,7 @@ func (c *multiClient) HelloB(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -174,6 +174,9 @@ func (c *multiClient) HelloA(
 	} else {
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}
@@ -240,6 +243,9 @@ func (c *multiClient) HelloB(
 	} else {
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -168,17 +168,19 @@ func (c *withexceptionsClient) Func1(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		var realErr error
+		// We want hystrix ckt-breaker to count errors only for system issues
+		var clientErr error
 		err = hystrix.DoC(ctx, "withexceptions", func(ctx context.Context) error {
-			res, realErr = req.Do()
+			res, clientErr = req.Do()
 			if res.StatusCode < 500 {
+				// This is not a system error/issue
 				return nil
 			}
-			return realErr
+			return clientErr
 		}, nil)
 		if err == nil {
-			// Bad request or equivalent error, bubble it up
-			err = realErr
+			// ckt-breaker was ok, bubble up client error if set
+			err = clientErr
 		}
 	}
 	if err != nil {

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -168,7 +168,7 @@ func (c *withexceptionsClient) Func1(
 	if c.circuitBreakerDisabled {
 		res, err = req.Do()
 	} else {
-		err = hystrix.DoC(ctx, "withexceptions", func(ctx context.Context) error {
+		hystrix.DoC(ctx, "withexceptions", func(ctx context.Context) error {
 			res, err = req.Do()
 			if res.StatusCode < 500 {
 				return nil

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -170,6 +170,9 @@ func (c *withexceptionsClient) Func1(
 	} else {
 		err = hystrix.DoC(ctx, "withexceptions", func(ctx context.Context) error {
 			res, err = req.Do()
+			if res.StatusCode < 500 {
+				return nil
+			}
 			return err
 		}, nil)
 	}


### PR DESCRIPTION
When the downstream client call fails due to application errors, we should not count that towards
the circuit breaker threshold.  The systems are still behaving okay.

For tchannel, it is the "system errors"
For http downstream, we sorta count 5xx as system failures. This may not always be the case, but is there a better way?
For grpc downstream, all exceptions are system errors, so things should be okay.