### PR TITLE
Bind pprof/trace in router

### DIFF
--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -37,8 +37,8 @@ import (
 
 // MockClientNodes contains mock client dependencies
 type MockClientNodes struct {
-	Mirror *mirrorclientgenerated.MockClient
 	Echo   *echoclientgenerated.MockClientWithFixture
+	Mirror *mirrorclientgenerated.MockClient
 }
 
 // InitializeDependenciesMock fully initializes all dependencies in the dep tree
@@ -63,13 +63,13 @@ func InitializeDependenciesMock(
 	}
 
 	mockClientNodes := &MockClientNodes{
-		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
 		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
+		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
 	}
 	initializedClientDependencies := &module.ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Mirror = mockClientNodes.Mirror
 	initializedClientDependencies.Echo = mockClientNodes.Echo
+	initializedClientDependencies.Mirror = mockClientNodes.Mirror
 
 	initializedEndpointDependencies := &module.EndpointDependenciesNodes{}
 	tree.Endpoint = initializedEndpointDependencies

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -42,8 +42,8 @@ type DependenciesTree struct {
 
 // ClientDependenciesNodes contains client dependencies
 type ClientDependenciesNodes struct {
-	Mirror mirrorclientgenerated.Client
 	Echo   echoclientgenerated.Client
+	Mirror mirrorclientgenerated.Client
 }
 
 // EndpointDependenciesNodes contains endpoint dependencies
@@ -74,10 +74,10 @@ func InitializeDependencies(
 
 	initializedClientDependencies := &ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
+	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
+	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -339,25 +339,18 @@ func (gateway *Gateway) Bootstrap() error {
 }
 
 func (gateway *Gateway) registerPredefined() {
-	gateway.HTTPRouter.Handle("GET", "/debug/pprof", http.HandlerFunc(pprof.Index))
-	gateway.HTTPRouter.Handle("GET", "/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
-	gateway.HTTPRouter.Handle("GET", "/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
-	gateway.HTTPRouter.Handle("GET", "/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	gateway.HTTPRouter.Handle("POST", "/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
-	gateway.HTTPRouter.Handle(
-		"GET", "/debug/pprof/goroutine", pprof.Handler("goroutine"),
-	)
-	gateway.HTTPRouter.Handle(
-		"GET", "/debug/pprof/heap", pprof.Handler("heap"),
-	)
-	gateway.HTTPRouter.Handle(
-		"GET", "/debug/pprof/threadcreate", pprof.Handler("threadcreate"),
-	)
-	gateway.HTTPRouter.Handle(
-		"GET", "/debug/pprof/block", pprof.Handler("block"),
-	)
-	gateway.HTTPRouter.Handle("GET", "/debug/loglevel", gateway.atomLevel)
-	gateway.HTTPRouter.Handle("PUT", "/debug/loglevel", gateway.atomLevel)
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof", http.HandlerFunc(pprof.Index))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/profile", http.HandlerFunc(pprof.Profile))
+	_ = gateway.HTTPRouter.Handle("POST", "/debug/pprof/trace", http.HandlerFunc(pprof.Trace))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	_ = gateway.HTTPRouter.Handle("POST", "/debug/pprof/symbol", http.HandlerFunc(pprof.Symbol))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/heap", pprof.Handler("heap"))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/pprof/block", pprof.Handler("block"))
+	_ = gateway.HTTPRouter.Handle("GET", "/debug/loglevel", gateway.atomLevel)
+	_ = gateway.HTTPRouter.Handle("PUT", "/debug/loglevel", gateway.atomLevel)
 
 	deps := &DefaultDependencies{
 		Scope:         gateway.RootScope,


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Feature | Medium |

## Description
This PR adds / changes the following

- Binds `trace` pprof symbol to `/debug/trace` in the router.

## Motivation & Context
- Required to trace gateway executions at load. Currently, because the router doesn't expose any, pprof trace yields nada.

## How was this tested?
- Built example gateway and tested the endpoint works as expected

![image](https://user-images.githubusercontent.com/12872673/125267042-0d83c780-e324-11eb-9df7-954d4778449f.png)
