### PR TITLE
Dedicated TChannel Client Per Callee Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.0 - 2021-08-05
+### Changed
+- **BREAKING** `gateway.Channel` has been renamed to `gateway.ServerTChannel` to distinguish between client and server TChannels.
+
+
+- **BREAKING** `gateway.TChannelRouter` has been renamed to `gateway.ServerTChannelRouter`
+
+### Added
+- A new boolean flag `dedicated.tchannel.client` is introduced. When set to `true`, each TChannel client creates a dedicated connection instead of registering on the default shared server connection.
+Clients need not do anything as the default behaviour is to use a shared connection.([#778](https://github.com/uber/zanzibar/pull/778))
+
+  
+- A new field has been added to the gateway to propagate the `TChannelSubLoggerLevel` for clients with dedicated connections.
+
+
 ## 0.6.7 - 2021-02-05
 ### Changed
 - **BREAKING** runtime/client_http_request.go, runtime/grpc_client.go, runtime/http_client.go, runtime/router.go, 

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2389,6 +2389,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		  g.JSONWrapper,
@@ -2423,7 +2424,7 @@ func module_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_initializer.tmpl", size: 2522, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_initializer.tmpl", size: 2564, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2489,6 +2490,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:   	  g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -2544,7 +2546,7 @@ func module_mock_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4430, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4471, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3065,34 +3067,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
-	processName := deps.Default.Config.MustGetString("tchannel.processName")
-	gateway := deps.Default.Gateway
-	level := gateway.TChannelSubLoggerLevel
-
-	channel, err := tchannel.NewChannel(
-		serviceName,
-		&tchannel.ChannelOptions{
-			ProcessName: processName,
-			Tracer:      deps.Default.Tracer,
-			Logger:      zanzibar.NewTChannelLogger(gateway.SubLogger("tchannel", level)),
-			StatsReporter: zanzibar.NewTChannelStatsReporter(
-			deps.Default.Scope,
-			),
-		})
-
-	scope := deps.Default.Scope.Tagged(map[string]string{
-		"client": serviceName,
-	})
-
-	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(0)
-	} else {
-		scope.Gauge("tchannel.client.running").Update(1)
-	}
-	return channel
-}
-
 func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail
@@ -3298,7 +3272,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14824, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14023, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3006,9 +3006,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		{{ end -}}
 		{{ end -}}
 	}
-	for _, method := range methodNames {
-		fmt.Printf("For Client: {{$clientName}} we are registering %v on the explicit client channel\n", method)
-	}
+
 
 	qpsLevels := map[string]string{
 				{{range $methodName, $qpsLevel := $QPSLevels -}}
@@ -3080,11 +3078,9 @@ func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *
 	})
 
 	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(1)
-		scope.Gauge("tchannel.client.failed").Update(0)
-	} else {
 		scope.Gauge("tchannel.client.running").Update(0)
-		scope.Gauge("tchannel.client.failed").Update(1)
+	} else {
+		scope.Gauge("tchannel.client.running").Update(1)
 	}
 	return channel
 }
@@ -3294,7 +3290,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13136, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 12889, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3493,7 +3489,6 @@ type {{$handlerName}} struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *{{$handlerName}}) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In {{$handlerName}} using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
@@ -3704,7 +3699,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8905, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8797, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2390,7 +2390,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		  g.JSONWrapper,
 	}
@@ -2424,7 +2423,7 @@ func module_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_initializer.tmpl", size: 2564, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_initializer.tmpl", size: 2522, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2490,7 +2489,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -2546,7 +2544,7 @@ func module_mock_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4472, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4430, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2960,7 +2958,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	} else {
-		channel = deps.Default.ServerTChannel
+		channel = gateway.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 
@@ -3300,7 +3298,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14829, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14824, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3301,7 +3301,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13288, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14862, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3710,7 +3710,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8797, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8803, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2943,7 +2943,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
 	gateway.ClientTchannels[serviceName] = channel
-	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
@@ -3290,7 +3289,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 12889, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 12798, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2957,12 +2957,11 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
-	} else {
-		channel = createNewTchannelForClient(deps, serviceName)
-		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 
 	/*Ex:
@@ -3301,7 +3300,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14862, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14829, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2489,7 +2489,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTchannel:       g.ServerTchannel,
+		Channel:              g.Channel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -2830,7 +2830,7 @@ func service_mockTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "service_mock.tmpl", size: 5410, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "service_mock.tmpl", size: 5424, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3060,7 +3060,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.ServerTchannel {
+func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
 	processName := deps.Default.Config.MustGetString("tchannel.processName")
 	gateway := deps.Default.Gateway
 	level := gateway.TchannelSubLoggerLevel
@@ -3090,7 +3090,7 @@ func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *
 	return channel
 }
 
-func initializeDynamicChannel(channel *tchannel.ServerTchannel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
+func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail
 		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.alternates", &alternateServiceDetail)
@@ -3295,7 +3295,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13219, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13072, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3705,7 +3705,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8899, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8905, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3294,7 +3294,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 12984, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13136, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2489,7 +2489,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -2726,7 +2726,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -2814,7 +2814,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }
@@ -2942,7 +2942,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTChannels[serviceName] = channel
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
@@ -3059,7 +3059,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
 	processName := deps.Default.Config.MustGetString("tchannel.processName")
 	gateway := deps.Default.Gateway
-	level := gateway.TchannelSubLoggerLevel
+	level := gateway.TChannelSubLoggerLevel
 
 	channel, err := tchannel.NewChannel(
 		serviceName,

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2489,7 +2489,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -2545,7 +2545,7 @@ func module_mock_initializerTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4465, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "module_mock_initializer.tmpl", size: 4472, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3007,7 +3007,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		{{ end -}}
 	}
 	for _, method := range methodNames {
-		//todo we were asserting that the registering of methods happen in separate tchannels
 		fmt.Printf("For Client: {{$clientName}} we are registering %v on the explicit client channel\n", method)
 	}
 
@@ -3295,7 +3294,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 13072, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 12984, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2954,15 +2954,15 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	var channel *tchannel.Channel
 
 	// If dedicated.tchannel.client : true, each tchannel client will create a
-	// dedicated connection with local Muttley, else it will use a shared connection
+	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
 	} else {
 		channel = createNewTchannelForClient(deps, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
 	}
 
 	/*Ex:

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -38,16 +38,16 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:           g.Logger,
-		ContextExtractor: g.ContextExtractor,
-		ContextLogger:    g.ContextLogger,
-		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
-		Scope:            g.RootScope,
-		Tracer:           g.Tracer,
-		Config:           g.Config,
-
+		Logger:               g.Logger,
+		ContextExtractor:     g.ContextExtractor,
+		ContextLogger:        g.ContextLogger,
+		ContextMetrics:       zanzibar.NewContextMetrics(g.RootScope),
+		Scope:                g.RootScope,
+		Tracer:               g.Tracer,
+		Config:               g.Config,
+		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
-		JSONWrapper:		g.JSONWrapper,
+		JSONWrapper:		  g.JSONWrapper,
 	}
 
 	{{range $idx, $className := $instance.DependencyOrder}}

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -38,14 +38,13 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:         g.Logger,
+		Logger:           g.Logger,
 		ContextExtractor: g.ContextExtractor,
-		ContextLogger:  g.ContextLogger,
-		ContextMetrics: zanzibar.NewContextMetrics(g.RootScope),
-		Scope:          g.RootScope,
-		Tracer:         g.Tracer,
-		Config:         g.Config,
-		Channel:        g.Channel,
+		ContextLogger:    g.ContextLogger,
+		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
+		Scope:            g.RootScope,
+		Tracer:           g.Tracer,
+		Config:           g.Config,
 
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		g.JSONWrapper,

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -46,7 +46,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		  g.JSONWrapper,
 	}

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -45,6 +45,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		  g.JSONWrapper,

--- a/codegen/templates/module_initializer.tmpl
+++ b/codegen/templates/module_initializer.tmpl
@@ -46,6 +46,7 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
+		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:		  g.JSONWrapper,
 	}

--- a/codegen/templates/module_mock_initializer.tmpl
+++ b/codegen/templates/module_mock_initializer.tmpl
@@ -59,7 +59,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/codegen/templates/module_mock_initializer.tmpl
+++ b/codegen/templates/module_mock_initializer.tmpl
@@ -59,7 +59,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/codegen/templates/module_mock_initializer.tmpl
+++ b/codegen/templates/module_mock_initializer.tmpl
@@ -59,7 +59,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/codegen/templates/module_mock_initializer.tmpl
+++ b/codegen/templates/module_mock_initializer.tmpl
@@ -59,6 +59,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:   	  g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -105,7 +105,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -193,7 +193,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/codegen/templates/service_mock.tmpl
+++ b/codegen/templates/service_mock.tmpl
@@ -105,7 +105,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.Channel,
+		server.ServerTchannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -193,7 +193,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.Channel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -69,7 +69,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTChannels[serviceName] = channel
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
@@ -186,7 +186,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
 	processName := deps.Default.Config.MustGetString("tchannel.processName")
 	gateway := deps.Default.Gateway
-	level := gateway.TchannelSubLoggerLevel
+	level := gateway.TChannelSubLoggerLevel
 
 	channel, err := tchannel.NewChannel(
 		serviceName,

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -67,18 +67,29 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
 		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
 	}
-	gateway := deps.Default.Gateway
-	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTChannels[serviceName] = channel
 
 	{{if $sidecarRouter -}}
-	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
-	port := deps.Default.Config.MustGetInt("sidecarRouter.{{$sidecarRouter}}.tchannel.port")
+		ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
+		port := deps.Default.Config.MustGetInt("sidecarRouter.{{$sidecarRouter}}.tchannel.port")
 	{{else -}}
-	ip := deps.Default.Config.MustGetString("clients.{{$clientID}}.ip")
-	port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
+		ip := deps.Default.Config.MustGetString("clients.{{$clientID}}.ip")
+		port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
 	{{end -}}
-	channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+
+	gateway := deps.Default.Gateway
+	var channel *tchannel.Channel
+
+	// If dedicated.tchannel.client : true, each tchannel client will create a
+	// dedicated connection with local Muttley, else it will use a shared connection
+	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
+		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = deps.Default.ServerTChannel
+		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
+		channel = createNewTchannelForClient(deps, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
+	}
 
 	/*Ex:
 	{

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -69,8 +69,8 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.TchannelChannels[serviceName] = channel
-	gateway.TchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
+	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -80,7 +80,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	var channel *tchannel.Channel
 
 	// If dedicated.tchannel.client : true, each tchannel client will create a
-	// dedicated connection with local Muttley, else it will use a shared connection
+	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
 		channel = deps.Default.ServerTChannel

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -86,7 +86,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	} else {
-		channel = deps.Default.ServerTChannel
+		channel = gateway.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -133,6 +133,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		{{ end -}}
 		{{ end -}}
 	}
+	for _, method := range methodNames {
+		//todo we were asserting that the registering of methods happen in separate tchannels
+		fmt.Printf("For Client: {{$clientName}} we are registering %v on the explicit client channel\n", method)
+	}
 
 	qpsLevels := map[string]string{
 				{{range $methodName, $qpsLevel := $QPSLevels -}}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -83,12 +83,11 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
-	} else {
-		channel = createNewTchannelForClient(deps, serviceName)
-		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 
 	/*Ex:

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -133,9 +133,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		{{ end -}}
 		{{ end -}}
 	}
-	for _, method := range methodNames {
-		fmt.Printf("For Client: {{$clientName}} we are registering %v on the explicit client channel\n", method)
-	}
+
 
 	qpsLevels := map[string]string{
 				{{range $methodName, $qpsLevel := $QPSLevels -}}
@@ -207,11 +205,9 @@ func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *
 	})
 
 	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(1)
-		scope.Gauge("tchannel.client.failed").Update(0)
-	} else {
 		scope.Gauge("tchannel.client.running").Update(0)
-		scope.Gauge("tchannel.client.failed").Update(1)
+	} else {
+		scope.Gauge("tchannel.client.running").Update(1)
 	}
 	return channel
 }

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -85,10 +85,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
 	} else {
 		channel = createNewTchannelForClient(deps, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
 	}
 
 	/*Ex:

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -67,7 +67,10 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
 		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
 	}
-	sc := deps.Default.Channel.GetSubChannel(serviceName, tchannel.Isolated)
+	gateway := deps.Default.Gateway
+	channel := createNewTchannelForClient(deps, serviceName)
+	gateway.TchannelChannels[serviceName] = channel
+	gateway.TchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")
@@ -76,7 +79,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	ip := deps.Default.Config.MustGetString("clients.{{$clientID}}.ip")
 	port := deps.Default.Config.MustGetInt("clients.{{$clientID}}.port")
 	{{end -}}
-	sc.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 
 	/*Ex:
 	{
@@ -108,7 +111,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	var re ruleengine.RuleEngine
 	var headerPatterns []string
 	altChannelMap  := make(map[string]*tchannel.SubChannel)
-	headerPatterns, re = initializeDynamicChannel(deps, headerPatterns, altChannelMap, re)
+	headerPatterns, re = initializeDynamicChannel(channel, deps, headerPatterns, altChannelMap, re)
 
 	{{/* TODO: (lu) maybe set these at per method level */ -}}
 	timeoutVal := int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.timeout"))
