### PR TITLE
Set proper service context in client tchannels

### DIFF
--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -143,6 +143,7 @@ func TestGatewaySetupClientTChannelWhenServiceNameAlreadyExists(t *testing.T) {
 func TestGatewaySetupClientTChannel(t *testing.T) {
 	cfg := NewStaticConfigOrDie(nil, map[string]interface{}{
 		"tchannel.processName": "test-proc",
+		"tchannel.serviceName": "test-gateway",
 	})
 	g := Gateway{
 		TChannelSubLoggerLevel: zapcore.ErrorLevel,

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -168,7 +168,7 @@ func TestCallMetrics(t *testing.T) {
 	tchannelTags := map[string]string{
 		"env":             "test",
 		"app":             "test-gateway",
-		"service":         "bazService",
+		"service":         "test-gateway",
 		"target-service":  "bazService",
 		"target-endpoint": "SimpleService__call",
 		"host":            zanzibar.GetHostname(),

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -168,7 +168,7 @@ func TestCallMetrics(t *testing.T) {
 		// this host tag is added by tchannel library, which we don't have control with
 		"host":            zanzibar.GetHostname(),
 		"env":             "test",
-		"service":         "bazService",
+		"service":         "test-gateway",
 		"target-endpoint": "SimpleService__call",
 		"target-service":  "bazService",
 		"dc":              "unknown",


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Bug | High |


## Description
- Set tchannel service name to be the same as server (gateway) name
- Add another helpful log to be tracked in ELK when the channel is created successfully

## Motivation 
- The newly initiated channels as part of #778 were passed a service name of their client-id while in essence they should use the same service name as the gateway. This is because even though there are dedicated channels now, they still need to talk to the routing sidecar as one unit 

- When we landed #778 some backends that had ACL enabled had their requests outright rejected by the sidecar router.
![image](https://user-images.githubusercontent.com/12872673/129969570-6bcd01ba-807b-4654-b502-6afc43dfd8b4.png)

---

## How was this tested?
- Tested in local that the new client channels are now passed the same value as of the server


## Benchmarks
- N/A
