### PR TITLE
Change circuit breaking naming to client id and method name

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1518,8 +1518,8 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.{{$clientID}}.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "{{$clientID}}" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
@@ -1908,7 +1908,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 17015, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 17017, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1276,8 +1276,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.{{$clientID}}.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutInMS, methodNames[methodKey])
+		for _, methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}"  + "-" + methodName
+			configureCircuitBreaker(deps, timeoutInMS, circuitBreakerName)
 		}
 	}
 
@@ -1299,7 +1300,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -1323,7 +1324,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -1365,7 +1366,8 @@ func (e *{{$clientName}}) {{$methodName}}(
 	if e.opts.CircuitBreakerDisabled {
 		result, err = runFunc(ctx, request, opts...)
 	} else {
-		err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)
@@ -1389,7 +1391,7 @@ func grpc_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "grpc_client.tmpl", size: 6680, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "grpc_client.tmpl", size: 6832, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1517,7 +1519,8 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "{{$clientID}}" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -1560,7 +1563,7 @@ func initializeAltRoutingMap(altServiceDetail config.AlternateServiceDetail) map
 }
 {{end -}}
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -1584,7 +1587,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 			MaxConcurrentRequests:  maxConcurrentRequests,
 			ErrorPercentThreshold:  errorPercentThreshold,
 			SleepWindow:            sleepWindowInMilliseconds,
@@ -1699,7 +1702,8 @@ func (c *{{$clientName}}) {{$methodName}}(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1904,7 +1908,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 16856, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 17015, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2921,8 +2925,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodNames[methodKey])
+		for _, methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}" + "-" + methodName
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -2983,7 +2988,7 @@ func initializeDynamicChannel(deps *module.Dependencies, headerPatterns []string
 	return headerPatterns, re
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -3007,7 +3012,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 			MaxConcurrentRequests:  maxConcurrentRequests,
 			ErrorPercentThreshold:  errorPercentThreshold,
 			SleepWindow:            sleepWindowInMilliseconds,
@@ -3061,7 +3066,8 @@ type {{$clientName}} struct {
 			"methodName" : "{{$methodName}}",
 			})
 		  start := time.Now()
-			err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+			circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+			err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			  elapsed := time.Now().Sub(start)
 			  scope.Timer("hystrix-timer").Record(elapsed)
 				success, respHeaders, clientErr = c.client.Call(
@@ -3128,7 +3134,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11764, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 11916, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/grpc_client.tmpl
+++ b/codegen/templates/grpc_client.tmpl
@@ -76,8 +76,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.{{$clientID}}.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutInMS, methodNames[methodKey])
+		for _, methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}"  + "-" + methodName
+			configureCircuitBreaker(deps, timeoutInMS, circuitBreakerName)
 		}
 	}
 
