### PR TITLE
Wrapping error for QPS not able to set, to enable debugging zanzibar

### DIFF
--- a/codegen/module.go
+++ b/codegen/module.go
@@ -1269,7 +1269,8 @@ func (system *ModuleSystem) IncrementalBuild(
 	}
 	qpsLevels, err := PopulateQPSLevels(baseDirectory + "/endpoints")
 	if err != nil {
-		return nil, errors.Errorf(
+		return nil, errors.Wrapf(
+			err,
 			"error in populating qps levels for base directory %q",
 			baseDirectory,
 		)

--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -654,7 +654,8 @@ func UnmarshalEndpointFile(endpointFile string) (map[string]interface{}, error) 
 func GetListOfAllFilesInEndpointDir(filePath string, filesList []string) ([]string, error) {
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
-		return nil, errors.Errorf(
+		return nil, errors.Wrapf(
+			err,
 			"error in getting file info for file path %q",
 			filePath,
 		)
@@ -662,7 +663,8 @@ func GetListOfAllFilesInEndpointDir(filePath string, filesList []string) ([]stri
 	if fileInfo.IsDir() {
 		items, err := ioutil.ReadDir(filePath)
 		if err != nil {
-			return nil, errors.Errorf(
+			return nil, errors.Wrapf(
+				err,
 				"error in reading base directory %q",
 				filePath,
 			)


### PR DESCRIPTION
`error in populating qps levels for base directory` is hiding the underlying root cause