### PR TITLE
update deputy middleware to properly close channel between connections

### DIFF
--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -244,10 +244,14 @@ func (h *{{$handlerName}}) redirectToDeputy(
 		"{{.ThriftService}}::{{.Name}}": "{{$methodName}}",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -262,10 +266,6 @@ func (h *{{$handlerName}}) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "{{.ThriftService}}", "{{$methodName}}", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }
 {{end -}}

--- a/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -158,10 +158,14 @@ func (h *BounceBounceHandler) redirectToDeputy(
 		"Bounce::bounce": "bounce",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -176,9 +180,5 @@ func (h *BounceBounceHandler) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "Bounce", "bounce", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -214,10 +214,14 @@ func (h *SimpleServiceCallHandler) redirectToDeputy(
 		"SimpleService::Call": "Call",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -232,9 +236,5 @@ func (h *SimpleServiceCallHandler) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "SimpleService", "Call", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -158,10 +158,14 @@ func (h *SimpleServiceEchoHandler) redirectToDeputy(
 		"SimpleService::Echo": "Echo",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -176,9 +180,5 @@ func (h *SimpleServiceEchoHandler) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "SimpleService", "Echo", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -158,10 +158,14 @@ func (h *EchoEchoHandler) redirectToDeputy(
 		"Echo::echo": "echo",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -176,9 +180,5 @@ func (h *EchoEchoHandler) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "Echo", "echo", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -208,10 +208,14 @@ func (h *SimpleServiceAnotherCallHandler) redirectToDeputy(
 		"SimpleService::AnotherCall": "AnotherCall",
 	}
 
-	sub := h.Deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
-	sub.Peers().Add(hostPort)
+	deputyChannel, err := tchannel.NewChannel(serviceName, nil)
+	if err != nil {
+		h.Deps.Default.ContextLogger.Error(ctx, "Deputy Failure", zap.Error(err))
+	}
+	defer deputyChannel.Close()
+	deputyChannel.Peers().Add(hostPort)
 	client := zanzibar.NewTChannelClientContext(
-		h.Deps.Default.Channel,
+		deputyChannel,
 		h.Deps.Default.Logger,
 		h.Deps.Default.ContextMetrics,
 		h.Deps.Default.ContextExtractor,
@@ -226,9 +230,5 @@ func (h *SimpleServiceAnotherCallHandler) redirectToDeputy(
 	)
 
 	success, respHeaders, err := client.Call(ctx, "SimpleService", "AnotherCall", reqHeaders, req, res)
-	// hostPort is added above, so there should not be any error returned for the
-	// following line
-	// nolint
-	_ = sub.Peers().Remove(hostPort)
 	return success, res, respHeaders, err
 }


### PR DESCRIPTION
Change deputy middleware to open a new channel, rather than use a sub-channel and edit the Peers list. 
From tchannel code: 
```
// Remove removes a peer from the peer list. It returns an error if the peer cannot be found.
// Remove does not affect connections to the peer in any way.
```
Observed that with the subchannel implementation, connections using deputy would work sporadically, especially soon after a service restart, but would start failing later, possibly after the Cerberus CLI session was restarted.  

Creating a new channel and closing it is consistent with the more generic middleware supported by Cerberus/Deputy team.

See https://code.uberinternal.com/T4892307 for internal Uber details