@@ -99,7 +100,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -123,7 +124,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -165,7 +166,8 @@ func (e *{{$clientName}}) {{$methodName}}(
 	if e.opts.CircuitBreakerDisabled {
 		result, err = runFunc(ctx, request, opts...)
 	} else {
-		err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -120,8 +120,8 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.{{$clientID}}.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "{{$clientID}}" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -121,7 +121,8 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "{{$clientID}}" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -164,7 +165,7 @@ func initializeAltRoutingMap(altServiceDetail config.AlternateServiceDetail) map
 }
 {{end -}}
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -188,7 +189,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 			MaxConcurrentRequests:  maxConcurrentRequests,
 			ErrorPercentThreshold:  errorPercentThreshold,
 			SleepWindow:            sleepWindowInMilliseconds,
@@ -303,7 +304,8 @@ func (c *{{$clientName}}) {{$methodName}}(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -134,8 +134,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodNames[methodKey])
+		for _, methodName := range methodNames {
+			circuitBreakerName := "{{$clientID}}" + "-" + methodName
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -196,7 +197,7 @@ func initializeDynamicChannel(deps *module.Dependencies, headerPatterns []string
 	return headerPatterns, re
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -220,7 +221,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 			MaxConcurrentRequests:  maxConcurrentRequests,
 			ErrorPercentThreshold:  errorPercentThreshold,
 			SleepWindow:            sleepWindowInMilliseconds,
@@ -274,7 +275,8 @@ type {{$clientName}} struct {
 			"methodName" : "{{$methodName}}",
 			})
 		  start := time.Now()
-			err = hystrix.DoC(ctx, "{{$methodName}}", func(ctx context.Context) error {
+			circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
+			err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			  elapsed := time.Now().Sub(start)
 			  scope.Timer("hystrix-timer").Record(elapsed)
 				success, respHeaders, clientErr = c.client.Call(

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -301,8 +301,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.bar.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "bar" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "bar" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -302,7 +302,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "bar" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -323,7 +324,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -347,7 +348,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.bar.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.bar.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -395,7 +396,8 @@ func (c *barClient) ArgNotStruct(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgNotStruct", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgNotStruct"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -500,7 +502,8 @@ func (c *barClient) ArgWithHeaders(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithHeaders", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithHeaders"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -680,7 +683,8 @@ func (c *barClient) ArgWithManyQueryParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithManyQueryParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithManyQueryParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -782,7 +786,8 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithNearDupQueryParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithNearDupQueryParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -908,7 +913,8 @@ func (c *barClient) ArgWithNestedQueryParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithNestedQueryParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithNestedQueryParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -993,7 +999,8 @@ func (c *barClient) ArgWithParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1078,7 +1085,8 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithParamsAndDuplicateFields", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithParamsAndDuplicateFields"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1163,7 +1171,8 @@ func (c *barClient) ArgWithQueryHeader(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithQueryHeader", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithQueryHeader"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1265,7 +1274,8 @@ func (c *barClient) ArgWithQueryParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ArgWithQueryParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ArgWithQueryParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1356,7 +1366,8 @@ func (c *barClient) DeleteFoo(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "DeleteFoo", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "DeleteFoo"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1433,7 +1444,8 @@ func (c *barClient) DeleteWithBody(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "DeleteWithBody", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "DeleteWithBody"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1519,7 +1531,8 @@ func (c *barClient) DeleteWithQueryParams(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "DeleteWithQueryParams", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "DeleteWithQueryParams"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1596,7 +1609,8 @@ func (c *barClient) Hello(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "Hello", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "Hello"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1708,7 +1722,8 @@ func (c *barClient) ListAndEnum(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "ListAndEnum", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "ListAndEnum"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1802,7 +1817,8 @@ func (c *barClient) MissingArg(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "MissingArg", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "MissingArg"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1897,7 +1913,8 @@ func (c *barClient) NoRequest(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "NoRequest", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "NoRequest"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -1993,7 +2010,8 @@ func (c *barClient) Normal(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "Normal", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "Normal"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2089,7 +2107,8 @@ func (c *barClient) NormalRecur(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "NormalRecur", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "NormalRecur"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2184,7 +2203,8 @@ func (c *barClient) TooManyArgs(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "TooManyArgs", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "TooManyArgs"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2294,7 +2314,8 @@ func (c *barClient) EchoBinary(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoBinary", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoBinary"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2377,7 +2398,8 @@ func (c *barClient) EchoBool(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoBool", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoBool"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2466,7 +2488,8 @@ func (c *barClient) EchoDouble(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoDouble", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoDouble"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2555,7 +2578,8 @@ func (c *barClient) EchoEnum(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoEnum", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoEnum"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2644,7 +2668,8 @@ func (c *barClient) EchoI16(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoI16", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoI16"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2733,7 +2758,8 @@ func (c *barClient) EchoI32(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoI32", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoI32"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2822,7 +2848,8 @@ func (c *barClient) EchoI32Map(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoI32Map", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoI32Map"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -2911,7 +2938,8 @@ func (c *barClient) EchoI64(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoI64", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoI64"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3000,7 +3028,8 @@ func (c *barClient) EchoI8(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoI8", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoI8"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3089,7 +3118,8 @@ func (c *barClient) EchoString(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoString", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoString"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3178,7 +3208,8 @@ func (c *barClient) EchoStringList(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoStringList", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoStringList"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3267,7 +3298,8 @@ func (c *barClient) EchoStringMap(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoStringMap", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoStringMap"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3356,7 +3388,8 @@ func (c *barClient) EchoStringSet(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoStringSet", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoStringSet"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3445,7 +3478,8 @@ func (c *barClient) EchoStructList(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoStructList", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoStructList"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3534,7 +3568,8 @@ func (c *barClient) EchoStructSet(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoStructSet", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoStructSet"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -3623,7 +3658,8 @@ func (c *barClient) EchoTypedef(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoTypedef", func(ctx context.Context) error {
+		circuitBreakerName := "bar" + "-" + "EchoTypedef"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -275,8 +275,9 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodNames[methodKey])
+		for _, methodName := range methodNames {
+			circuitBreakerName := "baz" + "-" + methodName
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -337,7 +338,7 @@ func initializeDynamicChannel(deps *module.Dependencies, headerPatterns []string
 	return headerPatterns, re
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -361,7 +362,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.baz.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.baz.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -403,7 +404,8 @@ func (c *bazClient) EchoBinary(
 			"methodName": "EchoBinary",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoBinary", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoBinary"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -468,7 +470,8 @@ func (c *bazClient) EchoBool(
 			"methodName": "EchoBool",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoBool", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoBool"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -533,7 +536,8 @@ func (c *bazClient) EchoDouble(
 			"methodName": "EchoDouble",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoDouble", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoDouble"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -598,7 +602,8 @@ func (c *bazClient) EchoEnum(
 			"methodName": "EchoEnum",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoEnum", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoEnum"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -663,7 +668,8 @@ func (c *bazClient) EchoI16(
 			"methodName": "EchoI16",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoI16", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoI16"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -728,7 +734,8 @@ func (c *bazClient) EchoI32(
 			"methodName": "EchoI32",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoI32", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoI32"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -793,7 +800,8 @@ func (c *bazClient) EchoI64(
 			"methodName": "EchoI64",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoI64", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoI64"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -858,7 +866,8 @@ func (c *bazClient) EchoI8(
 			"methodName": "EchoI8",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoI8", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoI8"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -923,7 +932,8 @@ func (c *bazClient) EchoString(
 			"methodName": "EchoString",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoString", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoString"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -988,7 +998,8 @@ func (c *bazClient) EchoStringList(
 			"methodName": "EchoStringList",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoStringList", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoStringList"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1053,7 +1064,8 @@ func (c *bazClient) EchoStringMap(
 			"methodName": "EchoStringMap",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoStringMap", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoStringMap"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1118,7 +1130,8 @@ func (c *bazClient) EchoStringSet(
 			"methodName": "EchoStringSet",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoStringSet", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoStringSet"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1183,7 +1196,8 @@ func (c *bazClient) EchoStructList(
 			"methodName": "EchoStructList",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoStructList", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoStructList"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1248,7 +1262,8 @@ func (c *bazClient) EchoStructSet(
 			"methodName": "EchoStructSet",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoStructSet", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoStructSet"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1313,7 +1328,8 @@ func (c *bazClient) EchoTypedef(
 			"methodName": "EchoTypedef",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "EchoTypedef", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "EchoTypedef"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1377,7 +1393,8 @@ func (c *bazClient) Call(
 			"methodName": "Call",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "Call", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "Call"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1437,7 +1454,8 @@ func (c *bazClient) Compare(
 			"methodName": "Compare",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "Compare", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "Compare"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1506,7 +1524,8 @@ func (c *bazClient) GetProfile(
 			"methodName": "GetProfile",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "GetProfile", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "GetProfile"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1573,7 +1592,8 @@ func (c *bazClient) HeaderSchema(
 			"methodName": "HeaderSchema",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "HeaderSchema", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "HeaderSchema"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1642,7 +1662,8 @@ func (c *bazClient) Ping(
 			"methodName": "Ping",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "Ping", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "Ping"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1706,7 +1727,8 @@ func (c *bazClient) DeliberateDiffNoop(
 			"methodName": "DeliberateDiffNoop",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "DeliberateDiffNoop", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "DeliberateDiffNoop"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1767,7 +1789,8 @@ func (c *bazClient) TestUUID(
 			"methodName": "TestUUID",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "TestUUID", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "TestUUID"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1825,7 +1848,8 @@ func (c *bazClient) Trans(
 			"methodName": "Trans",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "Trans", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "Trans"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1894,7 +1918,8 @@ func (c *bazClient) TransHeaders(
 			"methodName": "TransHeaders",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "TransHeaders", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "TransHeaders"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -1963,7 +1988,8 @@ func (c *bazClient) TransHeadersNoReq(
 			"methodName": "TransHeadersNoReq",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "TransHeadersNoReq", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "TransHeadersNoReq"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -2030,7 +2056,8 @@ func (c *bazClient) TransHeadersType(
 			"methodName": "TransHeadersType",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "TransHeadersType", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "TransHeadersType"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(
@@ -2098,7 +2125,8 @@ func (c *bazClient) URLTest(
 			"methodName": "URLTest",
 		})
 		start := time.Now()
-		err = hystrix.DoC(ctx, "URLTest", func(ctx context.Context) error {
+		circuitBreakerName := "baz" + "-" + "URLTest"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			elapsed := time.Now().Sub(start)
 			scope.Timer("hystrix-timer").Record(elapsed)
 			success, respHeaders, clientErr = c.client.Call(

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -101,7 +101,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "contacts" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -122,7 +123,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -146,7 +147,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.contacts.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.contacts.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -195,7 +196,8 @@ func (c *contactsClient) SaveContacts(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "SaveContacts", func(ctx context.Context) error {
+		circuitBreakerName := "contacts" + "-" + "SaveContacts"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -284,7 +286,8 @@ func (c *contactsClient) TestURLURL(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "TestURLURL", func(ctx context.Context) error {
+		circuitBreakerName := "contacts" + "-" + "TestURLURL"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -100,8 +100,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.contacts.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "contacts" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "contacts" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -134,7 +134,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "corge-http" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -172,7 +173,7 @@ func initializeAltRoutingMap(altServiceDetail config.AlternateServiceDetail) map
 	}
 	return routingMap
 }
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -196,7 +197,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.corge-http.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.corge-http.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -265,7 +266,8 @@ func (c *corgeHTTPClient) EchoString(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "EchoString", func(ctx context.Context) error {
+		circuitBreakerName := "corge-http" + "-" + "EchoString"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -368,7 +370,8 @@ func (c *corgeHTTPClient) NoContent(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "NoContent", func(ctx context.Context) error {
+		circuitBreakerName := "corge-http" + "-" + "NoContent"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -466,7 +469,8 @@ func (c *corgeHTTPClient) NoContentNoException(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "NoContentNoException", func(ctx context.Context) error {
+		circuitBreakerName := "corge-http" + "-" + "NoContentNoException"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -560,7 +564,8 @@ func (c *corgeHTTPClient) CorgeNoContentOnException(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "CorgeNoContentOnException", func(ctx context.Context) error {
+		circuitBreakerName := "corge-http" + "-" + "CorgeNoContentOnException"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -133,8 +133,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.corge-http.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "corge-http" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "corge-http" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -100,8 +100,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.google-now.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "google-now" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "google-now" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -98,8 +98,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.multi.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "multi" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "multi" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -99,7 +99,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "multi" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -120,7 +121,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -144,7 +145,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.multi.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.multi.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -192,7 +193,8 @@ func (c *multiClient) HelloA(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "HelloA", func(ctx context.Context) error {
+		circuitBreakerName := "multi" + "-" + "HelloA"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded
@@ -275,7 +277,8 @@ func (c *multiClient) HelloB(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "HelloB", func(ctx context.Context) error {
+		circuitBreakerName := "multi" + "-" + "HelloB"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -95,7 +95,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	if !circuitBreakerDisabled {
 		for methodKey := range methodNames {
-			configureCircuitBreaker(deps, timeoutVal, methodKey)
+			circuitBreakerName := "withexceptions" + "-" + methodKey
+			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}
 
@@ -116,7 +117,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method string) {
+func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, circuitBreakerName string) {
 	// sleepWindowInMilliseconds sets the amount of time, after tripping the circuit,
 	// to reject requests before allowing attempts again to determine if the circuit should again be closed
 	sleepWindowInMilliseconds := 5000
@@ -140,7 +141,7 @@ func configureCircuitBreaker(deps *module.Dependencies, timeoutVal int, method s
 	if deps.Default.Config.ContainsKey("clients.withexceptions.requestVolumeThreshold") {
 		requestVolumeThreshold = int(deps.Default.Config.MustGetInt("clients.withexceptions.requestVolumeThreshold"))
 	}
-	hystrix.ConfigureCommand(method, hystrix.CommandConfig{
+	hystrix.ConfigureCommand(circuitBreakerName, hystrix.CommandConfig{
 		MaxConcurrentRequests:  maxConcurrentRequests,
 		ErrorPercentThreshold:  errorPercentThreshold,
 		SleepWindow:            sleepWindowInMilliseconds,
@@ -188,7 +189,8 @@ func (c *withexceptionsClient) Func1(
 	} else {
 		// We want hystrix ckt-breaker to count errors only for system issues
 		var clientErr error
-		err = hystrix.DoC(ctx, "Func1", func(ctx context.Context) error {
+		circuitBreakerName := "withexceptions" + "-" + "Func1"
+		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
 			res, clientErr = req.Do()
 			if res != nil {
 				// This is not a system error/issue. Downstream responded

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -94,8 +94,8 @@ func NewClient(deps *module.Dependencies) Client {
 		circuitBreakerDisabled = deps.Default.Config.MustGetBoolean("clients.withexceptions.circuitBreakerDisabled")
 	}
 	if !circuitBreakerDisabled {
-		for methodKey := range methodNames {
-			circuitBreakerName := "withexceptions" + "-" + methodKey
+		for methodName := range methodNames {
+			circuitBreakerName := "withexceptions" + "-" + methodName
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName)
 		}
 	}


### PR DESCRIPTION
Circuit breaker naming was changed to prevent different clients with same method names to have overlap in circuit breaker key values. The recent circuit breaker change configured the circuit breaker settings to be stored by the method name. In prod a client had a duplicate client staging file with the same method names, which led to the timeout value of the non staging client to have its circuit breaker have the timeout value of 5 seconds instead of 15 seconds. This change to name the circuit breakers by client id + '-' + method name will allow naming to be unique and prevent the overlap issue. Also testing was added to baz and contacts test files to check if the correct settings were set for all method circuit breakers.