### PR TITLE
parallelization module

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -32,10 +32,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/abhishekparwal/parallelize-go/parallelize"
-
 	yaml "github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/uber/zanzibar/parallelize"
 )
 
 // moduleType enum defines whether a ModuleClass is a singleton or contains

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -28,12 +28,11 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/abhishekparwal/parallelize-go/parallelize"
-
 	validator2 "gopkg.in/validator.v2"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/uber/zanzibar/parallelize"
 	"go.uber.org/thriftrw/compile"
 )
 

--- a/codegen/post_gen_hooks.go
+++ b/codegen/post_gen_hooks.go
@@ -30,10 +30,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/abhishekparwal/parallelize-go/parallelize"
-
 	yaml "github.com/ghodss/yaml"
 	"github.com/pkg/errors"
+	"github.com/uber/zanzibar/parallelize"
 	"gopkg.in/validator.v2"
 )
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
 hash: 3f062f8bb36e98ab5f0e2d01fb79a28fe3fc681ee4ce2ad6d1b7f666c41f14fe
 updated: 2019-12-16T13:39:57.012116-08:00
 imports:
-- name: github.com/abhishekparwal/parallelize-go
-  version: d8b5605db3bba7174eb2d6ec4415c1bf33cbacc6
 - name: github.com/afex/hystrix-go
   version: fa1af6a1f4f56e0e50d427fe901cd604d8c6fb8a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -119,5 +119,3 @@ import:
   - prometheus/promhttp
 
 - package: github.com/emicklei/proto
-
-- package: github.com/abhishekparwal/parallelize-go

--- a/parallelize/README.md
+++ b/parallelize/README.md
@@ -1,0 +1,6 @@
+# parallelize-go
+Parallelize functions in golang
+
+This library works in few modes: a) for doing short io bound work default, it spawns 2x goroutines of CPU. b) If its unsuitable parallel count can be specified. c) for running long-running io bound work provides a function to spawns unbounded goroutine.
+
+It returns early with the first error it sees. note, first error it sees from parallel goroutine and not first error as in parallel many goroutines may simultaneously return an error.

