### PR TITLE
support for system wide whitelisting of default headers

### DIFF
--- a/codegen/gateway.go
+++ b/codegen/gateway.go
@@ -251,6 +251,8 @@ type EndpointSpec struct {
 	ReqHeaders map[string]*TypedHeader `yaml:"reqHeaderMap,omitempty"`
 	// ResHeaders maps headers from client to server
 	ResHeaders map[string]*TypedHeader `yaml:"resHeaderMap,omitempty"`
+	// DefaultHeaders a slice of headers that are forwarded to downstream when available
+	DefaultHeaders []string `yaml:"-"`
 	// WorkflowType, either "httpClient" or "custom".
 	// A httpClient workflow generates a http client Caller
 	// A custom workflow just imports the custom code
@@ -417,6 +419,7 @@ func NewEndpointSpec(
 		IsClientlessEndpoint: isClientlessEndpoint,
 		ClientID:             clientID,
 		ClientMethod:         clientMethod,
+		DefaultHeaders:       h.defaultHeaders,
 	}
 
 	defaultMidSpecs, err := getOrderedDefaultMiddlewareSpecs(

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -57,6 +57,7 @@ type EndpointMeta struct {
 	ResRequiredHeadersKeys []string
 	TraceKey               string
 	DeputyReqHeader        string
+	DefaultHeaders         []string
 }
 
 // EndpointCollectionMeta saves information used to generate an initializer
@@ -1274,6 +1275,7 @@ func (g *EndpointGenerator) generateEndpointFile(e *EndpointSpec, instance *Modu
 		WorkflowPkg:            workflowPkg,
 		TraceKey:               g.packageHelper.traceKey,
 		DeputyReqHeader:        g.packageHelper.DeputyReqHeader(),
+		DefaultHeaders:         e.DefaultHeaders,
 	}
 
 	targetPath := e.TargetEndpointPath(thriftServiceName, method.Name)

--- a/codegen/package.go
+++ b/codegen/package.go
@@ -58,6 +58,8 @@ type PackageHelper struct {
 	middlewareSpecs map[string]*MiddlewareSpec
 	// The default middlewares for all endpoints
 	defaultMiddlewareSpecs map[string]*MiddlewareSpec
+	// The default headers to forward with all requests when present
+	defaultHeaders []string
 	// Use deputy client when this header is set
 	deputyReqHeader string
 	// traceKey is the key for unique trace id that identifies request / response pair
@@ -95,6 +97,8 @@ type PackageHelperOptions struct {
 	CopyrightHeader string
 	// header key to redirect client requests to staging environment, defaults to "X-Zanzibar-Use-Staging"
 	StagingReqHeader string
+	// The default headers to forward with all requests when present
+	DefaultHeaders []string
 	// header key to redirect client requests to local environment, defaults to "x-deputy-forwarded"
 	DeputyReqHeader string
 	// header key to uniquely identifies request/response pair, defaults to "x-trace-id"
@@ -210,6 +214,7 @@ func NewPackageHelper(
 		traceKey:               options.traceKey(),
 		moduleSearchPaths:      options.ModuleSearchPaths,
 		defaultDependencies:    options.DefaultDependencies,
+		defaultHeaders:         options.DefaultHeaders,
 	}
 	return p, nil
 }

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -114,6 +114,9 @@ func main() {
 	defaultDependencies := make(map[string][]string, 0)
 	config.MustGetStruct("defaultDependencies", &defaultDependencies)
 
+	defaultHeaders := make([]string, 0)
+	config.MustGetStruct("defaultHeaders", &defaultHeaders)
+
 	options := &codegen.PackageHelperOptions{
 		RelThriftRootDir:              config.MustGetString("thriftRootDir"),
 		RelTargetGenDir:               config.MustGetString("targetGenDir"),
@@ -127,6 +130,7 @@ func main() {
 		TraceKey:                      config.MustGetString("traceKey"),
 		ModuleSearchPaths:             searchPaths,
 		DefaultDependencies:           defaultDependencies,
+		DefaultHeaders:                defaultHeaders,
 	}
 
 	packageHelper, err := codegen.NewPackageHelper(

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -115,7 +115,10 @@ func main() {
 	config.MustGetStruct("defaultDependencies", &defaultDependencies)
 
 	defaultHeaders := make([]string, 0)
-	config.MustGetStruct("defaultHeaders", &defaultHeaders)
+	if config.ContainsKey("defaultHeaders") {
+		config.MustGetStruct("defaultHeaders", &defaultHeaders)
+	}
+
 
 	options := &codegen.PackageHelperOptions{
 		RelThriftRootDir:              config.MustGetString("thriftRootDir"),

--- a/codegen/runner/runner.go
+++ b/codegen/runner/runner.go
@@ -119,7 +119,6 @@ func main() {
 		config.MustGetStruct("defaultHeaders", &defaultHeaders)
 	}
 
-
 	options := &codegen.PackageHelperOptions{
 		RelThriftRootDir:              config.MustGetString("thriftRootDir"),
 		RelTargetGenDir:               config.MustGetString("targetGenDir"),

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3573,9 +3573,10 @@ func (w {{$workflowStruct}}) Handle(
 	var ok bool
 	var h string
 	{{range $i, $k := $defaultHeaders}}
-	h, ok = reqHeaders.Get("{{$k}}")
+	k := textproto.CanonicalMIMEHeaderKey("{{$k}}")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["{{$k}}"] = h
+		clientHeaders[k] = h
 	}
 	{{- end -}}
 	{{- end -}}
@@ -3737,7 +3738,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 8642, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 8677, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3572,8 +3572,9 @@ func (w {{$workflowStruct}}) Handle(
 	{{if (ne (len $defaultHeaders) 0) }}
 	var ok bool
 	var h string
+	var k string
 	{{range $i, $k := $defaultHeaders}}
-	k := textproto.CanonicalMIMEHeaderKey("{{$k}}")
+	k = textproto.CanonicalMIMEHeaderKey("{{$k}}")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
@@ -3738,7 +3739,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 8677, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 8690, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3440,6 +3440,7 @@ package workflow
 {{- $endpointType := .Spec.EndpointType }}
 {{- $reqHeaderMap := .ReqHeaders }}
 {{- $reqHeaderMapKeys := .ReqHeadersKeys }}
+{{- $defaultHeaders := .DefaultHeaders }}
 {{- $reqHeaderRequiredKeys := .ReqRequiredHeadersKeys }}
 {{- $resHeaderMap := .ResHeaders }}
 {{- $resHeaderMapKeys := .ResHeadersKeys }}
@@ -3568,9 +3569,22 @@ func (w {{$workflowStruct}}) Handle(
 	{{end}}
 
 	clientHeaders := map[string]string{}
-	{{if (ne (len $reqHeaderMapKeys) 0) }}
+	{{if (ne (len $defaultHeaders) 0) }}
 	var ok bool
 	var h string
+	{{range $i, $k := $defaultHeaders}}
+	h, ok = reqHeaders.Get("{{$k}}")
+	if ok {
+		clientHeaders["{{$k}}"] = h
+	}
+	{{- end -}}
+	{{- end -}}
+
+	{{if (ne (len $reqHeaderMapKeys) 0) }}
+	{{if (eq (len $defaultHeaders) 0) }}
+	var ok bool
+	var h string
+	{{- end -}}
 	{{- end -}}
 	{{range $i, $k := $reqHeaderMapKeys}}
 	h, ok = reqHeaders.Get("{{$k}}")
@@ -3723,7 +3737,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 8344, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 8642, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -5,6 +5,7 @@ package workflow
 {{- $endpointType := .Spec.EndpointType }}
 {{- $reqHeaderMap := .ReqHeaders }}
 {{- $reqHeaderMapKeys := .ReqHeadersKeys }}
+{{- $defaultHeaders := .DefaultHeaders }}
 {{- $reqHeaderRequiredKeys := .ReqRequiredHeadersKeys }}
 {{- $resHeaderMap := .ResHeaders }}
 {{- $resHeaderMapKeys := .ResHeadersKeys }}
@@ -133,9 +134,22 @@ func (w {{$workflowStruct}}) Handle(
 	{{end}}
 
 	clientHeaders := map[string]string{}
-	{{if (ne (len $reqHeaderMapKeys) 0) }}
+	{{if (ne (len $defaultHeaders) 0) }}
 	var ok bool
 	var h string
+	{{range $i, $k := $defaultHeaders}}
+	h, ok = reqHeaders.Get("{{$k}}")
+	if ok {
+		clientHeaders["{{$k}}"] = h
+	}
+	{{- end -}}
+	{{- end -}}
+
+	{{if (ne (len $reqHeaderMapKeys) 0) }}
+	{{if (eq (len $defaultHeaders) 0) }}
+	var ok bool
+	var h string
+	{{- end -}}
 	{{- end -}}
 	{{range $i, $k := $reqHeaderMapKeys}}
 	h, ok = reqHeaders.Get("{{$k}}")

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -137,8 +137,9 @@ func (w {{$workflowStruct}}) Handle(
 	{{if (ne (len $defaultHeaders) 0) }}
 	var ok bool
 	var h string
+	var k string
 	{{range $i, $k := $defaultHeaders}}
-	k := textproto.CanonicalMIMEHeaderKey("{{$k}}")
+	k = textproto.CanonicalMIMEHeaderKey("{{$k}}")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -138,9 +138,10 @@ func (w {{$workflowStruct}}) Handle(
 	var ok bool
 	var h string
 	{{range $i, $k := $defaultHeaders}}
-	h, ok = reqHeaders.Get("{{$k}}")
+	k := textproto.CanonicalMIMEHeaderKey("{{$k}}")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["{{$k}}"] = h
+		clientHeaders[k] = h
 	}
 	{{- end -}}
 	{{- end -}}

--- a/examples/example-gateway/build.yaml
+++ b/examples/example-gateway/build.yaml
@@ -6,6 +6,9 @@ genCodePackage: github.com/uber/zanzibar/examples/example-gateway/build/gen-code
 genMock: true
 middlewareConfig: ./middlewares
 defaultMiddlewareConfig: ./middlewares/default
+defaultHeaders:
+  - x-uber-foo
+  - x-uber-bar
 packageRoot: github.com/uber/zanzibar/examples/example-gateway
 targetGenDir: ./build
 thriftRootDir: ./idl

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -85,13 +85,15 @@ func (w barArgNotStructWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -84,6 +84,16 @@ func (w barArgNotStructWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argnotstruct.go
@@ -84,13 +84,14 @@ func (w barArgNotStructWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -84,13 +84,14 @@ func (w barArgWithHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -84,6 +84,16 @@ func (w barArgWithHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -85,13 +85,15 @@ func (w barArgWithHeadersWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -84,13 +84,14 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -84,6 +84,16 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -85,13 +85,15 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
@@ -84,13 +84,14 @@ func (w barArgWithNearDupQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
@@ -84,6 +84,16 @@ func (w barArgWithNearDupQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
@@ -85,13 +85,15 @@ func (w barArgWithNearDupQueryParamsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -84,13 +84,14 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -85,13 +85,15 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -84,6 +84,16 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -84,13 +84,14 @@ func (w barArgWithParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -84,6 +84,16 @@ func (w barArgWithParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -85,13 +85,15 @@ func (w barArgWithParamsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
@@ -84,6 +84,16 @@ func (w barArgWithParamsAndDuplicateFieldsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
@@ -84,13 +84,14 @@ func (w barArgWithParamsAndDuplicateFieldsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
@@ -85,13 +85,15 @@ func (w barArgWithParamsAndDuplicateFieldsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -84,13 +84,14 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -84,6 +84,16 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -85,13 +85,15 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -84,13 +84,14 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -85,13 +85,15 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -84,6 +84,16 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -81,6 +81,16 @@ func (w barHelloWorldWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -82,13 +82,15 @@ func (w barHelloWorldWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -81,13 +81,14 @@ func (w barHelloWorldWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
@@ -84,6 +84,16 @@ func (w barListAndEnumWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
@@ -85,13 +85,15 @@ func (w barListAndEnumWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
@@ -84,13 +84,14 @@ func (w barListAndEnumWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -81,13 +81,14 @@ func (w barMissingArgWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -81,6 +81,16 @@ func (w barMissingArgWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -82,13 +82,15 @@ func (w barMissingArgWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -82,13 +82,15 @@ func (w barNoRequestWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -81,13 +81,14 @@ func (w barNoRequestWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -81,6 +81,16 @@ func (w barNoRequestWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -84,13 +84,14 @@ func (w barNormalWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -84,6 +84,16 @@ func (w barNormalWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -85,13 +85,15 @@ func (w barNormalWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -88,13 +88,15 @@ func (w barTooManyArgsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -87,13 +87,14 @@ func (w barTooManyArgsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -87,6 +87,16 @@ func (w barTooManyArgsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -85,13 +85,15 @@ func (w simpleServiceCallWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -84,13 +84,14 @@ func (w simpleServiceCallWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_call.go
@@ -84,6 +84,16 @@ func (w simpleServiceCallWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -86,13 +86,15 @@ func (w simpleServiceCompareWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -85,6 +85,16 @@ func (w simpleServiceCompareWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -85,13 +85,14 @@ func (w simpleServiceCompareWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -84,13 +84,14 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -84,6 +84,16 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -85,13 +85,15 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -84,6 +84,16 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("Auth")
 	if ok {
 		clientHeaders["Auth"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -85,13 +85,15 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("Auth")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -84,13 +84,14 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -81,6 +81,16 @@ func (w simpleServicePingWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -82,13 +82,15 @@ func (w simpleServicePingWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -81,13 +81,14 @@ func (w simpleServicePingWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -83,13 +83,15 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -82,6 +82,16 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_sillynoop.go
@@ -82,13 +82,14 @@ func (w simpleServiceSillyNoopWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -85,13 +85,14 @@ func (w simpleServiceTransWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -85,6 +85,16 @@ func (w simpleServiceTransWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -86,13 +86,15 @@ func (w simpleServiceTransWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -87,13 +87,15 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("Token")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -86,13 +86,14 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -86,6 +86,16 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("Token")
 	if ok {
 		clientHeaders["Token"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -84,13 +84,14 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -85,13 +85,15 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("B3")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -84,6 +84,16 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("B3")
 	if ok {
 		clientHeaders["B3"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -86,6 +86,16 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -87,13 +87,15 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -86,13 +86,14 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -85,13 +85,15 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -84,13 +84,14 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_addcredentials.go
@@ -84,6 +84,16 @@ func (w googleNowAddCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -78,6 +78,16 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -78,13 +78,14 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
+++ b/examples/example-gateway/build/endpoints/googlenow/workflow/googlenow_googlenow_method_checkcredentials.go
@@ -79,13 +79,15 @@ func (w googleNowCheckCredentialsWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -78,13 +78,14 @@ func (w serviceAFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -78,6 +78,16 @@ func (w serviceAFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -79,13 +79,15 @@ func (w serviceAFrontHelloWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -79,13 +79,15 @@ func (w serviceBFrontHelloWorkflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -78,6 +78,16 @@ func (w serviceBFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -78,13 +78,14 @@ func (w serviceBFrontHelloWorkflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h

--- a/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
+++ b/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
@@ -81,6 +81,16 @@ func (w withExceptionsFunc1Workflow) Handle(
 
 	var ok bool
 	var h string
+
+	h, ok = reqHeaders.Get("x-uber-foo")
+	if ok {
+		clientHeaders["x-uber-foo"] = h
+	}
+	h, ok = reqHeaders.Get("x-uber-bar")
+	if ok {
+		clientHeaders["x-uber-bar"] = h
+	}
+
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")
 	if ok {
 		clientHeaders["X-Deputy-Forwarded"] = h

--- a/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
+++ b/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
@@ -82,13 +82,15 @@ func (w withExceptionsFunc1Workflow) Handle(
 	var ok bool
 	var h string
 
-	h, ok = reqHeaders.Get("x-uber-foo")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-foo"] = h
+		clientHeaders[k] = h
 	}
-	h, ok = reqHeaders.Get("x-uber-bar")
+	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	h, ok = reqHeaders.Get(k)
 	if ok {
-		clientHeaders["x-uber-bar"] = h
+		clientHeaders[k] = h
 	}
 
 	h, ok = reqHeaders.Get("X-Deputy-Forwarded")

--- a/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
+++ b/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
@@ -81,13 +81,14 @@ func (w withExceptionsFunc1Workflow) Handle(
 
 	var ok bool
 	var h string
+	var k string
 
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-foo")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-foo")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h
 	}
-	k := textproto.CanonicalMIMEHeaderKey("x-uber-bar")
+	k = textproto.CanonicalMIMEHeaderKey("x-uber-bar")
 	h, ok = reqHeaders.Get(k)
 	if ok {
 		clientHeaders[k] = h


### PR DESCRIPTION
we have a concept of default middleware, this is a same concept where we
don't need a whitelist of headers per endpoint but rather a system-wide
whitelist that will be always forwarded when available. These should be
used for more of control plane kind of headers rather than application
logic.