### PR TITLE
Invert configureCircuitBreaker response

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1281,7 +1281,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		"{{$clientID}}",
 		routingKey,
 		requestUUIDHeaderKey,
-		configureCircuitBreaker(deps, timeoutInMS),
+		!configureCircuitBreaker(deps, timeoutInMS),
 		timeoutInMS,
 		),
 	}
@@ -1387,7 +1387,7 @@ func grpc_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "grpc_client.tmpl", size: 6610, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "grpc_client.tmpl", size: 6611, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/grpc_client.tmpl
+++ b/codegen/templates/grpc_client.tmpl
@@ -81,7 +81,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		"{{$clientID}}",
 		routingKey,
 		requestUUIDHeaderKey,
-		configureCircuitBreaker(deps, timeoutInMS),
+		!configureCircuitBreaker(deps, timeoutInMS),
 		timeoutInMS,
 		),
 	}

--- a/examples/example-gateway/build/clients/echo/echo.go
+++ b/examples/example-gateway/build/clients/echo/echo.go
@@ -75,7 +75,7 @@ func NewClient(deps *module.Dependencies) Client {
 			"echo",
 			routingKey,
 			requestUUIDHeaderKey,
-			configureCircuitBreaker(deps, timeoutInMS),
+			!configureCircuitBreaker(deps, timeoutInMS),
 			timeoutInMS,
 		),
 	}

--- a/examples/selective-gateway/build/clients/echo/echo.go
+++ b/examples/selective-gateway/build/clients/echo/echo.go
@@ -75,7 +75,7 @@ func NewClient(deps *module.Dependencies) Client {
 			"echo",
 			routingKey,
 			requestUUIDHeaderKey,
-			configureCircuitBreaker(deps, timeoutInMS),
+			!configureCircuitBreaker(deps, timeoutInMS),
 			timeoutInMS,
 		),
 	}

--- a/examples/selective-gateway/build/clients/mirror/mirror.go
+++ b/examples/selective-gateway/build/clients/mirror/mirror.go
@@ -84,7 +84,7 @@ func NewClient(deps *module.Dependencies) Client {
 			"mirror",
 			routingKey,
 			requestUUIDHeaderKey,
-			configureCircuitBreaker(deps, timeoutInMS),
+			!configureCircuitBreaker(deps, timeoutInMS),
 			timeoutInMS,
 		),
 	}


### PR DESCRIPTION
`configureCircuitBreaker` function returns `false`  if `circuitBreakerDisabled` config value is set and `true` otherwise. 

After that, this value is assigned to the `CircuitBreakerDisabled` field in `zanzibar.GRPCClientOpts`, which is logically the opposite so, when `circuitBreakerDisabled` config is set to `true`, the code doesn't configure circuit breaker but uses hystrix to call the endpoint. Also, when `circuitBreakerDisabled` config value is `false`, it configures hystrix but doesn't use it. 

This change inverts the function result so that hystrix circuitbreaker can be configured and used if the config value is `false`.