### PR TITLE
Avoid nil map deref in workflow/endpoint templates

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1432,7 +1432,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return {{if eq .ResponseType ""}}nil, err{{else}}defaultRes, nil, err{{end}}
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1580,7 +1580,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 12343, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 12347, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2717,7 +2717,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		var success bool
-		respHeaders := map[string]string{}
+		respHeaders := make(map[string]string)
 		var err error
 		if (c.circuitBreakerDisabled) {
 			success, respHeaders, err = c.client.Call(
@@ -2786,7 +2786,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11204, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11208, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2717,7 +2717,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		var success bool
-		var respHeaders map[string]string
+		respHeaders := map[string]string{}
 		var err error
 		if (c.circuitBreakerDisabled) {
 			success, respHeaders, err = c.client.Call(
@@ -2755,9 +2755,9 @@ type {{$clientName}} struct {
 		if err != nil {
 			logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		{{if eq .ResponseType "" -}}
-			return nil, err
+			return respHeaders, err
 		{{else -}}
-			return resp, nil, err
+			return resp, respHeaders, err
 		{{end -}}
 		}
 
@@ -2786,7 +2786,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11187, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11204, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -257,7 +257,7 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return {{if eq .ResponseType ""}}nil, err{{else}}defaultRes, nil, err{{end}}
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -257,7 +257,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		var success bool
-		var respHeaders map[string]string
+		respHeaders := map[string]string{}
 		var err error
 		if (c.circuitBreakerDisabled) {
 			success, respHeaders, err = c.client.Call(
@@ -295,9 +295,9 @@ type {{$clientName}} struct {
 		if err != nil {
 			logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
 		{{if eq .ResponseType "" -}}
-			return nil, err
+			return respHeaders, err
 		{{else -}}
-			return resp, nil, err
+			return resp, respHeaders, err
 		{{end -}}
 		}
 

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -257,7 +257,7 @@ type {{$clientName}} struct {
 		{{end -}}
 
 		var success bool
-		respHeaders := map[string]string{}
+		respHeaders := make(map[string]string)
 		var err error
 		if (c.circuitBreakerDisabled) {
 			success, respHeaders, err = c.client.Call(

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -388,7 +388,7 @@ func (c *barClient) ArgNotStruct(
 		return nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -484,7 +484,7 @@ func (c *barClient) ArgWithHeaders(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -657,7 +657,7 @@ func (c *barClient) ArgWithManyQueryParams(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -752,7 +752,7 @@ func (c *barClient) ArgWithNearDupQueryParams(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -871,7 +871,7 @@ func (c *barClient) ArgWithNestedQueryParams(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -949,7 +949,7 @@ func (c *barClient) ArgWithParams(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1027,7 +1027,7 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1105,7 +1105,7 @@ func (c *barClient) ArgWithQueryHeader(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1200,7 +1200,7 @@ func (c *barClient) ArgWithQueryParams(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1284,7 +1284,7 @@ func (c *barClient) DeleteFoo(
 		return nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1367,7 +1367,7 @@ func (c *barClient) DeleteWithQueryParams(
 		return nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1441,7 +1441,7 @@ func (c *barClient) Hello(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1543,7 +1543,7 @@ func (c *barClient) ListAndEnum(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1629,7 +1629,7 @@ func (c *barClient) MissingArg(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1716,7 +1716,7 @@ func (c *barClient) NoRequest(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1804,7 +1804,7 @@ func (c *barClient) Normal(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1892,7 +1892,7 @@ func (c *barClient) NormalRecur(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -1979,7 +1979,7 @@ func (c *barClient) TooManyArgs(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2081,7 +2081,7 @@ func (c *barClient) EchoBinary(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2161,7 +2161,7 @@ func (c *barClient) EchoBool(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2243,7 +2243,7 @@ func (c *barClient) EchoDouble(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2325,7 +2325,7 @@ func (c *barClient) EchoEnum(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2407,7 +2407,7 @@ func (c *barClient) EchoI16(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2489,7 +2489,7 @@ func (c *barClient) EchoI32(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2571,7 +2571,7 @@ func (c *barClient) EchoI32Map(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2653,7 +2653,7 @@ func (c *barClient) EchoI64(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2735,7 +2735,7 @@ func (c *barClient) EchoI8(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2817,7 +2817,7 @@ func (c *barClient) EchoString(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2899,7 +2899,7 @@ func (c *barClient) EchoStringList(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -2981,7 +2981,7 @@ func (c *barClient) EchoStringMap(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -3063,7 +3063,7 @@ func (c *barClient) EchoStringSet(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -3145,7 +3145,7 @@ func (c *barClient) EchoStructList(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -3227,7 +3227,7 @@ func (c *barClient) EchoStructSet(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -3309,7 +3309,7 @@ func (c *barClient) EchoTypedef(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -385,7 +385,7 @@ func (c *bazClient) EchoBinary(
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -418,7 +418,7 @@ func (c *bazClient) EchoBinary(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoBinary_Helper.UnwrapResponse(&result)
@@ -440,7 +440,7 @@ func (c *bazClient) EchoBool(
 	logger := c.client.Loggers["SecondService::echoBool"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -473,7 +473,7 @@ func (c *bazClient) EchoBool(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoBool_Helper.UnwrapResponse(&result)
@@ -495,7 +495,7 @@ func (c *bazClient) EchoDouble(
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -528,7 +528,7 @@ func (c *bazClient) EchoDouble(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoDouble_Helper.UnwrapResponse(&result)
@@ -550,7 +550,7 @@ func (c *bazClient) EchoEnum(
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -583,7 +583,7 @@ func (c *bazClient) EchoEnum(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoEnum_Helper.UnwrapResponse(&result)
@@ -605,7 +605,7 @@ func (c *bazClient) EchoI16(
 	logger := c.client.Loggers["SecondService::echoI16"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -638,7 +638,7 @@ func (c *bazClient) EchoI16(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI16_Helper.UnwrapResponse(&result)
@@ -660,7 +660,7 @@ func (c *bazClient) EchoI32(
 	logger := c.client.Loggers["SecondService::echoI32"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -693,7 +693,7 @@ func (c *bazClient) EchoI32(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI32_Helper.UnwrapResponse(&result)
@@ -715,7 +715,7 @@ func (c *bazClient) EchoI64(
 	logger := c.client.Loggers["SecondService::echoI64"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -748,7 +748,7 @@ func (c *bazClient) EchoI64(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI64_Helper.UnwrapResponse(&result)
@@ -770,7 +770,7 @@ func (c *bazClient) EchoI8(
 	logger := c.client.Loggers["SecondService::echoI8"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -803,7 +803,7 @@ func (c *bazClient) EchoI8(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoI8_Helper.UnwrapResponse(&result)
@@ -825,7 +825,7 @@ func (c *bazClient) EchoString(
 	logger := c.client.Loggers["SecondService::echoString"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -858,7 +858,7 @@ func (c *bazClient) EchoString(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoString_Helper.UnwrapResponse(&result)
@@ -880,7 +880,7 @@ func (c *bazClient) EchoStringList(
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -913,7 +913,7 @@ func (c *bazClient) EchoStringList(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringList_Helper.UnwrapResponse(&result)
@@ -935,7 +935,7 @@ func (c *bazClient) EchoStringMap(
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -968,7 +968,7 @@ func (c *bazClient) EchoStringMap(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringMap_Helper.UnwrapResponse(&result)
@@ -990,7 +990,7 @@ func (c *bazClient) EchoStringSet(
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1023,7 +1023,7 @@ func (c *bazClient) EchoStringSet(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStringSet_Helper.UnwrapResponse(&result)
@@ -1045,7 +1045,7 @@ func (c *bazClient) EchoStructList(
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1078,7 +1078,7 @@ func (c *bazClient) EchoStructList(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStructList_Helper.UnwrapResponse(&result)
@@ -1100,7 +1100,7 @@ func (c *bazClient) EchoStructSet(
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1133,7 +1133,7 @@ func (c *bazClient) EchoStructSet(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoStructSet_Helper.UnwrapResponse(&result)
@@ -1155,7 +1155,7 @@ func (c *bazClient) EchoTypedef(
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1188,7 +1188,7 @@ func (c *bazClient) EchoTypedef(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SecondService_EchoTypedef_Helper.UnwrapResponse(&result)
@@ -1209,7 +1209,7 @@ func (c *bazClient) Call(
 	logger := c.client.Loggers["SimpleService::call"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1244,7 +1244,7 @@ func (c *bazClient) Call(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return nil, err
+		return respHeaders, err
 	}
 
 	return respHeaders, err
@@ -1262,7 +1262,7 @@ func (c *bazClient) Compare(
 	logger := c.client.Loggers["SimpleService::compare"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1299,7 +1299,7 @@ func (c *bazClient) Compare(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Compare_Helper.UnwrapResponse(&result)
@@ -1321,7 +1321,7 @@ func (c *bazClient) GetProfile(
 	logger := c.client.Loggers["SimpleService::getProfile"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1356,7 +1356,7 @@ func (c *bazClient) GetProfile(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_GetProfile_Helper.UnwrapResponse(&result)
@@ -1378,7 +1378,7 @@ func (c *bazClient) HeaderSchema(
 	logger := c.client.Loggers["SimpleService::headerSchema"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1415,7 +1415,7 @@ func (c *bazClient) HeaderSchema(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_HeaderSchema_Helper.UnwrapResponse(&result)
@@ -1437,7 +1437,7 @@ func (c *bazClient) Ping(
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1470,7 +1470,7 @@ func (c *bazClient) Ping(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Ping_Helper.UnwrapResponse(&result)
@@ -1491,7 +1491,7 @@ func (c *bazClient) DeliberateDiffNoop(
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1528,7 +1528,7 @@ func (c *bazClient) DeliberateDiffNoop(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return nil, err
+		return respHeaders, err
 	}
 
 	return respHeaders, err
@@ -1545,7 +1545,7 @@ func (c *bazClient) TestUUID(
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1578,7 +1578,7 @@ func (c *bazClient) TestUUID(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return nil, err
+		return respHeaders, err
 	}
 
 	return respHeaders, err
@@ -1596,7 +1596,7 @@ func (c *bazClient) Trans(
 	logger := c.client.Loggers["SimpleService::trans"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1633,7 +1633,7 @@ func (c *bazClient) Trans(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_Trans_Helper.UnwrapResponse(&result)
@@ -1655,7 +1655,7 @@ func (c *bazClient) TransHeaders(
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1692,7 +1692,7 @@ func (c *bazClient) TransHeaders(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeaders_Helper.UnwrapResponse(&result)
@@ -1714,7 +1714,7 @@ func (c *bazClient) TransHeadersNoReq(
 	logger := c.client.Loggers["SimpleService::transHeadersNoReq"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1749,7 +1749,7 @@ func (c *bazClient) TransHeadersNoReq(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeadersNoReq_Helper.UnwrapResponse(&result)
@@ -1771,7 +1771,7 @@ func (c *bazClient) TransHeadersType(
 	logger := c.client.Loggers["SimpleService::transHeadersType"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1808,7 +1808,7 @@ func (c *bazClient) TransHeadersType(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsBazBaz.SimpleService_TransHeadersType_Helper.UnwrapResponse(&result)
@@ -1829,7 +1829,7 @@ func (c *bazClient) URLTest(
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1862,7 +1862,7 @@ func (c *bazClient) URLTest(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return nil, err
+		return respHeaders, err
 	}
 
 	return respHeaders, err

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -385,7 +385,7 @@ func (c *bazClient) EchoBinary(
 	logger := c.client.Loggers["SecondService::echoBinary"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -440,7 +440,7 @@ func (c *bazClient) EchoBool(
 	logger := c.client.Loggers["SecondService::echoBool"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -495,7 +495,7 @@ func (c *bazClient) EchoDouble(
 	logger := c.client.Loggers["SecondService::echoDouble"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -550,7 +550,7 @@ func (c *bazClient) EchoEnum(
 	logger := c.client.Loggers["SecondService::echoEnum"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -605,7 +605,7 @@ func (c *bazClient) EchoI16(
 	logger := c.client.Loggers["SecondService::echoI16"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -660,7 +660,7 @@ func (c *bazClient) EchoI32(
 	logger := c.client.Loggers["SecondService::echoI32"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -715,7 +715,7 @@ func (c *bazClient) EchoI64(
 	logger := c.client.Loggers["SecondService::echoI64"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -770,7 +770,7 @@ func (c *bazClient) EchoI8(
 	logger := c.client.Loggers["SecondService::echoI8"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -825,7 +825,7 @@ func (c *bazClient) EchoString(
 	logger := c.client.Loggers["SecondService::echoString"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -880,7 +880,7 @@ func (c *bazClient) EchoStringList(
 	logger := c.client.Loggers["SecondService::echoStringList"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -935,7 +935,7 @@ func (c *bazClient) EchoStringMap(
 	logger := c.client.Loggers["SecondService::echoStringMap"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -990,7 +990,7 @@ func (c *bazClient) EchoStringSet(
 	logger := c.client.Loggers["SecondService::echoStringSet"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1045,7 +1045,7 @@ func (c *bazClient) EchoStructList(
 	logger := c.client.Loggers["SecondService::echoStructList"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1100,7 +1100,7 @@ func (c *bazClient) EchoStructSet(
 	logger := c.client.Loggers["SecondService::echoStructSet"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1155,7 +1155,7 @@ func (c *bazClient) EchoTypedef(
 	logger := c.client.Loggers["SecondService::echoTypedef"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1209,7 +1209,7 @@ func (c *bazClient) Call(
 	logger := c.client.Loggers["SimpleService::call"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1262,7 +1262,7 @@ func (c *bazClient) Compare(
 	logger := c.client.Loggers["SimpleService::compare"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1321,7 +1321,7 @@ func (c *bazClient) GetProfile(
 	logger := c.client.Loggers["SimpleService::getProfile"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1378,7 +1378,7 @@ func (c *bazClient) HeaderSchema(
 	logger := c.client.Loggers["SimpleService::headerSchema"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1437,7 +1437,7 @@ func (c *bazClient) Ping(
 
 	args := &clientsBazBaz.SimpleService_Ping_Args{}
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1491,7 +1491,7 @@ func (c *bazClient) DeliberateDiffNoop(
 
 	args := &clientsBazBaz.SimpleService_SillyNoop_Args{}
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1545,7 +1545,7 @@ func (c *bazClient) TestUUID(
 
 	args := &clientsBazBaz.SimpleService_TestUuid_Args{}
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1596,7 +1596,7 @@ func (c *bazClient) Trans(
 	logger := c.client.Loggers["SimpleService::trans"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1655,7 +1655,7 @@ func (c *bazClient) TransHeaders(
 	logger := c.client.Loggers["SimpleService::transHeaders"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1714,7 +1714,7 @@ func (c *bazClient) TransHeadersNoReq(
 	logger := c.client.Loggers["SimpleService::transHeadersNoReq"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1771,7 +1771,7 @@ func (c *bazClient) TransHeadersType(
 	logger := c.client.Loggers["SimpleService::transHeadersType"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -1829,7 +1829,7 @@ func (c *bazClient) URLTest(
 
 	args := &clientsBazBaz.SimpleService_UrlTest_Args{}
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -194,7 +194,7 @@ func (c *contactsClient) SaveContacts(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -270,7 +270,7 @@ func (c *contactsClient) TestURLURL(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -206,7 +206,7 @@ func (c *corgeHTTPClient) EchoString(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -230,7 +230,7 @@ func (c *corgeClient) EchoString(
 	logger := c.client.Loggers["Corge::echoString"]
 
 	var success bool
-	var respHeaders map[string]string
+	respHeaders := map[string]string{}
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(
@@ -263,7 +263,7 @@ func (c *corgeClient) EchoString(
 	}
 	if err != nil {
 		logger.Warn("Client failure: TChannel client call returned error", zap.Error(err))
-		return resp, nil, err
+		return resp, respHeaders, err
 	}
 
 	resp, err = clientsCorgeCorge.Corge_EchoString_Helper.UnwrapResponse(&result)

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -230,7 +230,7 @@ func (c *corgeClient) EchoString(
 	logger := c.client.Loggers["Corge::echoString"]
 
 	var success bool
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	var err error
 	if c.circuitBreakerDisabled {
 		success, respHeaders, err = c.client.Call(

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -198,7 +198,7 @@ func (c *googleNowClient) AddCredentials(
 		return nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -277,7 +277,7 @@ func (c *googleNowClient) CheckCredentials(
 		return nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -191,7 +191,7 @@ func (c *multiClient) HelloA(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
@@ -267,7 +267,7 @@ func (c *multiClient) HelloB(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -187,7 +187,7 @@ func (c *withexceptionsClient) Func1(
 		return defaultRes, nil, err
 	}
 
-	respHeaders := map[string]string{}
+	respHeaders := make(map[string]string)
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
@@ -63,12 +63,11 @@ func TestBazCall(t *testing.T) {
 	ms.MockClients().Baz.EXPECT().Call(gomock.Any(), expectedReqHeaders, gomock.Any()).
 		Return(map[string]string{"some-res-header": "something"}, nil)
 
-	success, resHeaders, err = ms.MakeTChannelRequest(
+	success, _, err = ms.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
 	if !assert.Error(t, err, "got tchannel error") {
 		return
 	}
 	assert.False(t, success)
-	assert.Nil(t, resHeaders)
 }

--- a/runtime/middlewares_tchannel_test.go
+++ b/runtime/middlewares_tchannel_test.go
@@ -89,7 +89,7 @@ func TestTchannelHandlers(t *testing.T) {
 
 	ms.MockClients().Baz.EXPECT().Call(gomock.Any(), expectedClientReqHeaders, gomock.Any()).
 		Return(map[string]string{"some-res-header": "something"}, nil)
-	success, resHeaders, err = ms.MakeTChannelRequest(
+	success, _, err = ms.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
 	if !assert.Error(t, err, "got tchannel error") {
@@ -97,7 +97,6 @@ func TestTchannelHandlers(t *testing.T) {
 	}
 
 	assert.False(t, success)
-	assert.Nil(t, resHeaders)
 }
 
 // Ensures that a tchannel middleware can read state from a tchannel middeware earlier in the stack.

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -222,7 +222,8 @@ func (c *TChannelClient) call(
 	defer cancel()
 
 	err = c.ch.RunWithRetry(ctx, func(ctx netContext.Context, rs *tchannel.RequestState) (cerr error) {
-		call.resHeaders, call.success = nil, false
+		call.resHeaders = map[string]string{}
+		call.success = false
 
 		sc, ctx := c.getDynamicChannelWithFallback(reqHeaders, c.sc, ctx)
 		call.call, cerr = sc.BeginCall(ctx, call.serviceMethod, &tchannel.CallOptions{
@@ -262,7 +263,7 @@ func (c *TChannelClient) call(
 	if err != nil {
 		// Do not wrap system errors.
 		if _, ok := err.(tchannel.SystemError); ok {
-			return call.success, nil, err
+			return call.success, call.resHeaders, err
 		}
 		return call.success, nil, errors.Wrapf(
 			err, "Could not make outbound %s.%s (%s %s) response",

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -267,11 +267,10 @@ func TestCallTChannelTimeout(t *testing.T) {
 	}
 	var result endpointsBaz.SimpleService_Call_Result
 
-	success, resHeaders, err := gateway.MakeTChannelRequest(
+	success, _, err := gateway.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
 	assert.Error(t, err, "excepting tchannel error")
-	assert.Nil(t, resHeaders)
 	assert.False(t, success)
 
 	assert.Len(t, gateway.Logs("info", "Started Example-gateway"), 1)


### PR DESCRIPTION
The endpoint-template was iterating through the respHeaders without checking if it
was non-nil.  With this change, we actually eliminate the nil map creation and return
empty map of response headers.

It is better not to generate nils rather than have the caller test for nils