--- a/parallelize/parallelize.go
+++ b/parallelize/parallelize.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallelize
+
+import (
+	"runtime"
+	"sync"
+)
+
+// NewUnboundedRunner creates unbounded goroutines
+func NewUnboundedRunner(workSize int) *Runner {
+	r := getRunner(workSize)
+	r.wg.Add(workSize)
+	go r.consumeMessagesUnbounded()
+	return r
+}
+
+func getRunner(workSize int) *Runner {
+	r := &Runner{
+		resultQueue: make(chan result, workSize),
+		wg:          &sync.WaitGroup{},
+		workQueue:   make(chan Work, workSize),
+	}
+	return r
+}
+
+func (r *Runner) consumeMessagesUnbounded() {
+	func() {
+		for {
+			wrk, ok := <-r.workQueue
+			if !ok {
+				return
+			}
+
+			go func(wrk Work) {
+				defer r.wg.Done()
+				res, err := wrk.Work()
+				r.resultQueue <- result{
+					data: res,
+					err:  err,
+				}
+			}(wrk)
+		}
+	}()
+}
+
+// NewFixedBoundedRunner creates fixed bounded goroutines by factor of available CPU based on default setting.
+// Default setting is to have parallelization as factor of 4x if iobound work which is supposed to be short.
+// If its a long work use NewBoundedRunner instead with optimal config.
+// If cpu bound work parallel go routine will be bound by cpu.
+func NewFixedBoundedRunner(workSize int, ioBound bool) *Runner {
+	parallelCount := runtime.NumCPU()
+	// go routine busy doing io would be swapped out, hence 4x.
+	if ioBound {
+		parallelCount = parallelCount * 4
+	}
+	return NewBoundedRunner(workSize, parallelCount)
+}
+
+// NewBoundedRunner creates bounded goroutines by factor parallel count
+func NewBoundedRunner(workSize, parallelCount int) *Runner {
+	r := &Runner{
+		resultQueue: make(chan result, workSize),
+		wg:          &sync.WaitGroup{},
+		workQueue:   make(chan Work, workSize),
+	}
+	r.wg.Add(parallelCount)
+	go r.consumeMessagesBounded(parallelCount)
+	return r
+}
+
+func (r *Runner) consumeMessagesBounded(parallelCount int) {
+	func() {
+		for i := 0; i < parallelCount; i++ {
+			go func() {
+				defer r.wg.Done()
+				for {
+					wrk, ok := <-r.workQueue
+					if !ok {
+						return
+					}
+
+					res, err := wrk.Work()
+					r.resultQueue <- result{
+						data: res,
+						err:  err,
+					}
+				}
+			}()
+		}
+
+	}()
+}
+
+type result struct {
+	data interface{}
+	err  error
+}
+
+// Runner holds data for initiating parallel work
+type Runner struct {
+	resultQueue chan result
+	wg          *sync.WaitGroup
+	workQueue   chan Work
+}
+
+// SubmitWork submits a unit of work to be executed
+func (r *Runner) SubmitWork(wrk Work) {
+	r.workQueue <- wrk
+}
+
+// GetResult returns array of responses from executing Work and returns early on first error it gets.
+// Also after calling this no more work can be submitted to the Runner
+func (r *Runner) GetResult() ([]interface{}, error) {
+	go func() {
+		close(r.workQueue)
+		r.wg.Wait()
+		close(r.resultQueue)
+	}()
+
+	var results []interface{}
+	for ele := range r.resultQueue {
+		results = append(results, ele.data)
+		if ele.err != nil {
+			return nil, ele.err
+		}
+	}
+	return results, nil
+}
+
+// Work is a unit of work set to be executed by this Runner
+type Work interface {
+	Work() (interface{}, error)
+}
+
+// StatelessFunc is defined to simulate anonymous implementation directly lacking in golang.
+// It will avoid creating boilerplate implementation of Work interface
+type StatelessFunc func() (interface{}, error)
+
+// Work satisfies Work interface. So we can now pass an anonymous function casted to StatelessFunc
+func (sf StatelessFunc) Work() (interface{}, error) {
+	return sf()
+}
+
+// SingleParamWork is a utility for doing a single param work
+type SingleParamWork struct {
+	Data interface{}
+	Func func(data interface{}) (interface{}, error)
+}
+
+// Work satisfies Work interface. So we can now pass an anonymous function casted to SingleParamWork
+func (spw *SingleParamWork) Work() (interface{}, error) {
+	return spw.Func(spw.Data)
+}
+
+// TwoParamWork is a utility for doing a two param work
+type TwoParamWork struct {
+	Data1 interface{}
+	Data2 interface{}
+	Func  func(data1 interface{}, data2 interface{}) (interface{}, error)
+}
+
+// Work satisfies Work interface. So we can now pass an anonymous function casted to TwoParamWork
+func (tpw *TwoParamWork) Work() (interface{}, error) {
+	return tpw.Func(tpw.Data1, tpw.Data2)
+}
+
+// ThreeParamWork is a utility for doing a three param work
+type ThreeParamWork struct {
+	Data1 interface{}
+	Data2 interface{}
+	Data3 interface{}
+	Func  func(data1 interface{}, data2 interface{}, data3 interface{}) (interface{}, error)
+}
+
+// Work satisfies Work interface. So we can now pass an anonymous function casted to ThreeParamWork
+func (tpw *ThreeParamWork) Work() (interface{}, error) {
+	return tpw.Func(tpw.Data1, tpw.Data2, tpw.Data3)
+}
+
+// MultiParamWork is a utility for doing a multi param work
+type MultiParamWork struct {
+	Data []interface{}
+	Func func(...interface{}) (interface{}, error)
+}
+
+// Work satisfies Work interface. So we can now pass an anonymous function casted to MultiParamWork
+func (mpw *MultiParamWork) Work() (interface{}, error) {
+	return mpw.Func(mpw.Data...)
+}

