### PR TITLE
Fix circuit-breaker trigger for http downstream services

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1417,8 +1417,8 @@ func (c *{{$clientName}}) {{$methodName}}(
 		var clientErr error
 		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1616,7 +1616,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 13860, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 13872, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -242,8 +242,8 @@ func (c *{{$clientName}}) {{$methodName}}(
 		var clientErr error
 		err = hystrix.DoC(ctx, "{{$clientID}}", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -373,8 +373,8 @@ func (c *barClient) ArgNotStruct(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -469,8 +469,8 @@ func (c *barClient) ArgWithHeaders(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -642,8 +642,8 @@ func (c *barClient) ArgWithManyQueryParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -737,8 +737,8 @@ func (c *barClient) ArgWithNearDupQueryParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -856,8 +856,8 @@ func (c *barClient) ArgWithNestedQueryParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -934,8 +934,8 @@ func (c *barClient) ArgWithParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1012,8 +1012,8 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1090,8 +1090,8 @@ func (c *barClient) ArgWithQueryHeader(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1185,8 +1185,8 @@ func (c *barClient) ArgWithQueryParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1269,8 +1269,8 @@ func (c *barClient) DeleteFoo(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1352,8 +1352,8 @@ func (c *barClient) DeleteWithQueryParams(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1426,8 +1426,8 @@ func (c *barClient) Hello(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1529,8 +1529,8 @@ func (c *barClient) ListAndEnum(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1616,8 +1616,8 @@ func (c *barClient) MissingArg(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1704,8 +1704,8 @@ func (c *barClient) NoRequest(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1793,8 +1793,8 @@ func (c *barClient) Normal(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1882,8 +1882,8 @@ func (c *barClient) NormalRecur(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -1970,8 +1970,8 @@ func (c *barClient) TooManyArgs(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2073,8 +2073,8 @@ func (c *barClient) EchoBinary(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2153,8 +2153,8 @@ func (c *barClient) EchoBool(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2235,8 +2235,8 @@ func (c *barClient) EchoDouble(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2317,8 +2317,8 @@ func (c *barClient) EchoEnum(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2399,8 +2399,8 @@ func (c *barClient) EchoI16(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2481,8 +2481,8 @@ func (c *barClient) EchoI32(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2563,8 +2563,8 @@ func (c *barClient) EchoI32Map(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2645,8 +2645,8 @@ func (c *barClient) EchoI64(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2727,8 +2727,8 @@ func (c *barClient) EchoI8(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2809,8 +2809,8 @@ func (c *barClient) EchoString(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2891,8 +2891,8 @@ func (c *barClient) EchoStringList(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -2973,8 +2973,8 @@ func (c *barClient) EchoStringMap(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -3055,8 +3055,8 @@ func (c *barClient) EchoStringSet(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -3137,8 +3137,8 @@ func (c *barClient) EchoStructList(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -3219,8 +3219,8 @@ func (c *barClient) EchoStructSet(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -3301,8 +3301,8 @@ func (c *barClient) EchoTypedef(
 		var clientErr error
 		err = hystrix.DoC(ctx, "bar", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -179,8 +179,8 @@ func (c *contactsClient) SaveContacts(
 		var clientErr error
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -255,8 +255,8 @@ func (c *contactsClient) TestURLURL(
 		var clientErr error
 		err = hystrix.DoC(ctx, "contacts", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -209,8 +209,8 @@ func (c *corgeHTTPClient) EchoString(
 		var clientErr error
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -288,8 +288,8 @@ func (c *corgeHTTPClient) NoContent(
 		var clientErr error
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -366,8 +366,8 @@ func (c *corgeHTTPClient) NoContentNoException(
 		var clientErr error
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -440,8 +440,8 @@ func (c *corgeHTTPClient) CorgeNoContentOnException(
 		var clientErr error
 		err = hystrix.DoC(ctx, "corge-http", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -183,8 +183,8 @@ func (c *googleNowClient) AddCredentials(
 		var clientErr error
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -262,8 +262,8 @@ func (c *googleNowClient) CheckCredentials(
 		var clientErr error
 		err = hystrix.DoC(ctx, "google-now", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -176,8 +176,8 @@ func (c *multiClient) HelloA(
 		var clientErr error
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr
@@ -252,8 +252,8 @@ func (c *multiClient) HelloB(
 		var clientErr error
 		err = hystrix.DoC(ctx, "multi", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -172,8 +172,8 @@ func (c *withexceptionsClient) Func1(
 		var clientErr error
 		err = hystrix.DoC(ctx, "withexceptions", func(ctx context.Context) error {
 			res, clientErr = req.Do()
-			if res.StatusCode < 500 {
-				// This is not a system error/issue
+			if res != nil {
+				// This is not a system error/issue. Downstream responded
 				return nil
 			}
 			return clientErr


### PR DESCRIPTION
The previous change PR#666 had circuit-breaker not trigger on application errors downstream.
The T-Channel one was correct, but there was a mistake in the way we did http downstream.

When there is a system error, the response is nil and not 500 as we had expected.
This fixes it.