### PR TITLE
Add nil check in code-gen converter for binary

### DIFF
--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -808,6 +808,9 @@ func (c *TypeConverter) genStructConverter(
 			}
 		case *compile.BinarySpec:
 			// TODO: handle override. Check if binarySpec can be optional.
+			for _, line := range checkOptionalNil(indent, c.uninitialized, toIdentifier, prevKeyPrefixes, c.useRecurGen) {
+				c.append(line)
+			}
 			c.append(toIdentifier, " = []byte(", fromIdentifier, ")")
 
 		case *compile.StructSpec:

--- a/codegen/type_converter.go
+++ b/codegen/type_converter.go
@@ -807,12 +807,10 @@ func (c *TypeConverter) genStructConverter(
 				return err
 			}
 		case *compile.BinarySpec:
-			// TODO: handle override. Check if binarySpec can be optional.
 			for _, line := range checkOptionalNil(indent, c.uninitialized, toIdentifier, prevKeyPrefixes, c.useRecurGen) {
 				c.append(line)
 			}
 			c.append(toIdentifier, " = []byte(", fromIdentifier, ")")
-
 		case *compile.StructSpec:
 			var (
 				stFromPrefix = fromPrefix


### PR DESCRIPTION
### The problem:
Converter doesn't check nil for binary type. So when it tries to convert binary to a nested field, for example out.NestedTwo.Two, it can cause NPEs. Without this fix, it can generate code like the following, while out.NestedTwo can be nil.
> out.NestedTwo.Two = []byte(in.Two)

### The fix:
Add nil check for binary type.

### Testing:
Added test, failed and got:
> out.One = (*string)(in.One)
> out.NestedTwo.NestedNestedTwo.Two = []byte(in.Two)

Added code, test passed and got
> out.One = (*string)(in.One)
>if out.NestedTwo == nil {
>	out.NestedTwo = &structs.NestedBar{}
>}
>if out.NestedTwo.NestedNestedTwo == nil {
>	out.NestedTwo.NestedNestedTwo = &structs.NestedNestedBar{}
>}
>out.NestedTwo.NestedNestedTwo.Two = []byte(in.Two)
