### PR TITLE
Allow histogram buckets to be customized by gateways

### DIFF
--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -115,8 +115,8 @@ func TestCallMetrics(t *testing.T) {
 		statusTags[k] = v
 	}
 	histogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms", // TODO(argouber): Remove the ugly hardcoding
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms", // TODO(argouber): Remove the ugly hardcoding
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range statusTags {
 		histogramTags[k] = v
@@ -162,8 +162,8 @@ func TestCallMetrics(t *testing.T) {
 		cStatusTags[k] = v
 	}
 	cHistogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms", // TODO(argouber): Remove the ugly hardcoding
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms", // TODO(argouber): Remove the ugly hardcoding
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range httpClientTags {
 		cHistogramTags[k] = v

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -126,8 +126,8 @@ func TestCallMetrics(t *testing.T) {
 		statusTags[k] = v
 	}
 	histogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms", // TODO(argouber): Remove the ugly hardcoding
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms", // TODO(argouber): Remove the ugly hardcoding
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range statusTags {
 		histogramTags[k] = v
@@ -214,8 +214,8 @@ func TestCallMetrics(t *testing.T) {
 	assert.True(t, value < 10*1000*1000, "expected timer to be < 10 milli seconds")
 
 	cHistogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms",
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms",
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range clientTags {
 		cHistogramTags[k] = v

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -150,8 +150,8 @@ func TestCallMetrics(t *testing.T) {
 	assert.True(t, value < 10*1000*1000, "expected timer to be < 10 milli seconds")
 
 	histogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms", // TODO: Remove the ugly hardcoding
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms", // TODO: Remove the ugly hardcoding
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range endpointTags {
 		histogramTags[k] = v
@@ -221,8 +221,8 @@ func TestCallMetrics(t *testing.T) {
 	assert.True(t, value < 10*1000*1000, "expected timer to be < 10 milli seconds")
 
 	cHistogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms",
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms",
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range clientTags {
 		cHistogramTags[k] = v

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -149,8 +149,8 @@ func TestHealthMetrics(t *testing.T) {
 		statusTags[k] = v
 	}
 	histogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms", // TODO(argouber): There must be a better way than this hard-coding
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms", // TODO(argouber): There must be a better way than this hard-coding
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range statusTags {
 		histogramTags[k] = v
@@ -239,8 +239,8 @@ func TestRuntimeMetrics(t *testing.T) {
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 	histogramTags := map[string]string{
-		m3.DefaultHistogramBucketName:   "-infinity-10ms",
-		m3.DefaultHistogramBucketIDName: "0000",
+		m3.DefaultHistogramBucketName:   "0-10ms",
+		m3.DefaultHistogramBucketIDName: "0001",
 	}
 	for k, v := range tags {
 		histogramTags[k] = v


### PR DESCRIPTION
Currently the histogram duration buckets for tally stats is hard-coded in the common code.
We have gateways that need customized set of buckets as per their use-case.
Therefore, it is better to have the option available in the gateway config.
This change enables that.