### PR TITLE
Remove unwanted/unuseful error from codegen logs 

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -1085,8 +1085,6 @@ func (system *ModuleSystem) populateSpec(instance *ModuleInstance) error {
 
 	spec, err := specProvider.ComputeSpec(instance)
 	if err != nil {
-		// Don't create new errors, rather wrap the error as we need the original error at caller
-		fmt.Println("error when running computespec", err.Error())
 		return err
 	}
 	if spec != nil {


### PR DESCRIPTION
Removing errors which start with `error when running computespec`