### PR TITLE
Include jaeger tracing identifiers in request logs

### DIFF
--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -2297,6 +2297,9 @@ func testIncomingHTTPRequestServerLog(t *testing.T, isShadowRequest bool, enviro
 		"host",
 		"pid",
 		"timestamp-finished",
+		"trace.span",
+		"trace.traceId",
+		"trace.sampled",
 	}
 
 	if isShadowRequest {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -23,6 +23,7 @@ package zanzibar
 import (
 	"context"
 	"fmt"
+	"github.com/uber/jaeger-client-go"
 	"net/http"
 	"strconv"
 	"strings"
@@ -135,6 +136,17 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 		zap.Time("timestamp-started", req.startTime),
 		zap.Time("timestamp-finished", res.finishTime),
 		zap.Int("statusCode", res.StatusCode),
+	}
+
+	if span := req.GetSpan(); span != nil {
+		jc, ok := span.Context().(jaeger.SpanContext)
+		if ok {
+			fields = append(fields,
+				zap.String("trace.span", jc.SpanID().String()),
+				zap.String("trace.traceId", jc.TraceID().String()),
+				zap.Bool(  "trace.sampled", jc.IsSampled()),
+			)
+		}
 	}
 
 	for k, v := range res.Headers() {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -23,11 +23,12 @@ package zanzibar
 import (
 	"context"
 	"fmt"
-	"github.com/uber/jaeger-client-go"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/uber/jaeger-client-go"
 
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -148,6 +148,8 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 				zap.Bool("trace.sampled", jc.IsSampled()),
 			)
 		}
+	} else {
+		zap.String("missing-trace", "yes")
 	}
 
 	for k, v := range res.Headers() {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -144,7 +144,7 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 			fields = append(fields,
 				zap.String("trace.span", jc.SpanID().String()),
 				zap.String("trace.traceId", jc.TraceID().String()),
-				zap.Bool(  "trace.sampled", jc.IsSampled()),
+				zap.Bool("trace.sampled", jc.IsSampled()),
 			)
 		}
 	}


### PR DESCRIPTION
Including `jaeger-trace` context specific information in server request logs to improve debuggability.

```
trace.span
trace.traceId
trace.sampled
```