### PR TITLE
getter for startTime

### DIFF
--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -130,6 +130,11 @@ func (req *ServerHTTPRequest) Context() context.Context {
 	return req.httpRequest.Context()
 }
 
+// StartTime returns the request's start time.
+func (req *ServerHTTPRequest) StartTime() time.Time {
+	return req.startTime
+}
+
 // start the request, emit metrics etc
 func (req *ServerHTTPRequest) start() {
 	if req.started {

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -2323,6 +2323,7 @@ func TestSpanCreated(t *testing.T) {
 				req *zanzibar.ServerHTTPRequest,
 				res *zanzibar.ServerHTTPResponse,
 			) {
+				assert.NotEmpty(t, req.StartTime(), "startTime is not initialized")
 				span := req.GetSpan()
 				assert.NotNil(t, span)
 				res.WriteJSONBytes(200, nil, []byte(`{"ok":true}`))


### PR DESCRIPTION
there are use cases where we want to read the start time for the request (for custom metric, etc.) in our application.