### PR TITLE
skipping module only when thrift is not present

### DIFF
--- a/codegen/client.go
+++ b/codegen/client.go
@@ -116,9 +116,7 @@ func newClientSpec(
 	mspec, err := NewModuleSpec(thriftFile, annotate, false, h)
 
 	if err != nil {
-		return nil, errors.Wrapf(
-			err, "Could not build module spec for thrift %s: ", thriftFile,
-		)
+		return nil, err
 	}
 	mspec.PackageName = mspec.PackageName + "client"
 

--- a/codegen/service_test.go
+++ b/codegen/service_test.go
@@ -36,6 +36,12 @@ func TestModuleSpec(t *testing.T) {
 	assert.NoError(t, err, "unable to parse the thrift file")
 }
 
+func TestModuleSpecNoThriftExist(t *testing.T) {
+	barThrift := "../examples/example-gateway/idl/clients/bar/bar_no_exist.thrift"
+	_, err := codegen.NewModuleSpec(barThrift, true, false, newPackageHelper(t))
+	assert.Error(t, err.(*codegen.ErrorSkipCodeGen))
+}
+
 func TestProtoModuleSpec(t *testing.T) {
 	echoProto := "../examples/example-gateway/idl/clients/echo/echo.proto"
 	_, err := codegen.NewProtoModuleSpec(echoProto, false, newPackageHelper(t))


### PR DESCRIPTION
thrift being present or failing if not present is to be determined by previous steps than incremental. In one of the implementations utilizing Zanzibar code gen, it is doing while generating minified thrift specs and if not valid or not present for a module, fails at that layer. thus, at this layer,  if a spec is not present, it is skippable as determined by the previous layer.