### PR TITLE
Get more buckets for latency measurement

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -563,7 +563,7 @@ func (gateway *Gateway) setupMetrics(config *StaticConfig) (err error) {
 		tally.ScopeOptions{
 			Tags:            defaultTags,
 			CachedReporter:  gateway.metricsBackend,
-			DefaultBuckets:  tally.MustMakeExponentialDurationBuckets(10*time.Millisecond, 4, 6), // Range: 10ms - 10s
+			DefaultBuckets:  tally.MustMakeExponentialDurationBuckets(10*time.Millisecond, 2, 11), // Range: 10ms - 10s
 			Separator:       tally.DefaultSeparator,
 			SanitizeOptions: &m3.DefaultSanitizerOpts,
 		},


### PR DESCRIPTION
The current default while conservative, are not very useful.
This is one step towards more granular measurement - eventually this should be customizable in the system using zanzibar