### PR TITLE
Include jaeger tracing identifiers in request logs

### DIFF
--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -2297,6 +2297,9 @@ func testIncomingHTTPRequestServerLog(t *testing.T, isShadowRequest bool, enviro
 		"host",
 		"pid",
 		"timestamp-finished",
+		"trace.span",
+		"trace.traceId",
+		"trace.sampled",
 	}
 
 	if isShadowRequest {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/uber/jaeger-client-go"
+
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
 	"github.com/uber-go/tally"
@@ -135,6 +137,17 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 		zap.Time("timestamp-started", req.startTime),
 		zap.Time("timestamp-finished", res.finishTime),
 		zap.Int("statusCode", res.StatusCode),
+	}
+
+	if span := req.GetSpan(); span != nil {
+		jc, ok := span.Context().(jaeger.SpanContext)
+		if ok {
+			fields = append(fields,
+				zap.String("trace.span", jc.SpanID().String()),
+				zap.String("trace.traceId", jc.TraceID().String()),
+				zap.Bool("trace.sampled", jc.IsSampled()),
+			)
+		}
 	}
 
 	for k, v := range res.Headers() {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -147,6 +147,9 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 				zap.String("trace.traceId", jc.TraceID().String()),
 				zap.Bool("trace.sampled", jc.IsSampled()),
 			)
+		} else {
+			fields = append(fields,
+				zap.String("trace.missingSpan", "yes"))
 		}
 	}
 

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -147,9 +147,6 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 				zap.String("trace.traceId", jc.TraceID().String()),
 				zap.Bool("trace.sampled", jc.IsSampled()),
 			)
-		} else {
-			fields = append(fields,
-				zap.String("trace.missingSpan", "yes"))
 		}
 	}
 


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Observability | Medium |

## Description
This PR adds / changes the following

- Includes Jaeger Tracing information in Zanzibar logs for debugging purposes.

| Field | Type | Remarks |
| --- | --- | --- |
| trace.span | string | string version of the uint64 span id (locally unique) |
| trace.traceId | string | string version of the uint64  trace id (globally unique)|
| trace.sampled | bool | indicates whether this trace was sampled |


## Motivation & Context
- We recently found that we are not logging Jaeger traceID and spans in Edge Gateway logs. 
- This is required for debugging P0 issues where downstream teams can lookup traces by id.

## How was this tested?
- Updated zanzibar version in `glide.lock` in Uber Edge Gateway and confirmed the logs
![image](https://user-images.githubusercontent.com/12872673/121282261-cfdfe900-c8f6-11eb-946f-5a9a29e7d353.png)
