### PR TITLE
Fix errcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ lint: check-licence eclint-check
 	@go get golang.org/x/lint/golint
 	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
 	@echo "Checking errcheck..."
-	@go run vendor/github.com/kisielk/errchek/main.go $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
+	@go run vendor/github.com/kisielk/errcheck/main.go $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
 	@echo "Checking staticcheck..."
 	@go build -o vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck.go
 	@./vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -705,7 +705,7 @@ func newTChannelClientGenerator(templates *Template, packageHelper *PackageHelpe
 
 func getExposedMethodValidator() *validator2.Validator {
 	validator := validator2.NewValidator()
-	validator.SetValidationFunc("exposedMethods", validateExposedMethods)
+	_ = validator.SetValidationFunc("exposedMethods", validateExposedMethods)
 	return validator
 }
 

--- a/codegen/service_test.go
+++ b/codegen/service_test.go
@@ -51,7 +51,10 @@ func TestProtoModuleSpec(t *testing.T) {
 func TestProtoModuleSpecParseError(t *testing.T) {
 	tmpFile, err := ioutil.TempFile("../examples/example-gateway/idl/clients-idl/clients/", "temp*.proto")
 	assert.NoError(t, err, "failed to create temp file")
-	defer os.Remove(tmpFile.Name())
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(tmpFile.Name())
+
 	_, err = tmpFile.WriteString("test")
 	assert.NoError(t, err, "failed writing to temp file")
 

--- a/examples/example-gateway/endpoints/panic/endpoint_panic_test.go
+++ b/examples/example-gateway/endpoints/panic/endpoint_panic_test.go
@@ -23,7 +23,7 @@ func TestServiceCFrontHello(t *testing.T) {
 	}
 
 	buf := new(bytes.Buffer)
-	buf.ReadFrom(res.Body)
+	_, _ = buf.ReadFrom(res.Body)
 	assert.True(t, strings.Contains(buf.String(), "Unexpected workflow panic, recovered at endpoint."))
 	assert.Equal(t, "502 Bad Gateway", res.Status)
 }

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -368,7 +368,7 @@ func (gateway *Gateway) registerPredefined() {
 		"health", "health",
 		gateway.handleHealthRequest,
 	)
-	gateway.HTTPRouter.Handle("GET", "/health", http.HandlerFunc(tracer.HandleRequest))
+	_ = gateway.HTTPRouter.Handle("GET", "/health", http.HandlerFunc(tracer.HandleRequest))
 }
 
 func (gateway *Gateway) handleHealthRequest(

--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -59,15 +59,15 @@ func (s *routerSuite) SetupTest() {
 
 func (s *routerSuite) TestRouter() {
 	err := s.router.Handle("GET", "/noslash", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("noslash\n"))
+		_, _ = w.Write([]byte("noslash\n"))
 	}))
 	s.NoError(err)
 	err = s.router.Handle("GET", "/withslash/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("withslash\n"))
+		_, _ = w.Write([]byte("withslash\n"))
 	}))
 	s.NoError(err)
 	err = s.router.Handle("POST", "/postonly", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("postonly\n"))
+		_, _ = w.Write([]byte("postonly\n"))
 	}))
 	s.NoError(err)
 	err = s.router.Handle("GET", "/panicerror", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -120,12 +120,12 @@ func (s *routerSuite) TestExtractParameters() {
 
 func (s *routerSuite) TestRouteConflict() {
 	err := s.router.Handle("GET", "/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("foo1\n"))
+		_, _ = w.Write([]byte("foo1\n"))
 	}))
 	s.NoError(err)
 
 	err = s.router.Handle("GET", "/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("foo2\n"))
+		_, _ = w.Write([]byte("foo2\n"))
 	}))
 	s.Error(err)
 
@@ -141,12 +141,12 @@ func (s *routerSuite) TestRouteConflict() {
 
 func (s *routerSuite) TestRouteConflictVariable() {
 	err := s.router.Handle("GET", "/foo/:a", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("foo a\n"))
+		_, _ = w.Write([]byte("foo a\n"))
 	}))
 	s.NoError(err)
 
 	err = s.router.Handle("GET", "/foo/:b", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("foo b\n"))
+		_, _ = w.Write([]byte("foo b\n"))
 	}))
 	s.Error(err)
 

--- a/test/config/config_test.go
+++ b/test/config/config_test.go
@@ -37,13 +37,17 @@ const (
 
 func TestNewRuntimeConfigOrDie(t *testing.T) {
 	httpPortValue := os.Getenv(uberPortHTTPEnv)
-	defer os.Setenv(uberPortHTTPEnv, httpPortValue)
+	defer func(key, value string) {
+		_ = os.Setenv(key, value)
+	}(uberPortHTTPEnv, httpPortValue)
 
 	tchannelPortValue := os.Getenv(uberPortTChannelEnv)
-	defer os.Setenv(uberPortTChannelEnv, tchannelPortValue)
+	defer func(key, value string) {
+		_ = os.Setenv(key, value)
+	}(uberPortTChannelEnv, tchannelPortValue)
 
-	os.Setenv(uberPortHTTPEnv, "1111")
-	os.Setenv(uberPortTChannelEnv, "2222")
+	_ = os.Setenv(uberPortHTTPEnv, "1111")
+	_ = os.Setenv(uberPortTChannelEnv, "2222")
 	cfg := config.NewRuntimeConfigOrDie([]string{"test.yaml"}, nil)
 
 	assert.Equal(t, "my-gateway", cfg.MustGetString("serviceName")) // existing config


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Tooling | Low |

Fixes #571 


### Description
- `Errcheck` was added but never enabled in Zanzibar for over 3 years due to the typo.
-  Once the check runs, it fails builds unless the err is always checked. Fixed all inconsistencies in code.