### PR TITLE
Add clientless endpoint - fix references and update license to 2020

### DIFF
--- a/benchmarks/benchserver/main.go
+++ b/benchmarks/benchserver/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/runner/main.go
+++ b/benchmarks/runner/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/casing.go
+++ b/codegen/casing.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/casing_test.go
+++ b/codegen/casing_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/client.go
+++ b/codegen/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/client_test.go
+++ b/codegen/client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -279,8 +279,8 @@ type EndpointSpec struct {
 	ClientMethod string `yaml:"clientMethod,omitempty"`
 	// The client for this endpoint if httpClient or tchannelClient
 	ClientSpec *ClientSpec `yaml:"-"`
-	// DummyEndpoint checks if the endpoint is clientless
-	IsDummyEndpoint bool `yaml:"-"`
+	// IsClientlessEndpoint checks if the endpoint is clientless
+	IsClientlessEndpoint bool `yaml:"-"`
 }
 
 func ensureFields(config map[string]interface{}, mandatoryFields []string, yamlFile string) error {
@@ -352,7 +352,7 @@ func NewEndpointSpec(
 	var workflowImportPath string
 	var clientID string
 	var clientMethod string
-	var isDummyEndpoint bool
+	var isClientlessEndpoint bool
 
 	workflowType := endpointConfigObj["workflowType"].(string)
 	if workflowType == "httpClient" || workflowType == "tchannelClient" {
@@ -384,7 +384,7 @@ func NewEndpointSpec(
 		}
 		workflowImportPath = iworkflowImportPath.(string)
 	} else if workflowType == clientlessWorkflow {
-		isDummyEndpoint = true
+		isClientlessEndpoint = true
 	} else {
 		return nil, errors.Errorf(
 			"Invalid workflowType %q for endpoint %q",
@@ -417,22 +417,22 @@ func NewEndpointSpec(
 	}
 
 	espec := &EndpointSpec{
-		ModuleSpec:         mspec,
-		YAMLFile:           yamlFile,
-		GoStructsFileName:  goStructsFileName,
-		GoFolderName:       goFolderName,
-		GoPackageName:      goPackageName,
-		EndpointType:       endpointConfigObj["endpointType"].(string),
-		EndpointID:         endpointConfigObj["endpointId"].(string),
-		HandleID:           endpointConfigObj["handleId"].(string),
-		ThriftFile:         thriftFile,
-		ThriftServiceName:  parts[0],
-		ThriftMethodName:   parts[1],
-		WorkflowType:       workflowType,
-		WorkflowImportPath: workflowImportPath,
-		IsDummyEndpoint:    isDummyEndpoint,
-		ClientID:           clientID,
-		ClientMethod:       clientMethod,
+		ModuleSpec:           mspec,
+		YAMLFile:             yamlFile,
+		GoStructsFileName:    goStructsFileName,
+		GoFolderName:         goFolderName,
+		GoPackageName:        goPackageName,
+		EndpointType:         endpointConfigObj["endpointType"].(string),
+		EndpointID:           endpointConfigObj["endpointId"].(string),
+		HandleID:             endpointConfigObj["handleId"].(string),
+		ThriftFile:           thriftFile,
+		ThriftServiceName:    parts[0],
+		ThriftMethodName:     parts[1],
+		WorkflowType:         workflowType,
+		WorkflowImportPath:   workflowImportPath,
+		IsClientlessEndpoint: isClientlessEndpoint,
+		ClientID:             clientID,
+		ClientMethod:         clientMethod,
 	}
 
 	defaultMidSpecs, err := getOrderedDefaultMiddlewareSpecs(

--- a/codegen/gateway_test.go
+++ b/codegen/gateway_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/header_propagate.go
+++ b/codegen/header_propagate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/header_propagate_test.go
+++ b/codegen/header_propagate_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/method.go
+++ b/codegen/method.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/method.go
+++ b/codegen/method.go
@@ -137,8 +137,8 @@ type MethodSpec struct {
 	// Statements for converting response types
 	ConvertResponseGoStatements []string
 
-	// Statements for converting Dummy request types
-	ConvertDummyRequestGoStatements []string
+	// Statements for converting Clientless request types
+	ConvertClientlessRequestGoStatements []string
 
 	// Statements for propagating headers to client requests
 	PropagateHeadersGoStatements []string
@@ -1003,7 +1003,7 @@ func (ms *MethodSpec) setTypeConverters(
 	return nil
 }
 
-func (ms *MethodSpec) setDummyTypeConverters(
+func (ms *MethodSpec) setClientlessTypeConverters(
 	funcSpec *compile.FunctionSpec,
 	reqTransforms map[string]FieldMapperEntry,
 	headersPropagate map[string]FieldMapperEntry,
@@ -1012,11 +1012,11 @@ func (ms *MethodSpec) setDummyTypeConverters(
 	h *PackageHelper,
 ) error {
 
-	dummyConverter := NewTypeConverter(h, nil)
+	clientlessConverter := NewTypeConverter(h, nil)
 
 	respType := funcSpec.ResultSpec.ReturnType
 
-	dummyConverter.append(
+	clientlessConverter.append(
 		"func convert",
 		PascalCase(ms.Name),
 		"DummyResponse(in ", ms.RequestType, ") ", ms.ResponseType, "{")
@@ -1044,16 +1044,16 @@ func (ms *MethodSpec) setDummyTypeConverters(
 	default:
 		// default as struct
 		respFields := respType.(*compile.StructSpec).Fields
-		dummyConverter.append("out", " := ", "&", ms.ShortResponseType, "{}\t\n")
-		err := dummyConverter.GenStructConverter(structType, respFields, dummyReqTransforms)
+		clientlessConverter.append("out", " := ", "&", ms.ShortResponseType, "{}\t\n")
+		err := clientlessConverter.GenStructConverter(structType, respFields, dummyReqTransforms)
 		if err != nil {
 			return err
 		}
 
 	}
 
-	dummyConverter.append("\nreturn out \t}")
-	ms.ConvertDummyRequestGoStatements = dummyConverter.GetLines()
+	clientlessConverter.append("\nreturn out \t}")
+	ms.ConvertClientlessRequestGoStatements = clientlessConverter.GetLines()
 
 	return nil
 }

--- a/codegen/mockgen.go
+++ b/codegen/mockgen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/module.go
+++ b/codegen/module.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -44,7 +44,7 @@ type EndpointMeta struct {
 	ClientMethodName       string
 	WorkflowPkg            string
 	ReqHeaders             map[string]*TypedHeader
-	IsDummyEndpoint        bool
+	IsClientlessEndpoint   bool
 	ReqHeadersKeys         []string
 	ReqRequiredHeadersKeys []string
 	ResHeaders             map[string]*TypedHeader
@@ -1154,7 +1154,7 @@ func (g *EndpointGenerator) generateEndpointFile(
 		IncludedPackages:       includedPackages,
 		Method:                 method,
 		ReqHeaders:             reqHeaders,
-		IsDummyEndpoint:        e.IsDummyEndpoint,
+		IsClientlessEndpoint:   e.IsClientlessEndpoint,
 		ReqHeadersKeys:         sortedHeaders(reqHeaders, false),
 		ReqRequiredHeadersKeys: sortedHeaders(reqHeaders, true),
 		ResHeadersKeys:         sortedHeaders(e.ResHeaders, false),
@@ -1193,7 +1193,7 @@ func (g *EndpointGenerator) generateEndpointFile(
 	out[endpointFilePath] = endpoint
 
 	tmpl := ""
-	if e.IsDummyEndpoint {
+	if e.IsClientlessEndpoint {
 		tmpl = "clientless-workflow.tmpl"
 	} else {
 		tmpl = "workflow.tmpl"

--- a/codegen/module_test.go
+++ b/codegen/module_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/package_test.go
+++ b/codegen/package_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/proto.go
+++ b/codegen/proto.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/proto_test.go
+++ b/codegen/proto_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/reflect_interface.go
+++ b/codegen/reflect_interface.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/service.go
+++ b/codegen/service.go
@@ -249,9 +249,9 @@ func (ms *ModuleSpec) SetDownstream(
 		)
 	}
 
-	if e.IsDummyEndpoint {
+	if e.IsClientlessEndpoint {
 		funcSpec := method.CompiledThriftSpec
-		err := method.setDummyTypeConverters(funcSpec, reqTransforms, headersPropagate, respTransforms, dummyReqTransforms, h)
+		err := method.setClientlessTypeConverters(funcSpec, reqTransforms, headersPropagate, respTransforms, dummyReqTransforms, h)
 		if err != nil {
 			return errors.Errorf(
 				"unable to set dummy type convertors for dummy endpoint")

--- a/codegen/service_test.go
+++ b/codegen/service_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -197,7 +197,7 @@ package clientlessworkflow
 {{- $reqHeaderRequiredKeys := .ReqRequiredHeadersKeys }}
 {{- $resHeaderMap := .ResHeaders }}
 {{- $resHeaderMapKeys := .ResHeadersKeys }}
-{{- $dummyEndpoint := .IsDummyEndpoint }}
+{{- $clientlessEndpoint := .IsClientlessEndpoint }}
 {{- $clientID := .ClientID }}
 {{- $clientName := title .ClientName }}
 {{- $clientMethodName := title .ClientMethodName }}
@@ -335,8 +335,8 @@ func (w {{$workflowStruct}}) Handle(
 	{{- end -}}
 }
 
-{{if eq $dummyEndpoint true -}}
-{{ range $key, $line := $method.ConvertDummyRequestGoStatements -}}
+{{if eq $clientlessEndpoint true -}}
+{{ range $key, $line := $method.ConvertClientlessRequestGoStatements -}}
 {{$line}}
 {{ end }}
 {{end -}}
@@ -353,7 +353,7 @@ func clientlessWorkflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4094, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4114, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -417,7 +417,6 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $resHeaderRequiredKeys := .ResRequiredHeadersKeys }}
 {{- $clientName := title .ClientName }}
 {{- $serviceMethod := printf "%s%s" (title .Method.ThriftService) (title .Method.Name) }}
-{{- $dummyEndpoint := .IsDummyEndpoint}}
 {{- $handlerName := printf "%sHandler" $serviceMethod }}
 {{- $clientMethodName := title .ClientMethodName }}
 {{- $endpointId := .Spec.EndpointID }}
@@ -425,7 +424,6 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $middlewares := .Spec.Middlewares }}
 {{- $workflowPkg := .WorkflowPkg }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
-{{- $dummyWorkflowInterface := printf "%sDummyWorkflow" $serviceMethod }}
 {{- $traceKey := .TraceKey }}
 
 import (
@@ -658,7 +656,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 7154, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 7039, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_test.go
+++ b/codegen/template_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/templates/clientless-workflow.tmpl
+++ b/codegen/templates/clientless-workflow.tmpl
@@ -8,7 +8,7 @@ package clientlessworkflow
 {{- $reqHeaderRequiredKeys := .ReqRequiredHeadersKeys }}
 {{- $resHeaderMap := .ResHeaders }}
 {{- $resHeaderMapKeys := .ResHeadersKeys }}
-{{- $dummyEndpoint := .IsDummyEndpoint }}
+{{- $clientlessEndpoint := .IsClientlessEndpoint }}
 {{- $clientID := .ClientID }}
 {{- $clientName := title .ClientName }}
 {{- $clientMethodName := title .ClientMethodName }}
@@ -146,8 +146,8 @@ func (w {{$workflowStruct}}) Handle(
 	{{- end -}}
 }
 
-{{if eq $dummyEndpoint true -}}
-{{ range $key, $line := $method.ConvertDummyRequestGoStatements -}}
+{{if eq $clientlessEndpoint true -}}
+{{ range $key, $line := $method.ConvertClientlessRequestGoStatements -}}
 {{$line}}
 {{ end }}
 {{end -}}

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -10,7 +10,6 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $resHeaderRequiredKeys := .ResRequiredHeadersKeys }}
 {{- $clientName := title .ClientName }}
 {{- $serviceMethod := printf "%s%s" (title .Method.ThriftService) (title .Method.Name) }}
-{{- $dummyEndpoint := .IsDummyEndpoint}}
 {{- $handlerName := printf "%sHandler" $serviceMethod }}
 {{- $clientMethodName := title .ClientMethodName }}
 {{- $endpointId := .Spec.EndpointID }}
@@ -18,7 +17,6 @@ package {{$instance.PackageInfo.PackageName}}
 {{- $middlewares := .Spec.Middlewares }}
 {{- $workflowPkg := .WorkflowPkg }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
-{{- $dummyWorkflowInterface := printf "%sDummyWorkflow" $serviceMethod }}
 {{- $traceKey := .TraceKey }}
 
 import (

--- a/codegen/thrift.go
+++ b/codegen/thrift.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/thrift_test.go
+++ b/codegen/thrift_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/codegen/type_converter_test.go
+++ b/codegen/type_converter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/config/production.gen.go
+++ b/config/production.gen.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/fix_glide.go
+++ b/fix_glide.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/client_http_request_test.go
+++ b/runtime/client_http_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/client_http_request_write_json_test.go
+++ b/runtime/client_http_request_write_json_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/client_http_response_test.go
+++ b/runtime/client_http_response_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/grpc_client.go
+++ b/runtime/grpc_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/grpc_client_test.go
+++ b/runtime/grpc_client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/http_client.go
+++ b/runtime/http_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/http_server.go
+++ b/runtime/http_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/middlewares_tchannel.go
+++ b/runtime/middlewares_tchannel.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/middlewares_tchannel_test.go
+++ b/runtime/middlewares_tchannel_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/middlewares_test.go
+++ b/runtime/middlewares_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/plugins/m3_aggregator.go
+++ b/runtime/plugins/m3_aggregator.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router/router.go
+++ b/runtime/router/router.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router/router_test.go
+++ b/runtime/router/router_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router/trie.go
+++ b/runtime/router/trie.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router/trie_test.go
+++ b/runtime/router/trie_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/ruleengine/rule_engine.go
+++ b/runtime/ruleengine/rule_engine.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/ruleengine/rule_engine_test.go
+++ b/runtime/ruleengine/rule_engine_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/runtime_metrics.go
+++ b/runtime/runtime_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/runtime_metrics_test.go
+++ b/runtime/runtime_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_header.go
+++ b/runtime/server_header.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_header_test.go
+++ b/runtime/server_header_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_http_request.go
+++ b/runtime/server_http_request.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_http_response_easyjson_test.go
+++ b/runtime/server_http_response_easyjson_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/static_config.go
+++ b/runtime/static_config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/static_config_test.go
+++ b/runtime/static_config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_headers.go
+++ b/runtime/tchannel_headers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_headers_test.go
+++ b/runtime/tchannel_headers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_helpers.go
+++ b/runtime/tchannel_helpers.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_helpers_test.go
+++ b/runtime/tchannel_helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_inbound_call.go
+++ b/runtime/tchannel_inbound_call.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_interfaces.go
+++ b/runtime/tchannel_interfaces.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_logger.go
+++ b/runtime/tchannel_logger.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_logger_test.go
+++ b/runtime/tchannel_logger_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_metrics.go
+++ b/runtime/tchannel_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_metrics_test.go
+++ b/runtime/tchannel_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/runtime/tchannel_server_test.go
+++ b/runtime/tchannel_server_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scripts/easy_json/easy_json.go
+++ b/scripts/easy_json/easy_json.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scripts/resolve_i64/main.go
+++ b/scripts/resolve_i64/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/scripts/resolve_thrift/main.go
+++ b/scripts/resolve_thrift/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/bootstrap_test.go
+++ b/test/bootstrap_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/clients/bar/bar_test.go
+++ b/test/clients/bar/bar_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/clients/baz/baz_test.go
+++ b/test/clients/baz/baz_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/clients/echo/echo_test.go
+++ b/test/clients/echo/echo_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_arg_with_headers_test.go
+++ b/test/endpoints/bar/bar_arg_with_headers_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_arg_with_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_params_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_arg_with_query_params_test.go
+++ b/test/endpoints/bar/bar_arg_with_query_params_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_hello_test.go
+++ b/test/endpoints/bar/bar_hello_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/bar/bar_normal_test.go
+++ b/test/endpoints/bar/bar_normal_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_call_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/baz/baz_simpleservice_method_compare_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_compare_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/baz/baz_simpleservice_method_ping_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_ping_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
+++ b/test/endpoints/baz/baz_simpleservice_method_silly_noop_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/clientless/clientless_test.go
+++ b/test/endpoints/clientless/clientless_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/contacts/save_contacts_test.go
+++ b/test/endpoints/contacts/save_contacts_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/googlenow/googlenow_test.go
+++ b/test/endpoints/googlenow/googlenow_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/multi/multi_helloA_test.go
+++ b/test/endpoints/multi/multi_helloA_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/multi/multi_helloB_test.go
+++ b/test/endpoints/multi/multi_helloB_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/jaeger_test.go
+++ b/test/jaeger_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/sort_metrics.go
+++ b/test/lib/sort_metrics.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_backend/test_http_backend.go
+++ b/test/lib/test_backend/test_http_backend.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_backend/test_tchannel_backend.go
+++ b/test/lib/test_backend/test_tchannel_backend.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_gateway/test_gateway.go
+++ b/test/lib/test_gateway/test_gateway.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_gateway/test_gateway_cover.go
+++ b/test/lib/test_gateway/test_gateway_cover.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_gateway/test_gateway_process.go
+++ b/test/lib/test_gateway/test_gateway_process.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/test_m3_server/test_m3_server.go
+++ b/test/lib/test_m3_server/test_m3_server.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/util/util.go
+++ b/test/lib/util/util.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/test/lib/wait_at_least.go
+++ b/test/lib/wait_at_least.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This diff fixes the references from dummyEndpoint -> ClientlessEndpoint in all cases and updates the license for all files for 2020. Happy New Year! 