### PR TITLE
Export metrics

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1667,7 +1667,11 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return responseBody, respHeaders, nil
 		{{ else }}
 		var responseBody {{unref .ResponseType}}
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1739,7 +1743,11 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return responseBody, respHeaders, nil
 		{{ else }}
 		var responseBody {{unref .ResponseType}}
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1802,7 +1810,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 14172, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 14362, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -306,7 +306,11 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return responseBody, respHeaders, nil
 		{{ else }}
 		var responseBody {{unref .ResponseType}}
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -378,7 +382,11 @@ func (c *{{$clientName}}) {{$methodName}}(
 		return responseBody, respHeaders, nil
 		{{ else }}
 		var responseBody {{unref .ResponseType}}
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -500,7 +500,11 @@ func (c *barClient) ArgWithHeaders(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -673,7 +677,11 @@ func (c *barClient) ArgWithManyQueryParams(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -768,7 +776,11 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -887,7 +899,11 @@ func (c *barClient) ArgWithNestedQueryParams(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -965,7 +981,11 @@ func (c *barClient) ArgWithParams(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1043,7 +1063,11 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1121,7 +1145,11 @@ func (c *barClient) ArgWithQueryHeader(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1216,7 +1244,11 @@ func (c *barClient) ArgWithQueryParams(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1457,7 +1489,11 @@ func (c *barClient) Hello(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1560,7 +1596,11 @@ func (c *barClient) ListAndEnum(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1647,7 +1687,11 @@ func (c *barClient) MissingArg(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1735,7 +1779,11 @@ func (c *barClient) NoRequest(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1824,7 +1872,11 @@ func (c *barClient) Normal(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -1913,7 +1965,11 @@ func (c *barClient) NormalRecur(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponseRecur
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2001,7 +2057,11 @@ func (c *barClient) TooManyArgs(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2184,7 +2244,11 @@ func (c *barClient) EchoBool(
 	switch res.StatusCode {
 	case 200:
 		var responseBody bool
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2266,7 +2330,11 @@ func (c *barClient) EchoDouble(
 	switch res.StatusCode {
 	case 200:
 		var responseBody float64
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2348,7 +2416,11 @@ func (c *barClient) EchoEnum(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.Fruit
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2430,7 +2502,11 @@ func (c *barClient) EchoI16(
 	switch res.StatusCode {
 	case 200:
 		var responseBody int16
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2512,7 +2588,11 @@ func (c *barClient) EchoI32(
 	switch res.StatusCode {
 	case 200:
 		var responseBody int32
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2594,7 +2674,11 @@ func (c *barClient) EchoI32Map(
 	switch res.StatusCode {
 	case 200:
 		var responseBody map[int32]*clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2676,7 +2760,11 @@ func (c *barClient) EchoI64(
 	switch res.StatusCode {
 	case 200:
 		var responseBody int64
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2758,7 +2846,11 @@ func (c *barClient) EchoI8(
 	switch res.StatusCode {
 	case 200:
 		var responseBody int8
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2840,7 +2932,11 @@ func (c *barClient) EchoString(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -2922,7 +3018,11 @@ func (c *barClient) EchoStringList(
 	switch res.StatusCode {
 	case 200:
 		var responseBody []string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -3004,7 +3104,11 @@ func (c *barClient) EchoStringMap(
 	switch res.StatusCode {
 	case 200:
 		var responseBody map[string]*clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -3086,7 +3190,11 @@ func (c *barClient) EchoStringSet(
 	switch res.StatusCode {
 	case 200:
 		var responseBody map[string]struct{}
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -3168,7 +3276,11 @@ func (c *barClient) EchoStructList(
 	switch res.StatusCode {
 	case 200:
 		var responseBody []*clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -3250,7 +3362,11 @@ func (c *barClient) EchoStructSet(
 	switch res.StatusCode {
 	case 200:
 		var responseBody []*clientsBarBar.BarResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -3332,7 +3448,11 @@ func (c *barClient) EchoTypedef(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsBarBar.UUID
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -204,7 +204,11 @@ func (c *contactsClient) SaveContacts(
 	switch res.StatusCode {
 	case 202:
 		var responseBody clientsContactsContacts.SaveContactsResponse
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -286,7 +290,11 @@ func (c *contactsClient) TestURLURL(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -234,7 +234,11 @@ func (c *corgeHTTPClient) EchoString(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -465,7 +469,11 @@ func (c *corgeHTTPClient) CorgeNoContentOnException(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsCorgeCorge.Foo
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -201,7 +201,11 @@ func (c *multiClient) HelloA(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}
@@ -277,7 +281,11 @@ func (c *multiClient) HelloB(
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -197,7 +197,11 @@ func (c *withexceptionsClient) Func1(
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsWithexceptionsWithexceptions.Response
-		err = res.ReadAndUnmarshalBody(&responseBody)
+		rawBody, err := res.ReadAll()
+		if err != nil {
+			return defaultRes, respHeaders, err
+		}
+		err = res.UnmarshalBody(&responseBody, rawBody)
 		if err != nil {
 			return defaultRes, respHeaders, err
 		}

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -41,6 +41,7 @@ type ClientHTTPRequest struct {
 	ClientID             string
 	ClientTargetEndpoint string
 	MethodName           string
+	Metrics              ContextMetrics
 	client               *HTTPClient
 	httpReq              *http.Request
 	res                  *ClientHTTPResponse
@@ -51,7 +52,6 @@ type ClientHTTPRequest struct {
 	rawBody              []byte
 	defaultHeaders       map[string]string
 	ctx                  context.Context
-	metrics              ContextMetrics
 }
 
 // NewClientHTTPRequest allocates a ClientHTTPRequest. The ctx parameter is the context associated with the outbound requests.

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -73,12 +73,12 @@ func NewClientHTTPRequest(
 		ClientID:             clientID,
 		MethodName:           clientMethod,
 		ClientTargetEndpoint: clientTargetEndpoint,
+		Metrics:              client.contextMetrics,
 		client:               client,
 		Logger:               client.loggers[clientMethod],
 		ContextLogger:        NewContextLogger(client.loggers[clientMethod]),
 		defaultHeaders:       client.DefaultHeaders,
 		ctx:                  ctx,
-		metrics:              client.contextMetrics,
 	}
 	req.res = NewClientHTTPResponse(req)
 	req.start()
@@ -212,7 +212,7 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 	}
 
 	// emit metrics
-	req.metrics.IncCounter(req.ctx, clientRequest, 1)
+	req.Metrics.IncCounter(req.ctx, clientRequest, 1)
 
 	req.res.setRawHTTPResponse(res)
 	return req.res, nil

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -176,8 +176,8 @@ func (res *ClientHTTPResponse) finish() {
 
 	// emit metrics
 	delta := res.finishTime.Sub(res.req.startTime)
-	res.req.metrics.RecordTimer(res.req.ctx, clientLatency, delta)
-	res.req.metrics.RecordHistogramDuration(res.req.ctx, clientLatencyHist, delta)
+	res.req.Metrics.RecordTimer(res.req.ctx, clientLatency, delta)
+	res.req.Metrics.RecordHistogramDuration(res.req.ctx, clientLatencyHist, delta)
 	_, known := knownStatusCodes[res.StatusCode]
 	if !known {
 		res.req.Logger.Error(
@@ -187,10 +187,10 @@ func (res *ClientHTTPResponse) finish() {
 	} else {
 		scopeTags := map[string]string{scopeTagStatus: fmt.Sprintf("%d", res.StatusCode)}
 		res.req.ctx = WithScopeTags(res.req.ctx, scopeTags)
-		res.req.metrics.IncCounter(res.req.ctx, clientStatus, 1)
+		res.req.Metrics.IncCounter(res.req.ctx, clientStatus, 1)
 	}
 	if !known || res.StatusCode >= 400 && res.StatusCode < 600 {
-		res.req.metrics.IncCounter(res.req.ctx, clientErrors, 1)
+		res.req.Metrics.IncCounter(res.req.ctx, clientErrors, 1)
 		logFn = res.req.ContextLogger.Warn
 	}
 

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -106,6 +106,7 @@ func (res *ClientHTTPResponse) UnmarshalBody(v interface{}, rawBody []byte) erro
 	err := json.Unmarshal(rawBody, v)
 	if err != nil {
 		res.req.Logger.Warn("Could not parse response json", zap.Error(err))
+		res.req.Metrics.IncCounter(res.req.ctx, clientHTTPUnmarshalError, 1)
 		return errors.Wrapf(
 			err, "Could not parse %s.%s response json",
 			res.req.ClientID, res.req.MethodName,

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -46,6 +46,9 @@ const (
 	clientSystemErrors = "client.system-errors"
 	clientLatency      = "client.latency"
 	clientLatencyHist  = "client.latency-hist"
+
+	// clientHTTPUnmarshalError is the metric for tracking errors due to unmarshalling json responses
+	clientHTTPUnmarshalError = "client.http-unmarshal-error"
 )
 
 var knownMetrics = []string{

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -49,6 +49,8 @@ const (
 
 	// clientHTTPUnmarshalError is the metric for tracking errors due to unmarshalling json responses
 	clientHTTPUnmarshalError = "client.http-unmarshal-error"
+	// clientTchannelReadError is the metric for tracking errors in reading tchannel response
+	clientTchannelReadError = "client.tchannel-read-error"
 )
 
 var knownMetrics = []string{

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -253,7 +253,7 @@ func (c *TChannelClient) call(
 		if cerr = call.readResHeaders(response); cerr != nil {
 			return cerr
 		}
-		if cerr = call.readResBody(response, resp); cerr != nil {
+		if cerr = call.readResBody(ctx, response, resp); cerr != nil {
 			return cerr
 		}
 

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -219,8 +219,8 @@ func (c *tchannelOutboundCall) readResHeaders(response *tchannel.OutboundCallRes
 	return nil
 }
 
-// readResHeaders read response headers from arg2
-func (c *tchannelOutboundCall) readResBody(response *tchannel.OutboundCallResponse, resp RWTStruct) error {
+// readResBody read response body from arg3
+func (c *tchannelOutboundCall) readResBody(ctx context.Context, response *tchannel.OutboundCallResponse, resp RWTStruct) error {
 	treader, err := response.Arg3Reader()
 	if err != nil {
 		return errors.Wrapf(
@@ -230,6 +230,7 @@ func (c *tchannelOutboundCall) readResBody(response *tchannel.OutboundCallRespon
 	}
 	if err := ReadStruct(treader, resp); err != nil {
 		_ = treader.Close()
+		c.metrics.IncCounter(ctx, clientTchannelReadError, 1)
 		return errors.Wrapf(
 			err, "Could not read outbound %s.%s (%s %s) response",
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,


### PR DESCRIPTION
Exporting metrics to capture failure rates in HTTP clients. 

In the generated client code in EG - we want to add metrics to see failures. There is no way of doing that today, since we don't have the Metrics in scope there.