### PR TITLE
Check before unmarshaling body

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -748,16 +748,17 @@ func (req *ServerHTTPRequest) ReadAll() ([]byte, bool) {
 func (req *ServerHTTPRequest) UnmarshalBody(
 	body json.Unmarshaler, rawBody []byte,
 ) bool {
-	err := body.UnmarshalJSON(rawBody)
-	if err != nil {
-		req.logger.Warn("Could not parse json", zap.Error(err))
-		if !req.parseFailed {
-			req.res.SendError(400, "Could not parse json: "+err.Error(), err)
-			req.parseFailed = true
+	if len(rawBody) > 0 {
+		err := body.UnmarshalJSON(rawBody)
+		if err != nil {
+			req.logger.Warn("Could not parse json", zap.Error(err))
+			if !req.parseFailed {
+				req.res.SendError(400, "Could not parse json: "+err.Error(), err)
+				req.parseFailed = true
+			}
+			return false
 		}
-		return false
 	}
-
 	return true
 }
 


### PR DESCRIPTION
We were not checking that the request body is empty before unmarshaling. Adding a check to prevent request failures. 
