### PR TITLE
Cleaning up extra shut down of Tchannel server

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -422,15 +422,6 @@ func (gateway *Gateway) Shutdown() {
 		}
 	}()
 
-	// shutdown tchannel server
-	swg.Add(1)
-	go func() {
-		defer swg.Done()
-		if err := gateway.shutdownTChannelServer(ctx); err != nil {
-			ec <- errors.Wrap(err, "error shutting down tchannel server")
-		}
-	}()
-
 	// stop all grpc clients
 	if gateway.GRPCClientDispatcher != nil {
 		swg.Add(1)


### PR DESCRIPTION
Tchannel server was being shut down twice (probably causing some amount of slow deploys on the servers). Removing the additional shutdown.