### PR TITLE
Use context logger

### DIFF
--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -135,7 +135,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 		var err error
 		rawBody, err = req.jsonWrapper.Marshal(body)
 		if err != nil {
-			req.ContextLogger.Error(req.ctx,"Could not serialize request json", zap.Error(err))
+			req.ContextLogger.Error(req.ctx, "Could not serialize request json", zap.Error(err))
 			return errors.Wrapf(
 				err, "Could not serialize %s.%s request json",
 				req.ClientID, req.MethodName,

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -92,7 +92,7 @@ func NewClientHTTPRequest(
 func (req *ClientHTTPRequest) start() {
 	if req.started {
 		/* coverage ignore next line */
-		req.Logger.Error("Cannot start ClientHTTPRequest twice")
+		req.ContextLogger.Error(req.ctx, "Cannot start ClientHTTPRequest twice")
 		/* coverage ignore next line */
 		return
 	}
@@ -113,7 +113,7 @@ func (req *ClientHTTPRequest) CheckHeaders(expected []string) error {
 		// headerName is case insensitive, http.Header Get canonicalize the key
 		headerValue := actualHeaders.Get(headerName)
 		if headerValue == "" {
-			req.Logger.Warn("Got outbound request without mandatory header",
+			req.ContextLogger.Warn(req.ctx, "Got outbound request without mandatory header",
 				zap.String("headerName", headerName),
 			)
 
@@ -135,7 +135,7 @@ func (req *ClientHTTPRequest) WriteJSON(
 		var err error
 		rawBody, err = req.jsonWrapper.Marshal(body)
 		if err != nil {
-			req.Logger.Error("Could not serialize request json", zap.Error(err))
+			req.ContextLogger.Error(req.ctx,"Could not serialize request json", zap.Error(err))
 			return errors.Wrapf(
 				err, "Could not serialize %s.%s request json",
 				req.ClientID, req.MethodName,
@@ -164,7 +164,7 @@ func (req *ClientHTTPRequest) WriteBytes(
 	}
 
 	if httpErr != nil {
-		req.Logger.Error("Could not create outbound request", zap.Error(httpErr))
+		req.ContextLogger.Error(req.ctx, "Could not create outbound request", zap.Error(httpErr))
 		return errors.Wrapf(
 			httpErr, "Could not create outbound %s.%s request",
 			req.ClientID, req.MethodName,
@@ -200,7 +200,7 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 	err := req.InjectSpanToHeader(span, opentracing.HTTPHeaders)
 	if err != nil {
 		/* coverage ignore next line */
-		req.Logger.Error("Fail to inject span to headers", zap.Error(err))
+		req.ContextLogger.Error(req.ctx, "Fail to inject span to headers", zap.Error(err))
 		/* coverage ignore next line */
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 	res, err := req.client.Client.Do(req.httpReq.WithContext(ctx))
 	span.Finish()
 	if err != nil {
-		req.Logger.Error("Could not make outbound request", zap.Error(err))
+		req.ContextLogger.Error(req.ctx, "Could not make outbound request", zap.Error(err))
 		return nil, err
 	}
 
@@ -225,7 +225,7 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 func (req *ClientHTTPRequest) InjectSpanToHeader(span opentracing.Span, format interface{}) error {
 	carrier := opentracing.HTTPHeadersCarrier(req.httpReq.Header)
 	if err := span.Tracer().Inject(span.Context(), format, carrier); err != nil {
-		req.Logger.Error("Failed to inject tracing span.", zap.Error(err))
+		req.ContextLogger.Error(req.ctx, "Failed to inject tracing span.", zap.Error(err))
 		return err
 	}
 

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -72,11 +72,11 @@ func (res *ClientHTTPResponse) ReadAll() ([]byte, error) {
 	cerr := res.rawResponse.Body.Close()
 	if cerr != nil {
 		/* coverage ignore next line */
-		res.req.Logger.Error("Could not close response body", zap.Error(cerr))
+		res.req.ContextLogger.Error(res.req.ctx, "Could not close response body", zap.Error(cerr))
 	}
 
 	if err != nil {
-		res.req.Logger.Error("Could not read response body", zap.Error(err))
+		res.req.ContextLogger.Error(res.req.ctx, "Could not read response body", zap.Error(err))
 		res.finish()
 		return nil, errors.Wrapf(
 			err, "Could not read %s.%s response body",
@@ -108,7 +108,7 @@ func (res *ClientHTTPResponse) ReadAndUnmarshalBody(v interface{}) error {
 func (res *ClientHTTPResponse) UnmarshalBody(v interface{}, rawBody []byte) error {
 	err := res.jsonWrapper.Unmarshal(rawBody, v)
 	if err != nil {
-		res.req.Logger.Warn("Could not parse response json", zap.Error(err))
+		res.req.ContextLogger.Warn(res.req.ctx, "Could not parse response json", zap.Error(err))
 		res.req.Metrics.IncCounter(res.req.ctx, clientHTTPUnmarshalError, 1)
 		return errors.Wrapf(
 			err, "Could not parse %s.%s response json",
@@ -139,7 +139,7 @@ func (res *ClientHTTPResponse) ReadAndUnmarshalBodyMultipleOptions(vs []interfac
 
 	err = fmt.Errorf("all json serialization errors: %s", merr.Error())
 
-	res.req.Logger.Warn("Could not parse response json into any of provided interfaces", zap.Error(err))
+	res.req.ContextLogger.Warn(res.req.ctx, "Could not parse response json into any of provided interfaces", zap.Error(err))
 	return nil, errors.Wrapf(
 		err, "Could not parse %s.%s response json into any of provided interfaces",
 		res.req.ClientID, res.req.MethodName,
@@ -154,7 +154,7 @@ func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
 		}
 	}
 
-	res.req.Logger.Warn("Unknown response status code",
+	res.req.ContextLogger.Warn(res.req.ctx,"Unknown response status code",
 		zap.Int("UnknownStatusCode", res.rawResponse.StatusCode),
 	)
 }
@@ -163,13 +163,13 @@ func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
 func (res *ClientHTTPResponse) finish() {
 	if !res.req.started {
 		/* coverage ignore next line */
-		res.req.Logger.Error("Forgot to start client request")
+		res.req.ContextLogger.Error(res.req.ctx,"Forgot to start client request")
 		/* coverage ignore next line */
 		return
 	}
 	if res.finished {
 		/* coverage ignore next line */
-		res.req.Logger.Error("Finished a client response multiple times")
+		res.req.ContextLogger.Error(res.req.ctx,"Finished a client response multiple times")
 		/* coverage ignore next line */
 		return
 	}
@@ -184,7 +184,7 @@ func (res *ClientHTTPResponse) finish() {
 	res.req.Metrics.RecordHistogramDuration(res.req.ctx, clientLatencyHist, delta)
 	_, known := knownStatusCodes[res.StatusCode]
 	if !known {
-		res.req.Logger.Error(
+		res.req.ContextLogger.Error(res.req.ctx,
 			"Could not emit statusCode metric",
 			zap.Int("UnknownStatusCode", res.StatusCode),
 		)

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -154,7 +154,7 @@ func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
 		}
 	}
 
-	res.req.ContextLogger.Warn(res.req.ctx,"Unknown response status code",
+	res.req.ContextLogger.Warn(res.req.ctx, "Unknown response status code",
 		zap.Int("UnknownStatusCode", res.rawResponse.StatusCode),
 	)
 }
@@ -163,13 +163,13 @@ func (res *ClientHTTPResponse) CheckOKResponse(okResponses []int) {
 func (res *ClientHTTPResponse) finish() {
 	if !res.req.started {
 		/* coverage ignore next line */
-		res.req.ContextLogger.Error(res.req.ctx,"Forgot to start client request")
+		res.req.ContextLogger.Error(res.req.ctx, "Forgot to start client request")
 		/* coverage ignore next line */
 		return
 	}
 	if res.finished {
 		/* coverage ignore next line */
-		res.req.ContextLogger.Error(res.req.ctx,"Finished a client response multiple times")
+		res.req.ContextLogger.Error(res.req.ctx, "Finished a client response multiple times")
 		/* coverage ignore next line */
 		return
 	}


### PR DESCRIPTION
- Using ContextLogger will add all the default log fields we set in context to log
- When user looks at an error log, related default context log fields will help in understanding the error better