### PR TITLE
Change ordering of override fx during invocation

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1986,8 +1986,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }
@@ -2018,7 +2018,7 @@ func mainTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "main.tmpl", size: 1842, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "main.tmpl", size: 1858, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -78,8 +78,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }

--- a/examples/example-gateway/build/app/demo/services/xyz/main/main.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/main/main.go
@@ -96,8 +96,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }

--- a/examples/example-gateway/build/services/echo-gateway/main/main.go
+++ b/examples/example-gateway/build/services/echo-gateway/main/main.go
@@ -96,8 +96,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }

--- a/examples/example-gateway/build/services/example-gateway/main/main.go
+++ b/examples/example-gateway/build/services/example-gateway/main/main.go
@@ -96,8 +96,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }

--- a/examples/selective-gateway/build/clients/echo/mock-client/mock_client_with_fixture.go
+++ b/examples/selective-gateway/build/clients/echo/mock-client/mock_client_with_fixture.go
@@ -47,8 +47,8 @@ func (c Call) MaxTimes(max int) {
 }
 
 // MinTimes marks a fixture as must be called a minimum number of times.
-func (c Call) MinTimes(max int) {
-	c.call.MinTimes(max)
+func (c Call) MinTimes(min int) {
+	c.call.MinTimes(min)
 }
 
 // New creates a new mock instance

--- a/examples/selective-gateway/build/services/selective-gateway/main/main.go
+++ b/examples/selective-gateway/build/services/selective-gateway/main/main.go
@@ -96,8 +96,8 @@ func readFlags() {
 func main() {
 	fx.New(
 		append(
-			app.GetOverrideFxOptions(),
-			fx.Invoke(zanzibarMain),
+			[]fx.Option{fx.Invoke(zanzibarMain)},
+			app.GetOverrideFxOptions()...,
 		)...,
 	).Run()
 }

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -37,8 +37,8 @@ import (
 
 // MockClientNodes contains mock client dependencies
 type MockClientNodes struct {
-	Echo   *echoclientgenerated.MockClientWithFixture
 	Mirror *mirrorclientgenerated.MockClient
+	Echo   *echoclientgenerated.MockClientWithFixture
 }
 
 // InitializeDependenciesMock fully initializes all dependencies in the dep tree
@@ -63,13 +63,13 @@ func InitializeDependenciesMock(
 	}
 
 	mockClientNodes := &MockClientNodes{
-		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
 		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
+		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
 	}
 	initializedClientDependencies := &module.ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Echo = mockClientNodes.Echo
 	initializedClientDependencies.Mirror = mockClientNodes.Mirror
+	initializedClientDependencies.Echo = mockClientNodes.Echo
 
 	initializedEndpointDependencies := &module.EndpointDependenciesNodes{}
 	tree.Endpoint = initializedEndpointDependencies

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -42,8 +42,8 @@ type DependenciesTree struct {
 
 // ClientDependenciesNodes contains client dependencies
 type ClientDependenciesNodes struct {
-	Echo   echoclientgenerated.Client
 	Mirror mirrorclientgenerated.Client
+	Echo   echoclientgenerated.Client
 }
 
 // EndpointDependenciesNodes contains endpoint dependencies
@@ -74,10 +74,10 @@ func InitializeDependencies(
 
 	initializedClientDependencies := &ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
+	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
+	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
 


### PR DESCRIPTION
This PR fixes a small implementation artefact from  #769 

## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Fix | High |

## Description
This PR adds / changes the following

- Change the order of overriding fx dependencies to be registered after the invocation of zanzibar

## Motivation & Context
- Because tally scopes and other required parameters for the overriding dependencies are registered in the subsequent invocation, `fx.start` for override modules that depend on them fails with an error and the application panics.

## How was this tested?
- Current Zanzibar master (with the addition of gogctuner-fx) when imported into Uber Edfe
```
2021/06/25 17:45:47 [Fx] Error during "vendor/code.uber.internal/sre/gogctunerfx.start()" invoke: missing dependencies for function "code.uber.internal/sre/gogctunerfx".start (: the following types are not in the container: *zap.Logger; tally.Scope
2021/06/25 17:45:47 [Fx] ERROR		Failed to start: missing dependencies for function "code.uber.internal/sre/gogctunerfx".start  the following types are not in the container: *zap.Logger; tally.Scope
```

- This branch (works as expected) post addition of override dependencies.
```
{"level":"info","ts":1624623478.887975,"msg":"Started gateway-sk"
```