--- a/parallelize/parallelize_test.go
+++ b/parallelize/parallelize_test.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parallelize
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBoundedRunner(t *testing.T) {
+	var tests = []struct {
+		name          string
+		workItems     []*sampleWork
+		parallelCount int
+		expected      []string
+		isErr         bool
+	}{
+		{
+			name:          "parallelized - bounded",
+			workItems:     []*sampleWork{{data: "abc"}, {data: "def"}},
+			parallelCount: 2,
+			expected:      []string{"abc", "def"},
+		},
+		{
+			name:          "serial - bounded",
+			workItems:     []*sampleWork{{data: "abc"}, {data: "def"}},
+			parallelCount: 1,
+			expected:      []string{"abc", "def"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewBoundedRunner(len(tt.workItems), tt.parallelCount)
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func TestIOBoundedRunner(t *testing.T) {
+	var tests = []struct {
+		name      string
+		workItems []*sampleWork
+		ioBound   bool
+		isErr     bool
+		expected  []string
+	}{
+		{
+			name:      "parallelized - io",
+			workItems: []*sampleWork{{data: "abc"}, {data: "def"}},
+			ioBound:   true,
+			expected:  []string{"abc", "def"},
+		},
+		{
+			name:      "parallelized - non io work",
+			workItems: []*sampleWork{{data: "abc"}, {data: "def"}},
+			ioBound:   false,
+			expected:  []string{"abc", "def"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewFixedBoundedRunner(len(tt.workItems), tt.ioBound)
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func TestUnboundedRunner(t *testing.T) {
+	var tests = []struct {
+		name      string
+		workItems []*sampleWork
+		ioBound   bool
+		isErr     bool
+		expected  []string
+	}{
+		{
+			name:      "parallelized - unbounded",
+			workItems: []*sampleWork{{data: "abc"}, {data: "def"}},
+			ioBound:   true,
+			expected:  []string{"abc", "def"},
+		},
+		{
+			name:      "parallelized - unbounded error",
+			workItems: []*sampleWork{{data: "abc"}, {data: "def", err: errors.New("error")}},
+			ioBound:   false,
+			expected:  nil,
+			isErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewUnboundedRunner(len(tt.workItems))
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func TestStatelessWork(t *testing.T) {
+	var tests = []struct {
+		name      string
+		workItems []Work
+		ioBound   bool
+		isErr     bool
+		expected  []string
+	}{
+		{
+			name: "stateless work",
+			workItems: []Work{StatelessFunc(func() (interface{}, error) { return "abc", nil }),
+				StatelessFunc(func() (interface{}, error) { return "def", nil })},
+			ioBound:  true,
+			expected: []string{"abc", "def"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewUnboundedRunner(len(tt.workItems))
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func TestSingleWork(t *testing.T) {
+	var tests = []struct {
+		name      string
+		workItems []*SingleParamWork
+		ioBound   bool
+		isErr     bool
+		expected  []string
+	}{
+		{
+			name: "single param work",
+			workItems: []*SingleParamWork{{
+				Data: "abc",
+				Func: func(data1 interface{}) (interface{}, error) {
+					return data1, nil
+				}}},
+			ioBound:  true,
+			expected: []string{"abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewUnboundedRunner(len(tt.workItems))
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func TestMultiParamWork(t *testing.T) {
+	var tests = []struct {
+		name      string
+		workItems []*MultiParamWork
+		ioBound   bool
+		isErr     bool
+		expected  []string
+	}{
+		{
+			name: "single param work",
+			workItems: []*MultiParamWork{{
+				Data: []interface{}{"abc", "def"},
+				Func: func(data ...interface{}) (interface{}, error) {
+					return data[0], nil
+				}}},
+			ioBound:  true,
+			expected: []string{"abc"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewUnboundedRunner(len(tt.workItems))
+			for _, wi := range tt.workItems {
+				r.SubmitWork(wi)
+			}
+			compareResult(r, t, tt.isErr, tt.expected)
+		})
+	}
+}
+
+func compareResult(r *Runner, t *testing.T, isErr bool, expected []string) {
+	actual, err := r.GetResult()
+	var actualStrResults []string
+	for _, a := range actual {
+		actualStrResults = append(actualStrResults, a.(string))
+	}
+	sort.Strings(actualStrResults)
+	if !isErr {
+		assert.NoError(t, err)
+	} else {
+		assert.Error(t, err)
+	}
+	assert.Equal(t, expected, actualStrResults)
+}
+
+type sampleWork struct {
+	data string
+	err  error
+}
+
+func (sw *sampleWork) Work() (interface{}, error) {
+	if sw.err != nil {
+		return nil, sw.err
+	}
+	return sw.data, nil
+}


### PR DESCRIPTION
Parallelize functions in golang

This library works in few modes: a) for doing short io bound work default, it spawns 2x goroutines of CPU. b) If its unsuitable parallel count can be specified. c) for running long-running io bound work provides a function to spawns unbounded goroutine.

It returns early with the first error it sees. note, first error it sees from parallel goroutine and not first error as in parallel many goroutines may simultaneously return an error.