@@ -155,7 +158,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 
 	client := zanzibar.NewTChannelClientContext(
-		deps.Default.Channel,
+		channel,
 		deps.Default.ContextLogger,
 		deps.Default.ContextMetrics,
 		deps.Default.ContextExtractor,
@@ -180,7 +183,37 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func initializeDynamicChannel(deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
+func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
+	processName := deps.Default.Config.MustGetString("tchannel.processName")
+	gateway := deps.Default.Gateway
+	level := gateway.TchannelSubLoggerLevel
+
+	channel, err := tchannel.NewChannel(
+		serviceName,
+		&tchannel.ChannelOptions{
+			ProcessName: processName,
+			Tracer:      deps.Default.Tracer,
+			Logger:      zanzibar.NewTChannelLogger(gateway.SubLogger("tchannel", level)),
+			StatsReporter: zanzibar.NewTChannelStatsReporter(
+			deps.Default.Scope,
+			),
+		})
+
+	scope := deps.Default.Scope.Tagged(map[string]string{
+		"client": serviceName,
+	})
+
+	if err != nil {
+		scope.Gauge("tchannel.client.running").Update(1)
+		scope.Gauge("tchannel.client.failed").Update(0)
+	} else {
+		scope.Gauge("tchannel.client.running").Update(0)
+		scope.Gauge("tchannel.client.failed").Update(1)
+	}
+	return channel
+}
+
+func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail
 		deps.Default.Config.MustGetStruct("clients.{{$clientID}}.alternates", &alternateServiceDetail)
@@ -197,7 +230,7 @@ func initializeDynamicChannel(deps *module.Dependencies, headerPatterns []string
 			headerPatterns = append(headerPatterns, textproto.CanonicalMIMEHeaderKey(routingConfig.HeaderName))
 			ruleWrapper.Rules = append(ruleWrapper.Rules, rawRule)
 
-			scAlt := deps.Default.Channel.GetSubChannel(routingConfig.ServiceName, tchannel.Isolated)
+			scAlt := channel.GetSubChannel(routingConfig.ServiceName, tchannel.Isolated)
 			serviceRouting, ok := alternateServiceDetail.ServicesDetailMap[routingConfig.ServiceName]
 			if !ok {
 				panic("service routing mapping incorrect for service: " + routingConfig.ServiceName)

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -193,34 +193,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	}
 }
 
-func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
-	processName := deps.Default.Config.MustGetString("tchannel.processName")
-	gateway := deps.Default.Gateway
-	level := gateway.TChannelSubLoggerLevel
-
-	channel, err := tchannel.NewChannel(
-		serviceName,
-		&tchannel.ChannelOptions{
-			ProcessName: processName,
-			Tracer:      deps.Default.Tracer,
-			Logger:      zanzibar.NewTChannelLogger(gateway.SubLogger("tchannel", level)),
-			StatsReporter: zanzibar.NewTChannelStatsReporter(
-			deps.Default.Scope,
-			),
-		})
-
-	scope := deps.Default.Scope.Tagged(map[string]string{
-		"client": serviceName,
-	})
-
-	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(0)
-	} else {
-		scope.Gauge("tchannel.client.running").Update(1)
-	}
-	return channel
-}
-
 func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.{{$clientID}}.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -134,7 +134,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 		{{ end -}}
 	}
 	for _, method := range methodNames {
-		//todo we were asserting that the registering of methods happen in separate tchannels
 		fmt.Printf("For Client: {{$clientName}} we are registering %v on the explicit client channel\n", method)
 	}
 

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -70,7 +70,6 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
 	gateway.ClientTchannels[serviceName] = channel
-	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	{{if $sidecarRouter -}}
 	ip := deps.Default.Config.MustGetString("sidecarRouter.{{$sidecarRouter}}.tchannel.ip")

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -73,7 +73,8 @@ type {{$handlerName}} struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *{{$handlerName}}) Register(g *zanzibar.Gateway) error {
-	return g.TChannelRouter.Register(h.endpoint)
+	serviceName := deps.Default.Config.MustGetString("clients.{{$clientID}}.serviceName")
+	return g.TchannelRouters[serviceName].Register(h.endpoint)
 }
 
 // Handle handles RPC call of "{{.ThriftService}}::{{.Name}}".

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -73,8 +73,8 @@ type {{$handlerName}} struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *{{$handlerName}}) Register(g *zanzibar.Gateway) error {
-	serviceName := deps.Default.Config.MustGetString("clients.{{$clientID}}.serviceName")
-	return g.TchannelRouters[serviceName].Register(h.endpoint)
+	fmt.Printf("Register phase: In {{$handlerName}} using main server tchannel for [%v]\n", h.endpoint.Method)
+	return g.TChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "{{.ThriftService}}::{{.Name}}".

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -73,7 +73,6 @@ type {{$handlerName}} struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *{{$handlerName}}) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In {{$handlerName}} using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -74,7 +74,7 @@ type {{$handlerName}} struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *{{$handlerName}}) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In {{$handlerName}} using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "{{.ThriftService}}::{{.Name}}".

--- a/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
@@ -67,7 +67,7 @@ type AppDemoServiceCallHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *AppDemoServiceCallHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In AppDemoServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "AppDemoService::Call".

--- a/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
@@ -25,6 +25,7 @@ package appdemoabcendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 
 	"github.com/pkg/errors"
@@ -65,6 +66,7 @@ type AppDemoServiceCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *AppDemoServiceCallHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In AppDemoServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
@@ -25,7 +25,6 @@ package appdemoabcendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 
 	"github.com/pkg/errors"
@@ -66,7 +65,6 @@ type AppDemoServiceCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *AppDemoServiceCallHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In AppDemoServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,6 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		Channel:              g.Channel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,6 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		Channel:              g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_init.go
@@ -65,7 +65,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.ServerTchannel,
+		Channel:              g.Channel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.Channel,
+		server.ServerTchannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.Channel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/app/demo/services/xyz/module/init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/module/init.go
@@ -86,7 +86,6 @@ func InitializeDependencies(
 		Scope:            g.RootScope,
 		Tracer:           g.Tracer,
 		Config:           g.Config,
-		Channel:          g.Channel,
 
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/module/init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/module/init.go
@@ -86,6 +86,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/app/demo/services/xyz/module/init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/module/init.go
@@ -79,14 +79,14 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:           g.Logger,
-		ContextExtractor: g.ContextExtractor,
-		ContextLogger:    g.ContextLogger,
-		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
-		Scope:            g.RootScope,
-		Tracer:           g.Tracer,
-		Config:           g.Config,
-
+		Logger:               g.Logger,
+		ContextExtractor:     g.ContextExtractor,
+		ContextLogger:        g.ContextLogger,
+		ContextMetrics:       zanzibar.NewContextMetrics(g.RootScope),
+		Scope:                g.RootScope,
+		Tracer:               g.Tracer,
+		Config:               g.Config,
+		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/app/demo/services/xyz/module/init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/module/init.go
@@ -87,7 +87,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/app/demo/services/xyz/module/init.go
+++ b/examples/example-gateway/build/app/demo/services/xyz/module/init.go
@@ -87,6 +87,7 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
+		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -205,12 +205,11 @@ func NewClient(deps *module.Dependencies) Client {
 	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
-	} else {
-		channel = createNewTchannelForClient(deps, serviceName)
-		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 
 	/*Ex:

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -208,7 +208,7 @@ func NewClient(deps *module.Dependencies) Client {
 		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	} else {
-		channel = deps.Default.ServerTChannel
+		channel = gateway.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -26,7 +26,6 @@ package bazclient
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/textproto"
 	"strconv"
 	"strings"
@@ -274,9 +273,6 @@ func NewClient(deps *module.Dependencies) Client {
 		"SimpleService::transHeadersType":  "TransHeadersType",
 		"SimpleService::urlTest":           "URLTest",
 	}
-	for _, method := range methodNames {
-		fmt.Printf("For Client: bazClient we are registering %v on the explicit client channel\n", method)
-	}
 
 	qpsLevels := map[string]string{
 		"baz-Call":               "4",
@@ -372,11 +368,9 @@ func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *
 	})
 
 	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(1)
-		scope.Gauge("tchannel.client.failed").Update(0)
-	} else {
 		scope.Gauge("tchannel.client.running").Update(0)
-		scope.Gauge("tchannel.client.failed").Update(1)
+	} else {
+		scope.Gauge("tchannel.client.running").Update(1)
 	}
 	return channel
 }

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -197,7 +197,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTChannels[serviceName] = channel
 
 	ip := deps.Default.Config.MustGetString("clients.baz.ip")
 	port := deps.Default.Config.MustGetInt("clients.baz.port")
@@ -349,7 +349,7 @@ func NewClient(deps *module.Dependencies) Client {
 func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
 	processName := deps.Default.Config.MustGetString("tchannel.processName")
 	gateway := deps.Default.Gateway
-	level := gateway.TchannelSubLoggerLevel
+	level := gateway.TChannelSubLoggerLevel
 
 	channel, err := tchannel.NewChannel(
 		serviceName,

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -198,8 +198,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.TchannelChannels[serviceName] = channel
-	gateway.TchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
+	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	ip := deps.Default.Config.MustGetString("clients.baz.ip")
 	port := deps.Default.Config.MustGetInt("clients.baz.port")

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -198,7 +198,6 @@ func NewClient(deps *module.Dependencies) Client {
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
 	gateway.ClientTchannels[serviceName] = channel
-	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	ip := deps.Default.Config.MustGetString("clients.baz.ip")
 	port := deps.Default.Config.MustGetInt("clients.baz.port")

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -355,34 +355,6 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
-	processName := deps.Default.Config.MustGetString("tchannel.processName")
-	gateway := deps.Default.Gateway
-	level := gateway.TChannelSubLoggerLevel
-
-	channel, err := tchannel.NewChannel(
-		serviceName,
-		&tchannel.ChannelOptions{
-			ProcessName: processName,
-			Tracer:      deps.Default.Tracer,
-			Logger:      zanzibar.NewTChannelLogger(gateway.SubLogger("tchannel", level)),
-			StatsReporter: zanzibar.NewTChannelStatsReporter(
-				deps.Default.Scope,
-			),
-		})
-
-	scope := deps.Default.Scope.Tagged(map[string]string{
-		"client": serviceName,
-	})
-
-	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(0)
-	} else {
-		scope.Gauge("tchannel.client.running").Update(1)
-	}
-	return channel
-}
-
 func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.baz.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -26,6 +26,7 @@ package bazclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/textproto"
 	"strconv"
 	"strings"
@@ -272,6 +273,10 @@ func NewClient(deps *module.Dependencies) Client {
 		"SimpleService::transHeadersNoReq": "TransHeadersNoReq",
 		"SimpleService::transHeadersType":  "TransHeadersType",
 		"SimpleService::urlTest":           "URLTest",
+	}
+	for _, method := range methodNames {
+		//todo we were asserting that the registering of methods happen in separate tchannels
+		fmt.Printf("For Client: bazClient we are registering %v on the explicit client channel\n", method)
 	}
 
 	qpsLevels := map[string]string{

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -202,15 +202,15 @@ func NewClient(deps *module.Dependencies) Client {
 	var channel *tchannel.Channel
 
 	// If dedicated.tchannel.client : true, each tchannel client will create a
-	// dedicated connection with local Muttley, else it will use a shared connection
+	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
 	} else {
 		channel = createNewTchannelForClient(deps, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
 	}
 
 	/*Ex:

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -195,13 +195,23 @@ func NewClient(deps *module.Dependencies) Client {
 	if deps.Default.Config.ContainsKey("tchannel.clients.requestUUIDHeaderKey") {
 		requestUUIDHeaderKey = deps.Default.Config.MustGetString("tchannel.clients.requestUUIDHeaderKey")
 	}
-	gateway := deps.Default.Gateway
-	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTChannels[serviceName] = channel
 
 	ip := deps.Default.Config.MustGetString("clients.baz.ip")
 	port := deps.Default.Config.MustGetInt("clients.baz.port")
-	channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	gateway := deps.Default.Gateway
+	var channel *tchannel.Channel
+
+	// If dedicated.tchannel.client : true, each tchannel client will create a
+	// dedicated connection with local Muttley, else it will use a shared connection
+	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
+		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = deps.Default.ServerTChannel
+		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
+		channel = createNewTchannelForClient(deps, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
+	}
 
 	/*Ex:
 	{

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -275,7 +275,6 @@ func NewClient(deps *module.Dependencies) Client {
 		"SimpleService::urlTest":           "URLTest",
 	}
 	for _, method := range methodNames {
-		//todo we were asserting that the registering of methods happen in separate tchannels
 		fmt.Printf("For Client: bazClient we are registering %v on the explicit client channel\n", method)
 	}
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -68,7 +68,7 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTChannels[serviceName] = channel
 
 	ip := deps.Default.Config.MustGetString("sidecarRouter.default.tchannel.ip")
 	port := deps.Default.Config.MustGetInt("sidecarRouter.default.tchannel.port")
@@ -168,7 +168,7 @@ func NewClient(deps *module.Dependencies) Client {
 func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
 	processName := deps.Default.Config.MustGetString("tchannel.processName")
 	gateway := deps.Default.Gateway
-	level := gateway.TchannelSubLoggerLevel
+	level := gateway.TChannelSubLoggerLevel
 
 	channel, err := tchannel.NewChannel(
 		serviceName,

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -76,12 +76,11 @@ func NewClient(deps *module.Dependencies) Client {
 	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
+		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
+		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+	} else {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
-	} else {
-		channel = createNewTchannelForClient(deps, serviceName)
-		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 
 	/*Ex:

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -174,34 +174,6 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 }
 
-func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *tchannel.Channel {
-	processName := deps.Default.Config.MustGetString("tchannel.processName")
-	gateway := deps.Default.Gateway
-	level := gateway.TChannelSubLoggerLevel
-
-	channel, err := tchannel.NewChannel(
-		serviceName,
-		&tchannel.ChannelOptions{
-			ProcessName: processName,
-			Tracer:      deps.Default.Tracer,
-			Logger:      zanzibar.NewTChannelLogger(gateway.SubLogger("tchannel", level)),
-			StatsReporter: zanzibar.NewTChannelStatsReporter(
-				deps.Default.Scope,
-			),
-		})
-
-	scope := deps.Default.Scope.Tagged(map[string]string{
-		"client": serviceName,
-	})
-
-	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(0)
-	} else {
-		scope.Gauge("tchannel.client.running").Update(1)
-	}
-	return channel
-}
-
 func initializeDynamicChannel(channel *tchannel.Channel, deps *module.Dependencies, headerPatterns []string, altChannelMap map[string]*tchannel.SubChannel, re ruleengine.RuleEngine) ([]string, ruleengine.RuleEngine) {
 	if deps.Default.Config.ContainsKey("clients.corge.alternates") {
 		var alternateServiceDetail config.AlternateServiceDetail

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -79,7 +79,7 @@ func NewClient(deps *module.Dependencies) Client {
 		channel = gateway.SetupClientTChannel(deps.Default.Config, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	} else {
-		channel = deps.Default.ServerTChannel
+		channel = gateway.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
 	}
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -73,15 +73,15 @@ func NewClient(deps *module.Dependencies) Client {
 	var channel *tchannel.Channel
 
 	// If dedicated.tchannel.client : true, each tchannel client will create a
-	// dedicated connection with local Muttley, else it will use a shared connection
+	// dedicated connection with local sidecar, else it will use a shared connection
 	if deps.Default.Config.ContainsKey("dedicated.tchannel.client") &&
 		deps.Default.Config.MustGetBoolean("dedicated.tchannel.client") {
 		channel = deps.Default.ServerTChannel
 		channel.GetSubChannel(serviceName, tchannel.Isolated).Peers().Add(ip + ":" + strconv.Itoa(int(port)))
+		gateway.ClientTChannels[serviceName] = channel
 	} else {
 		channel = createNewTchannelForClient(deps, serviceName)
 		channel.Peers().Add(ip + ":" + strconv.Itoa(int(port)))
-		gateway.ClientTChannels[serviceName] = channel
 	}
 
 	/*Ex:

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -69,8 +69,8 @@ func NewClient(deps *module.Dependencies) Client {
 	}
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
-	gateway.TchannelChannels[serviceName] = channel
-	gateway.TchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
+	gateway.ClientTchannels[serviceName] = channel
+	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	ip := deps.Default.Config.MustGetString("sidecarRouter.default.tchannel.ip")
 	port := deps.Default.Config.MustGetInt("sidecarRouter.default.tchannel.port")

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -69,7 +69,6 @@ func NewClient(deps *module.Dependencies) Client {
 	gateway := deps.Default.Gateway
 	channel := createNewTchannelForClient(deps, serviceName)
 	gateway.ClientTchannels[serviceName] = channel
-	gateway.ClientTchannelRouters[serviceName] = zanzibar.NewTChannelRouter(channel, gateway)
 
 	ip := deps.Default.Config.MustGetString("sidecarRouter.default.tchannel.ip")
 	port := deps.Default.Config.MustGetInt("sidecarRouter.default.tchannel.port")

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -120,7 +120,6 @@ func NewClient(deps *module.Dependencies) Client {
 		"Corge::echoString": "EchoString",
 	}
 	for _, method := range methodNames {
-		//todo we were asserting that the registering of methods happen in separate tchannels
 		fmt.Printf("For Client: corgeClient we are registering %v on the explicit client channel\n", method)
 	}
 

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -26,7 +26,6 @@ package corgeclient
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/textproto"
 	"strconv"
 	"strings"
@@ -119,9 +118,6 @@ func NewClient(deps *module.Dependencies) Client {
 	methodNames := map[string]string{
 		"Corge::echoString": "EchoString",
 	}
-	for _, method := range methodNames {
-		fmt.Printf("For Client: corgeClient we are registering %v on the explicit client channel\n", method)
-	}
 
 	qpsLevels := map[string]string{
 		"corge-EchoString": "default",
@@ -191,11 +187,9 @@ func createNewTchannelForClient(deps *module.Dependencies, serviceName string) *
 	})
 
 	if err != nil {
-		scope.Gauge("tchannel.client.running").Update(1)
-		scope.Gauge("tchannel.client.failed").Update(0)
-	} else {
 		scope.Gauge("tchannel.client.running").Update(0)
-		scope.Gauge("tchannel.client.failed").Update(1)
+	} else {
+		scope.Gauge("tchannel.client.running").Update(1)
 	}
 	return channel
 }

--- a/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -25,6 +25,7 @@ package bounceendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -67,6 +68,7 @@ type BounceBounceHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -69,7 +69,7 @@ type BounceBounceHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "Bounce::bounce".

--- a/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -25,7 +25,6 @@ package bounceendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -68,7 +67,6 @@ type BounceBounceHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -25,6 +25,7 @@ package baztchannelendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -74,8 +75,8 @@ type SimpleServiceCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceCallHandler) Register(g *zanzibar.Gateway) error {
-	serviceName := g.Config.MustGetString("clients.baz.serviceName")
-	return g.TchannelRouters[serviceName].Register(h.endpoint)
+	fmt.Printf("Register phase: In SimpleServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
+	return g.TChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::Call".

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -76,7 +76,7 @@ type SimpleServiceCallHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceCallHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In SimpleServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::Call".

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -25,7 +25,6 @@ package baztchannelendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -75,7 +74,6 @@ type SimpleServiceCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceCallHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In SimpleServiceCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -74,7 +74,8 @@ type SimpleServiceCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceCallHandler) Register(g *zanzibar.Gateway) error {
-	return g.TChannelRouter.Register(h.endpoint)
+	serviceName := g.Config.MustGetString("clients.baz.serviceName")
+	return g.TchannelRouters[serviceName].Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::Call".

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -69,7 +69,7 @@ type SimpleServiceEchoHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In SimpleServiceEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::Echo".

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -25,6 +25,7 @@ package baztchannelendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -67,6 +68,7 @@ type SimpleServiceEchoHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In SimpleServiceEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -25,7 +25,6 @@ package baztchannelendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -68,7 +67,6 @@ type SimpleServiceEchoHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In SimpleServiceEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -25,7 +25,6 @@ package echoendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -68,7 +67,6 @@ type EchoEchoHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *EchoEchoHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In EchoEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -25,6 +25,7 @@ package echoendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -67,6 +68,7 @@ type EchoEchoHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *EchoEchoHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In EchoEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -69,7 +69,7 @@ type EchoEchoHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *EchoEchoHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In EchoEchoHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "Echo::echo".

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -25,6 +25,7 @@ package panictchannelendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -68,6 +69,7 @@ type SimpleServiceAnotherCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceAnotherCallHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In SimpleServiceAnotherCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -70,7 +70,7 @@ type SimpleServiceAnotherCallHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceAnotherCallHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In SimpleServiceAnotherCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::AnotherCall".

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -25,7 +25,6 @@ package panictchannelendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"strings"
 	"time"
@@ -69,7 +68,6 @@ type SimpleServiceAnotherCallHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceAnotherCallHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In SimpleServiceAnotherCallHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
@@ -25,7 +25,6 @@ package quuxendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -68,7 +67,6 @@ type SimpleServiceEchoStringHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoStringHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In SimpleServiceEchoStringHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
@@ -25,6 +25,7 @@ package quuxendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -67,6 +68,7 @@ type SimpleServiceEchoStringHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoStringHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In SimpleServiceEchoStringHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
@@ -69,7 +69,7 @@ type SimpleServiceEchoStringHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *SimpleServiceEchoStringHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In SimpleServiceEchoStringHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "SimpleService::EchoString".

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
@@ -63,7 +63,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
@@ -63,7 +63,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
@@ -63,6 +63,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_init.go
@@ -63,7 +63,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.Channel,
+		server.ServerTchannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.Channel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/echo-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/services/echo-gateway/module/init.go
+++ b/examples/example-gateway/build/services/echo-gateway/module/init.go
@@ -84,7 +84,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/echo-gateway/module/init.go
+++ b/examples/example-gateway/build/services/echo-gateway/module/init.go
@@ -84,6 +84,7 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
+		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/echo-gateway/module/init.go
+++ b/examples/example-gateway/build/services/echo-gateway/module/init.go
@@ -76,15 +76,14 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:           g.Logger,
-		ContextExtractor: g.ContextExtractor,
-		ContextLogger:    g.ContextLogger,
-		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
-		Scope:            g.RootScope,
-		Tracer:           g.Tracer,
-		Config:           g.Config,
-		Channel:          g.Channel,
-
+		Logger:               g.Logger,
+		ContextExtractor:     g.ContextExtractor,
+		ContextLogger:        g.ContextLogger,
+		ContextMetrics:       zanzibar.NewContextMetrics(g.RootScope),
+		Scope:                g.RootScope,
+		Tracer:               g.Tracer,
+		Config:               g.Config,
+		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/echo-gateway/module/init.go
+++ b/examples/example-gateway/build/services/echo-gateway/module/init.go
@@ -83,6 +83,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,6 +97,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,7 +97,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,7 +97,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,7 +97,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.ServerTchannel,
+		Channel:              g.Channel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,7 +97,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		Channel:              g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_init.go
@@ -97,7 +97,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.Channel,
+		server.ServerTchannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.Channel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
+++ b/examples/example-gateway/build/services/example-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -124,15 +124,14 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:           g.Logger,
-		ContextExtractor: g.ContextExtractor,
-		ContextLogger:    g.ContextLogger,
-		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
-		Scope:            g.RootScope,
-		Tracer:           g.Tracer,
-		Config:           g.Config,
-		Channel:          g.Channel,
-
+		Logger:               g.Logger,
+		ContextExtractor:     g.ContextExtractor,
+		ContextLogger:        g.ContextLogger,
+		ContextMetrics:       zanzibar.NewContextMetrics(g.RootScope),
+		Scope:                g.RootScope,
+		Tracer:               g.Tracer,
+		Config:               g.Config,
+		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -132,7 +132,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -132,6 +132,7 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
+		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/example-gateway/build/services/example-gateway/module/init.go
+++ b/examples/example-gateway/build/services/example-gateway/module/init.go
@@ -131,6 +131,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -52,8 +52,9 @@ http.defaultHeaders:
 http.port: 7783
 http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /var/log/example-gateway/example-gateway.log
-logger.output: disk
+logger.output: stdout
 metrics.serviceName: example-gateway
+metrics.flushInterval: 10000
 metrics.m3.includeHost: true
 service.env.config: {}
 serviceName: example-gateway
@@ -68,6 +69,7 @@ sidecarRouter.default.tchannel.port: 5000
 tchannel.port: 7784
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
+subLoggerLevel.tchannel: debug
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
 useDatacenter: false
 clients.baz.alternates:

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -125,4 +125,4 @@ circuitbreaking-configurations:
       maxConcurrentRequests: 30
 
 service.shadow.env.override.enable: true
-dedicated.tchannel.client: true
+dedicated.tchannel.client: false

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -52,9 +52,8 @@ http.defaultHeaders:
 http.port: 7783
 http.clients.requestUUIDHeaderKey: x-request-uuid
 logger.fileName: /var/log/example-gateway/example-gateway.log
-logger.output: stdout
+logger.output: disk
 metrics.serviceName: example-gateway
-metrics.flushInterval: 10000
 metrics.m3.includeHost: true
 service.env.config: {}
 serviceName: example-gateway
@@ -69,7 +68,6 @@ sidecarRouter.default.tchannel.port: 5000
 tchannel.port: 7784
 tchannel.processName: example-gateway
 tchannel.serviceName: example-gateway
-subLoggerLevel.tchannel: debug
 tchannel.clients.requestUUIDHeaderKey: x-request-uuid
 useDatacenter: false
 clients.baz.alternates:
@@ -92,7 +90,7 @@ grpc.clientServiceNameMapping:
   echo: echo
 router.whitelistedPaths:
   - /path/whitelisted
-service.shadow.env.override.enable: true
+
 circuitbreaking-configurations:
   levels:
     '1': '0-99'
@@ -125,3 +123,5 @@ circuitbreaking-configurations:
       errorPercentThreshold: 30
       requestVolumeThreshold: 25
       maxConcurrentRequests: 30
+
+service.shadow.env.override.enable: true

--- a/examples/example-gateway/config/production.yaml
+++ b/examples/example-gateway/config/production.yaml
@@ -125,3 +125,4 @@ circuitbreaking-configurations:
       maxConcurrentRequests: 30
 
 service.shadow.env.override.enable: true
+dedicated.tchannel.client: true

--- a/examples/example-gateway/config/test.yaml
+++ b/examples/example-gateway/config/test.yaml
@@ -122,3 +122,4 @@ circuitbreaking-configurations:
       errorPercentThreshold: 30
       requestVolumeThreshold: 25
       maxConcurrentRequests: 30
+dedicated.tchannel.client: true

--- a/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -25,6 +25,7 @@ package bounceendpoint
 
 import (
 	"context"
+	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -61,6 +62,7 @@ type BounceBounceHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
+	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.TChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -63,7 +63,7 @@ type BounceBounceHandler struct {
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
 	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
-	return g.TChannelRouter.Register(h.endpoint)
+	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 
 // Handle handles RPC call of "Bounce::bounce".

--- a/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -25,7 +25,6 @@ package bounceendpoint
 
 import (
 	"context"
-	"fmt"
 	"runtime/debug"
 	"time"
 
@@ -62,7 +61,6 @@ type BounceBounceHandler struct {
 
 // Register adds the tchannel handler to the gateway's tchannel router
 func (h *BounceBounceHandler) Register(g *zanzibar.Gateway) error {
-	fmt.Printf("Register phase: In BounceBounceHandler using main server tchannel for [%v]\n", h.endpoint.Method)
 	return g.ServerTChannelRouter.Register(h.endpoint)
 }
 

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -37,8 +37,8 @@ import (
 
 // MockClientNodes contains mock client dependencies
 type MockClientNodes struct {
-	Echo   *echoclientgenerated.MockClientWithFixture
 	Mirror *mirrorclientgenerated.MockClient
+	Echo   *echoclientgenerated.MockClientWithFixture
 }
 
 // InitializeDependenciesMock fully initializes all dependencies in the dep tree
@@ -56,19 +56,20 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}
 
 	mockClientNodes := &MockClientNodes{
-		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
 		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
+		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
 	}
 	initializedClientDependencies := &module.ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Echo = mockClientNodes.Echo
 	initializedClientDependencies.Mirror = mockClientNodes.Mirror
+	initializedClientDependencies.Echo = mockClientNodes.Echo
 
 	initializedEndpointDependencies := &module.EndpointDependenciesNodes{}
 	tree.Endpoint = initializedEndpointDependencies

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -56,7 +56,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		Channel:              g.Channel,
+		ServerTChannel:       g.ServerTchannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -37,8 +37,8 @@ import (
 
 // MockClientNodes contains mock client dependencies
 type MockClientNodes struct {
-	Mirror *mirrorclientgenerated.MockClient
 	Echo   *echoclientgenerated.MockClientWithFixture
+	Mirror *mirrorclientgenerated.MockClient
 }
 
 // InitializeDependenciesMock fully initializes all dependencies in the dep tree
@@ -63,13 +63,13 @@ func InitializeDependenciesMock(
 	}
 
 	mockClientNodes := &MockClientNodes{
-		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
 		Echo:   echoclientgenerated.New(ctrl, fixtureechoclientgenerated.Fixture),
+		Mirror: mirrorclientgenerated.NewMockClient(ctrl),
 	}
 	initializedClientDependencies := &module.ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Mirror = mockClientNodes.Mirror
 	initializedClientDependencies.Echo = mockClientNodes.Echo
+	initializedClientDependencies.Mirror = mockClientNodes.Mirror
 
 	initializedEndpointDependencies := &module.EndpointDependenciesNodes{}
 	tree.Endpoint = initializedEndpointDependencies

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -56,7 +56,7 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTchannel,
+		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_init.go
@@ -56,7 +56,6 @@ func InitializeDependenciesMock(
 		Logger:               g.Logger,
 		Scope:                g.RootScope,
 		Config:               g.Config,
-		ServerTChannel:       g.ServerTChannel,
 		Tracer:               g.Tracer,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_service.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.Channel,
+		server.ServerTchannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.Channel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_service.go
+++ b/examples/selective-gateway/build/services/selective-gateway/mock-service/mock_service.go
@@ -121,7 +121,7 @@ func MustCreateTestService(t *testing.T, testConfigPaths ...string) MockService 
 	timeoutPerAttempt := time.Duration(1) * time.Minute
 
 	tchannelClient := zanzibar.NewRawTChannelClient(
-		server.ServerTchannel,
+		server.ServerTChannel,
 		server.ContextLogger,
 		server.RootScope,
 		&zanzibar.TChannelClientOption{
@@ -209,7 +209,7 @@ func (m *mockService) MakeTChannelRequest(
 		return false, nil, errors.New("mock server is not started")
 	}
 
-	sc := m.server.ServerTchannel.GetSubChannel(m.server.ServiceName)
+	sc := m.server.ServerTChannel.GetSubChannel(m.server.ServiceName)
 	sc.Peers().Add(m.server.RealTChannelAddr)
 	return m.tChannelClient.Call(ctx, thriftService, method, headers, req, res)
 }

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -42,8 +42,8 @@ type DependenciesTree struct {
 
 // ClientDependenciesNodes contains client dependencies
 type ClientDependenciesNodes struct {
-	Mirror mirrorclientgenerated.Client
 	Echo   echoclientgenerated.Client
+	Mirror mirrorclientgenerated.Client
 }
 
 // EndpointDependenciesNodes contains endpoint dependencies
@@ -67,16 +67,17 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
+		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}
 
 	initializedClientDependencies := &ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
+	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
+	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
 

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -67,7 +67,6 @@ func InitializeDependencies(
 		Tracer:               g.Tracer,
 		Config:               g.Config,
 		Gateway:              g,
-		ServerTChannel:       g.ServerTChannel,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -59,15 +59,14 @@ func InitializeDependencies(
 	tree := &DependenciesTree{}
 
 	initializedDefaultDependencies := &zanzibar.DefaultDependencies{
-		Logger:           g.Logger,
-		ContextExtractor: g.ContextExtractor,
-		ContextLogger:    g.ContextLogger,
-		ContextMetrics:   zanzibar.NewContextMetrics(g.RootScope),
-		Scope:            g.RootScope,
-		Tracer:           g.Tracer,
-		Config:           g.Config,
-		Channel:          g.Channel,
-
+		Logger:               g.Logger,
+		ContextExtractor:     g.ContextExtractor,
+		ContextLogger:        g.ContextLogger,
+		ContextMetrics:       zanzibar.NewContextMetrics(g.RootScope),
+		Scope:                g.RootScope,
+		Tracer:               g.Tracer,
+		Config:               g.Config,
+		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
 	}

--- a/examples/selective-gateway/build/services/selective-gateway/module/init.go
+++ b/examples/selective-gateway/build/services/selective-gateway/module/init.go
@@ -42,8 +42,8 @@ type DependenciesTree struct {
 
 // ClientDependenciesNodes contains client dependencies
 type ClientDependenciesNodes struct {
-	Echo   echoclientgenerated.Client
 	Mirror mirrorclientgenerated.Client
+	Echo   echoclientgenerated.Client
 }
 
 // EndpointDependenciesNodes contains endpoint dependencies
@@ -66,6 +66,7 @@ func InitializeDependencies(
 		Scope:                g.RootScope,
 		Tracer:               g.Tracer,
 		Config:               g.Config,
+		ServerTChannel:       g.ServerTChannel,
 		Gateway:              g,
 		GRPCClientDispatcher: g.GRPCClientDispatcher,
 		JSONWrapper:          g.JSONWrapper,
@@ -73,10 +74,10 @@ func InitializeDependencies(
 
 	initializedClientDependencies := &ClientDependenciesNodes{}
 	tree.Client = initializedClientDependencies
-	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
+	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
-	initializedClientDependencies.Mirror = mirrorclientgenerated.NewClient(&mirrorclientmodule.Dependencies{
+	initializedClientDependencies.Echo = echoclientgenerated.NewClient(&echoclientmodule.Dependencies{
 		Default: initializedDefaultDependencies,
 	})
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -833,7 +833,7 @@ func (gateway *Gateway) setupServerTChannel(config *StaticConfig) error {
 // from the generated clients if "dedicated.tchannel.client: true"
 func (gateway *Gateway) SetupClientTChannel(config *StaticConfig, serviceName string) *tchannel.Channel {
 	if ch, ok := gateway.ClientTChannels[serviceName]; ok {
-		gateway.Logger.Info(fmt.Sprintf("Returning already initialised TChannel client for [%v]", serviceName))
+		gateway.Logger.Info(fmt.Sprintf("returning already initialised TChannel client for [%v]", serviceName))
 		return ch
 	}
 	processName := config.MustGetString("tchannel.processName")
@@ -853,6 +853,7 @@ func (gateway *Gateway) SetupClientTChannel(config *StaticConfig, serviceName st
 	})
 	if err != nil {
 		scope.Gauge("tchannel.client.running").Update(0)
+		gateway.Logger.Info(fmt.Sprintf("failed to initialise TChannel client for [%v]", serviceName))
 	} else {
 		scope.Gauge("tchannel.client.running").Update(1)
 	}

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -426,7 +426,7 @@ func (gateway *Gateway) Shutdown() {
 	go func() {
 		defer swg.Done()
 		if err := gateway.shutdownTChannelServerAndClients(ctx); err != nil {
-			ec <- errors.Wrap(err, "error shutting down tchannel server")
+			ec <- errors.Wrap(err, "error shutting down tchannel server or clients")
 		}
 	}()
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -147,8 +147,7 @@ type DefaultDependencies struct {
 	Tracer         opentracing.Tracer
 	Config         *StaticConfig
 	ServerTChannel *tchannel.Channel
-	//todo we had to add gateway here, see if there's a way around
-	Gateway *Gateway
+	Gateway        *Gateway
 
 	// dispatcher for managing gRPC clients
 	GRPCClientDispatcher *yarpc.Dispatcher
@@ -927,7 +926,6 @@ func (gateway *Gateway) shutdownTChannelServer(ctx context.Context) error {
 		scope := gateway.RootScope.Tagged(map[string]string{
 			"client": serviceName,
 		})
-		scope.Gauge("tchannel.client.closed").Update(1)
 		scope.Gauge("tchannel.client.running").Update(0)
 		scope.Gauge("tchannel.client.failed").Update(0)
 	}

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -141,11 +141,12 @@ type DefaultDependencies struct {
 	// ContextMetrics emit metrics from context
 	ContextMetrics ContextMetrics
 
-	Logger  *zap.Logger
-	Scope   tally.Scope
-	Tracer  opentracing.Tracer
-	Config  *StaticConfig
-	Gateway *Gateway
+	Logger         *zap.Logger
+	Scope          tally.Scope
+	Tracer         opentracing.Tracer
+	Config         *StaticConfig
+	ServerTChannel *tchannel.Channel
+	Gateway        *Gateway
 
 	// dispatcher for managing gRPC clients
 	GRPCClientDispatcher *yarpc.Dispatcher

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -927,7 +927,6 @@ func (gateway *Gateway) shutdownTChannelServerAndClients(ctx context.Context) er
 			"client": serviceName,
 		})
 		scope.Gauge("tchannel.client.running").Update(0)
-		scope.Gauge("tchannel.client.failed").Update(0)
 	}
 	gateway.tchannelServer.Close()
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -96,8 +96,8 @@ type Gateway struct {
 	RealTChannelPort       int32
 	RealTChannelAddr       string
 	WaitGroup              *sync.WaitGroup
-	ServerTchannel         *tchannel.Channel
-	ClientTchannels        map[string]*tchannel.Channel
+	ServerTChannel         *tchannel.Channel
+	ClientTChannels        map[string]*tchannel.Channel
 	ContextLogger          ContextLogger
 	ContextMetrics         ContextMetrics
 	ContextExtractor       ContextExtractor
@@ -107,7 +107,7 @@ type Gateway struct {
 	Config                 *StaticConfig
 	HTTPRouter             HTTPRouter
 	ServerTChannelRouter   *TChannelRouter
-	TchannelSubLoggerLevel zapcore.Level
+	TChannelSubLoggerLevel zapcore.Level
 	Tracer                 opentracing.Tracer
 	JSONWrapper            jsonwrapper.JSONWrapper
 
@@ -803,7 +803,7 @@ func (gateway *Gateway) setupTChannel(config *StaticConfig) error {
 	if !ok {
 		return errors.Errorf("unknown sub logger level for tchannel server: %s", levelString)
 	}
-	gateway.TchannelSubLoggerLevel = level
+	gateway.TChannelSubLoggerLevel = level
 
 	channel, err := tchannel.NewChannel(
 		serviceName,
@@ -820,11 +820,11 @@ func (gateway *Gateway) setupTChannel(config *StaticConfig) error {
 		return errors.Errorf("Error creating top channel:\n%s", err)
 	}
 
-	gateway.ServerTchannel = channel
-	gateway.tchannelServer = gateway.ServerTchannel
+	gateway.ServerTChannel = channel
+	gateway.tchannelServer = gateway.ServerTChannel
 	gateway.ServerTChannelRouter = NewTChannelRouter(channel, gateway)
 	// client tchannels are created explicitly for each client
-	gateway.ClientTchannels = make(map[string]*tchannel.Channel)
+	gateway.ClientTChannels = make(map[string]*tchannel.Channel)
 	return nil
 }
 
@@ -917,7 +917,7 @@ func (gateway *Gateway) shutdownTChannelServerAndClients(ctx context.Context) er
 	ticker := time.NewTicker(shutdownPollInterval)
 	defer ticker.Stop()
 
-	for serviceName, serviceTchannel := range gateway.ClientTchannels {
+	for serviceName, serviceTchannel := range gateway.ClientTChannels {
 		gateway.Logger.Info(fmt.Sprintf("Closing tchannel client for [%v]", serviceName))
 		serviceTchannel.Close()
 		scope := gateway.RootScope.Tagged(map[string]string{

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -142,11 +142,11 @@ type DefaultDependencies struct {
 	// ContextMetrics emit metrics from context
 	ContextMetrics ContextMetrics
 
-	Logger *zap.Logger
-	Scope  tally.Scope
-	Tracer opentracing.Tracer
-	Config *StaticConfig
-
+	Logger         *zap.Logger
+	Scope          tally.Scope
+	Tracer         opentracing.Tracer
+	Config         *StaticConfig
+	ServerTChannel *tchannel.Channel
 	//todo we had to add gateway here, see if there's a way around
 	Gateway *Gateway
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -97,6 +97,7 @@ type Gateway struct {
 	RealTChannelAddr string
 	WaitGroup        *sync.WaitGroup
 	//todo remove this..but this is being used in bench/mock init :(
+	//todo lets rename this...
 	Channel          *tchannel.Channel
 	TchannelChannels map[string]*tchannel.Channel
 	ContextLogger    ContextLogger

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -107,7 +107,6 @@ type Gateway struct {
 	Config                 *StaticConfig
 	HTTPRouter             HTTPRouter
 	ServerTChannelRouter   *TChannelRouter
-	ClientTchannelRouters  map[string]*TChannelRouter
 	TchannelSubLoggerLevel zapcore.Level
 	Tracer                 opentracing.Tracer
 	JSONWrapper            jsonwrapper.JSONWrapper
@@ -824,10 +823,8 @@ func (gateway *Gateway) setupTChannel(config *StaticConfig) error {
 	gateway.ServerTchannel = channel
 	gateway.tchannelServer = gateway.ServerTchannel
 	gateway.ServerTChannelRouter = NewTChannelRouter(channel, gateway)
-	// client tchannels and router are created explicitly for each client
+	// client tchannels are created explicitly for each client
 	gateway.ClientTchannels = make(map[string]*tchannel.Channel)
-	gateway.ClientTchannelRouters = make(map[string]*TChannelRouter)
-
 	return nil
 }
 

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -141,12 +141,11 @@ type DefaultDependencies struct {
 	// ContextMetrics emit metrics from context
 	ContextMetrics ContextMetrics
 
-	Logger         *zap.Logger
-	Scope          tally.Scope
-	Tracer         opentracing.Tracer
-	Config         *StaticConfig
-	ServerTChannel *tchannel.Channel
-	Gateway        *Gateway
+	Logger  *zap.Logger
+	Scope   tally.Scope
+	Tracer  opentracing.Tracer
+	Config  *StaticConfig
+	Gateway *Gateway
 
 	// dispatcher for managing gRPC clients
 	GRPCClientDispatcher *yarpc.Dispatcher

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -426,7 +426,7 @@ func (gateway *Gateway) Shutdown() {
 	swg.Add(1)
 	go func() {
 		defer swg.Done()
-		if err := gateway.shutdownTChannelServer(ctx); err != nil {
+		if err := gateway.shutdownTChannelServerAndClients(ctx); err != nil {
 			ec <- errors.Wrap(err, "error shutting down tchannel server")
 		}
 	}()
@@ -909,10 +909,10 @@ func GetHostname() string {
 	return host
 }
 
-// shutdownTChannelServer gracefully shuts down the tchannel server, blocks until the shutdown is
+// shutdownTChannelServerAndClients gracefully shuts down the tchannel server, blocks until the shutdown is
 // complete or the timeout has reached if there is one associated with the given context
 // It also shuts down all the dedicated client tchannel connections on a best effort basis
-func (gateway *Gateway) shutdownTChannelServer(ctx context.Context) error {
+func (gateway *Gateway) shutdownTChannelServerAndClients(ctx context.Context) error {
 	shutdownPollInterval := defaultShutdownPollInterval
 	if gateway.Config.ContainsKey("shutdown.pollInterval") {
 		shutdownPollInterval = time.Duration(gateway.Config.MustGetInt("shutdown.pollInterval")) * time.Millisecond

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -921,7 +921,6 @@ func (gateway *Gateway) shutdownTChannelServer(ctx context.Context) error {
 	ticker := time.NewTicker(shutdownPollInterval)
 	defer ticker.Stop()
 
-	gateway.tchannelServer.Close()
 	for serviceName, serviceTchannel := range gateway.ClientTchannels {
 		gateway.Logger.Info(fmt.Sprintf("Closing tchannel client for [%v]", serviceName))
 		serviceTchannel.Close()
@@ -932,6 +931,7 @@ func (gateway *Gateway) shutdownTChannelServer(ctx context.Context) error {
 		scope.Gauge("tchannel.client.running").Update(0)
 		scope.Gauge("tchannel.client.failed").Update(0)
 	}
+	gateway.tchannelServer.Close()
 
 	for {
 		select {

--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -21,8 +21,13 @@
 package zanzibar
 
 import (
+	"context"
 	"os"
 	"testing"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/uber/tchannel-go"
 
 	"github.com/uber-go/tally"
 	"github.com/uber/zanzibar/runtime/jsonwrapper"
@@ -118,8 +123,80 @@ func TestCreateGatewayBadLoggingConfig(t *testing.T) {
 	g := Gateway{
 		Config: cfg,
 	}
-
 	err := g.setupLogger(cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown log level for gateway logger: invalid")
+}
+
+func TestGatewaySetupClientTChannelWhenServiceNameAlreadyExists(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{})
+	g := Gateway{
+		ClientTChannels: map[string]*tchannel.Channel{
+			"service-foo": {},
+		},
+		Logger: zap.NewNop(),
+	}
+	ch := g.SetupClientTChannel(cfg, "service-foo")
+	assert.Equal(t, ch, &tchannel.Channel{})
+}
+
+func TestGatewaySetupClientTChannel(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
+		"tchannel.processName": "test-proc",
+	})
+	g := Gateway{
+		TChannelSubLoggerLevel: zapcore.ErrorLevel,
+		RootScope:              tally.NoopScope,
+		ClientTChannels:        map[string]*tchannel.Channel{},
+		Logger:                 zap.NewNop(),
+		logEncoder:             zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+	}
+
+	ch := g.SetupClientTChannel(cfg, "service-foo")
+	assert.Equal(t, ch, g.ClientTChannels["service-foo"])
+	assert.NotEqual(t, ch, &tchannel.Channel{})
+
+	gauge := g.RootScope.Tagged(map[string]string{
+		"client": "service-foo",
+	}).Gauge("tchannel.client.running")
+	assert.NotNil(t, gauge)
+}
+
+func TestGatewaySetupServerTChannelThrowsErrorWhenLoggerLevelIsIncorrect(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
+		"tchannel.serviceName":    "test-gateway",
+		"tchannel.processName":    "proc",
+		"subLoggerLevel.tchannel": "non-compliant",
+	})
+	g := Gateway{
+		Config: cfg,
+	}
+	err := g.setupServerTChannel(cfg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown sub logger level for tchannel server: non-compliant")
+}
+
+func TestGatewaySetupServerTChannelWithShutdown(t *testing.T) {
+	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
+		"tchannel.serviceName":    "test-gateway",
+		"tchannel.processName":    "proc",
+		"subLoggerLevel.tchannel": "error",
+	})
+	g := Gateway{
+		Config:     cfg,
+		Logger:     zap.NewNop(),
+		logEncoder: zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+	}
+	err := g.setupServerTChannel(cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, g.ServerTChannel)
+	assert.NotNil(t, g.ClientTChannels)
+	assert.False(t, g.tchannelServer.Closed())
+	assert.NotNil(t, g.ServerTChannelRouter)
+	assert.Equal(t, g.tchannelServer, g.ServerTChannel)
+
+	// now shut down the tchannel server
+	err = g.shutdownTChannelServerAndClients(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, g.tchannelServer.Closed())
 }

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -22,6 +22,7 @@ package zanzibar
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -150,6 +151,7 @@ func (c *TChannelClient) Call(
 	reqHeaders map[string]string,
 	req, resp RWTStruct,
 ) (success bool, resHeaders map[string]string, err error) {
+	fmt.Printf("\n **********************Hello Edge, Zanzibar Call called on [%v] %v******************", c.ClientID, c.ch)
 	serviceMethod := thriftService + "::" + methodName
 	scopeTags := map[string]string{
 		scopeTagClient:          c.ClientID,
@@ -262,7 +264,7 @@ func (c *TChannelClient) call(
 	return call.success, call.resHeaders, err
 }
 
-// first rule match, would be the choosen channel. if nothing matches fallback to default channel
+// first rule match, would be the chosen channel. if nothing matches fallback to default channel
 func (c *TChannelClient) getDynamicChannelWithFallback(reqHeaders map[string]string,
 	sc *tchannel.SubChannel, ctx netContext.Context) (*tchannel.SubChannel, netContext.Context) {
 	ch := sc

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -150,7 +150,6 @@ func (c *TChannelClient) Call(
 	reqHeaders map[string]string,
 	req, resp RWTStruct,
 ) (success bool, resHeaders map[string]string, err error) {
-	//fmt.Printf("\n **********************Hello Edge, Zanzibar Call called on [%v] %v******************", c.ClientID, c.ch)
 	serviceMethod := thriftService + "::" + methodName
 	scopeTags := map[string]string{
 		scopeTagClient:          c.ClientID,

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -22,7 +22,6 @@ package zanzibar
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -151,7 +150,7 @@ func (c *TChannelClient) Call(
 	reqHeaders map[string]string,
 	req, resp RWTStruct,
 ) (success bool, resHeaders map[string]string, err error) {
-	fmt.Printf("\n **********************Hello Edge, Zanzibar Call called on [%v] %v******************", c.ClientID, c.ch)
+	//fmt.Printf("\n **********************Hello Edge, Zanzibar Call called on [%v] %v******************", c.ClientID, c.ch)
 	serviceMethod := thriftService + "::" + methodName
 	scopeTags := map[string]string{
 		scopeTagClient:          c.ClientID,

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -62,7 +62,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 14
+	numMetrics := 13
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -62,7 +62,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 12
+	numMetrics := 14
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -168,7 +168,7 @@ func TestCallMetrics(t *testing.T) {
 	tchannelTags := map[string]string{
 		"env":             "test",
 		"app":             "test-gateway",
-		"service":         "test-gateway",
+		"service":         "bazService",
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
 		"host":            zanzibar.GetHostname(),

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -78,7 +78,7 @@ func TestCallMetrics(t *testing.T) {
 	headers["device"] = "ios"
 	headers["deviceversion"] = "carbon"
 
-	numMetrics := 15
+	numMetrics := 14
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	_, err = gateway.MakeRequest(

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -78,7 +78,7 @@ func TestCallMetrics(t *testing.T) {
 	headers["device"] = "ios"
 	headers["deviceversion"] = "carbon"
 
-	numMetrics := 13
+	numMetrics := 15
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	_, err = gateway.MakeRequest(

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -22,7 +22,6 @@ package baztchannel
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -177,7 +176,6 @@ func TestCallMetrics(t *testing.T) {
 
 	for _, name := range tchannelOutboundNames {
 		key := tally.KeyForPrefixedStringMap(name, tchannelOutboundTags)
-		fmt.Println("Key aayi:", key)
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -169,7 +169,7 @@ func TestCallMetrics(t *testing.T) {
 		// this host tag is added by tchannel library, which we don't have control with
 		"host":            zanzibar.GetHostname(),
 		"env":             "test",
-		"service":         "test-gateway",
+		"service":         "bazService",
 		"target-endpoint": "SimpleService__call",
 		"target-service":  "bazService",
 		"dc":              "unknown",

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -22,6 +22,7 @@ package baztchannel
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -76,7 +77,7 @@ func TestCallMetrics(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	numMetrics := 12
+	numMetrics := 11
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	ctx := context.Background()
@@ -176,6 +177,7 @@ func TestCallMetrics(t *testing.T) {
 
 	for _, name := range tchannelOutboundNames {
 		key := tally.KeyForPrefixedStringMap(name, tchannelOutboundTags)
+		fmt.Println("Key aayi:", key)
 		assert.Contains(t, metrics, key, "expected metric: %s", key)
 	}
 

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -76,7 +76,7 @@ func TestCallMetrics(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	numMetrics := 10
+	numMetrics := 12
 	cg.MetricsWaitGroup.Add(numMetrics)
 
 	ctx := context.Background()

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -114,7 +114,7 @@ func TestHealthMetrics(t *testing.T) {
 	defer gateway.Close()
 
 	cgateway := gateway.(*testGateway.ChildProcessGateway)
-	numMetrics := 9
+	numMetrics := 11
 	cgateway.MetricsWaitGroup.Add(numMetrics)
 
 	headers := make(map[string]string)

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -163,7 +163,7 @@ func CreateGateway(
 	}
 
 	benchGateway.tchannelClient = zanzibar.NewTChannelClient(
-		gateway.ServerTchannel,
+		gateway.ServerTChannel,
 		gateway.ContextLogger,
 		gateway.RootScope,
 		gateway.ContextExtractor,
@@ -317,7 +317,7 @@ func (gateway *BenchGateway) MakeTChannelRequest(
 	headers map[string]string,
 	req, res zanzibar.RWTStruct,
 ) (bool, map[string]string, error) {
-	sc := gateway.ActualGateway.ServerTchannel.GetSubChannel(gateway.ActualGateway.ServiceName)
+	sc := gateway.ActualGateway.ServerTChannel.GetSubChannel(gateway.ActualGateway.ServiceName)
 	sc.Peers().Add(gateway.ActualGateway.RealTChannelAddr)
 
 	return gateway.tchannelClient.Call(ctx, thriftService, method, headers, req, res)

--- a/test/lib/bench_gateway/bench_gateway.go
+++ b/test/lib/bench_gateway/bench_gateway.go
@@ -163,7 +163,7 @@ func CreateGateway(
 	}
 
 	benchGateway.tchannelClient = zanzibar.NewTChannelClient(
-		gateway.Channel,
+		gateway.ServerTchannel,
 		gateway.ContextLogger,
 		gateway.RootScope,
 		gateway.ContextExtractor,
@@ -317,7 +317,7 @@ func (gateway *BenchGateway) MakeTChannelRequest(
 	headers map[string]string,
 	req, res zanzibar.RWTStruct,
 ) (bool, map[string]string, error) {
-	sc := gateway.ActualGateway.Channel.GetSubChannel(gateway.ActualGateway.ServiceName)
+	sc := gateway.ActualGateway.ServerTchannel.GetSubChannel(gateway.ActualGateway.ServiceName)
 	sc.Peers().Add(gateway.ActualGateway.RealTChannelAddr)
 
 	return gateway.tchannelClient.Call(ctx, thriftService, method, headers, req, res)

--- a/test/lib/test_backend/test_tchannel_backend.go
+++ b/test/lib/test_backend/test_tchannel_backend.go
@@ -35,7 +35,7 @@ import (
 	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
-// TestTChannelBackend will pretend to be a http backend
+// TestTChannelBackend will pretend to be a tchannel backend
 type TestTChannelBackend struct {
 	Channel     *tchannel.Channel
 	Router      *zanzibar.TChannelRouter

--- a/test/lib/test_gateway/test_gateway_process.go
+++ b/test/lib/test_gateway/test_gateway_process.go
@@ -42,13 +42,13 @@ var realTChannelAddrRegex = regexp.MustCompile(
 
 var infoIgnoreList = map[string]bool{
 	"Outbound connection is active.":            true,
-	"Channel.Close called.":                     true,
+	"ServerTchannel.Close called.":              true,
 	"Connection.Close called.":                  true,
 	"Connection state updated in Close.":        true,
 	"Connection state updated during shutdown.": true,
 	"Removed peer from root peer list.":         true,
 	"Inbound connection is active.":             true,
-	"Channel closed.":                           true,
+	"ServerTchannel closed.":                    true,
 }
 
 // MalformedStdoutError is used when the child process has unexpected stdout

--- a/test/lib/test_gateway/test_gateway_process.go
+++ b/test/lib/test_gateway/test_gateway_process.go
@@ -42,13 +42,13 @@ var realTChannelAddrRegex = regexp.MustCompile(
 
 var infoIgnoreList = map[string]bool{
 	"Outbound connection is active.":            true,
-	"ServerTchannel.Close called.":              true,
+	"Channel.Close called.":                     true,
 	"Connection.Close called.":                  true,
 	"Connection state updated in Close.":        true,
 	"Connection state updated during shutdown.": true,
 	"Removed peer from root peer list.":         true,
 	"Inbound connection is active.":             true,
-	"ServerTchannel closed.":                    true,
+	"Channel closed.":                           true,
 }
 
 // MalformedStdoutError is used when the child process has unexpected stdout


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Feature | High |

Internal JIRA: https://t3.uberinternal.com/browse/EDGE-326 (ERD attached in the ticket)

## Release 1.0.0 - 2021-08-05
### Changed
- **BREAKING** `gateway.Channel` has been renamed to `gateway.ServerTChannel` to distinguish between client and server TChannels.


- **BREAKING** `gateway.TChannelRouter` has been renamed to `gateway.ServerTChannelRouter`

### Added
- A new boolean flag `dedicated.tchannel.client` is introduced. When set to `true`, each TChannel client creates a dedicated connection instead of registering on the default shared server connection.
Clients need not do anything as the default behaviour is to use a shared connection.([#778](https://github.com/uber/zanzibar/pull/778))


- A new field has been added to the gateway to propagate the `TChannelSubLoggerLevel` for clients with dedicated connections.

---

## Reviewer Notes
- Only 6-7 files need a review. Rest are generated / tests
- Estimated time to review: 20 mins given that you've read the internal ERD :)

## Description
This PR adds / changes the following

- Changes the way Edge `TChannel` Clients connect with the sidecar. Instead of using a common gateway channel and router, we create dedicated channels for each client. This is done based on the flag `dedicated.tchannel.client: true`
![image](https://user-images.githubusercontent.com/12872673/128399975-24509c4d-41fc-4aaa-862b-2d658ec6a71b.png)

- Shutdown hooks now include the shutdown for clients in a separate goroutine.
- Refactor existing gateway channel and router to more readable names
- **Does not** change templates for tchannel endpoints. They still get registered on the common server router. Only clients get new routers.
- Fixes some formatting consistencies and typos.


## Motivation & Context
- Current TChannel clients speak like below
![image](https://user-images.githubusercontent.com/12872673/128399876-330b6703-9b56-44e1-936a-381d587f2298.png)

- Maintaining a dedicated connection ensures that in the event of a misbehaving downstream, requests to other “healthy” tchannel clients do not time out. Only the backlog requests in the queue for the unhealthy service would be affected if the timeout expires. This leads to a more fault tolerant request layer in Edge. As a Tier 0 service, this offers significant platform stability.

- Since each queue would be separate and multiple router-sidecar goroutines would be reading requests in parallel, we expect good improvements in request latency.

- Slight although insignificant improvements may be seen in CPU (more utilization) and memory (reduced pressure of requests in the queue).

## How was this tested?
Tested this version of Zanzibar in Uber's Edge Gateway and verifying that 
- Multiple tchannel clients in Edge get their own channels and are able to make RPCs
- Statsd metrics are emitted
```
tchannel.client.running+client=bazService,dc=unknown,env=test,service=test-gateway
      Value:v2.MetricValue{MetricType:2, Count:0, Gauge:1, Timer:0},..., 
```
- Shutdown hooks are called


Tested that conditional client generation works and when `dedicated.tchannel.client: false | nil`, the existing behaviour remains true




## Benchmarks


**Verdict:** No considerable change in op/sec. Zero change in memory allocs

### Branch
```

========

Branch
time -p sh -c "go test -run _NONE_ -bench . -benchmem -benchtime 7s -cpu 2 ./test/... | grep -v '^ok ' | grep -v '\[no test files\]' | grep -v '^PASS'"
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
  108061	     67386 ns/op	   21593 B/op	     165 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/baz
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   36069	    232823 ns/op	   85245 B/op	     716 allocs/op
   36259	    229871 ns/op	   80946 B/op	     713 allocs/op
   39594	    213469 ns/op	   74620 B/op	     671 allocs/op
   38223	    213605 ns/op	   74171 B/op	     657 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/contacts
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   42102	    190982 ns/op	   73774 B/op	     559 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/googlenow
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   52650	    155615 ns/op	   63501 B/op	     441 allocs/op
real 96.87
user 121.16
sys 39.36
========
````

### Master

```
========
time -p sh -c "go test -run _NONE_ -bench . -benchmem -benchtime 7s -cpu 2 ./test/... | grep -v '^ok ' | grep -v '\[no test files\]' | grep -v '^PASS'"
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
  126316	     56844 ns/op	   21978 B/op	     165 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/baz
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   35053	    228300 ns/op	   88222 B/op	     716 allocs/op
   36102	    226970 ns/op	   83794 B/op	     713 allocs/op
   39868	    213884 ns/op	   76952 B/op	     671 allocs/op
   39051	    214590 ns/op	   76357 B/op	     657 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/contacts
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   42651	    195224 ns/op	   78067 B/op	     559 allocs/op
goos: darwin
goarch: amd64
pkg: github.com/uber/zanzibar/test/endpoints/googlenow
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
   51500	    151183 ns/op	   60568 B/op	     441 allocs/op
real 98.17
user 129.94
sys 42.91
========
```

