### PR TITLE
Fix eclint errors

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -648,9 +648,9 @@ func (h *{{$handlerName}}) HandleRequest(
 			{{end -}}
 			return ctx
 		{{end}}
-		  default:
-			 res.SendError(500, "Unexpected server error", err)
-			 return ctx
+			default:
+				res.SendError(500, "Unexpected server error", err)
+				return ctx
 		}
 		{{ end }}
 	}
@@ -683,7 +683,7 @@ func endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "endpoint.tmpl", size: 7486, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "endpoint.tmpl", size: 7485, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2967,30 +2967,30 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 
 	/*Ex:
 	{
-	  "clients.rider-presentation.alternates": {
-		"routingConfigs": [
-		  {
-			"headerName": "x-test-env",
-			"headerValue": "*",
-			"serviceName": "testservice"
-		  },
-		  {
-			"headerName": "x-container",
-			"headerValue": "container*",
-			"serviceName": "relayer"
-		  }
-		],
-		"servicesDetail": {
-		  "testservice": {
-			"ip": "127.0.0.1",
-			"port": 5000
-		  },
-		  "relayer": {
-			"ip": "127.0.0.1",
-			"port": 12000
-		  }
-		}
-	  }
+		"clients.rider-presentation.alternates": {
+			"routingConfigs": [
+				{
+					"headerName": "x-test-env",
+					"headerValue": "*",
+					"serviceName": "testservice"
+				},
+				{
+					"headerName": "x-container",
+					"headerValue": "container*",
+					"serviceName": "relayer"
+				}
+			],
+			"servicesDetail": {
+				"testservice": {
+					"ip": "127.0.0.1",
+					"port": 5000
+				},
+				"relayer": {
+					"ip": "127.0.0.1",
+					"port": 12000
+				}
+			}
+	  	}
 	}*/
 	var re ruleengine.RuleEngine
 	var headerPatterns []string
@@ -3298,7 +3298,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 15243, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 15267, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -229,9 +229,9 @@ func (h *{{$handlerName}}) HandleRequest(
 			{{end -}}
 			return ctx
 		{{end}}
-		  default:
-			 res.SendError(500, "Unexpected server error", err)
-			 return ctx
+			default:
+				res.SendError(500, "Unexpected server error", err)
+				return ctx
 		}
 		{{ end }}
 	}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -92,30 +92,30 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 
 	/*Ex:
 	{
-	  "clients.rider-presentation.alternates": {
-		"routingConfigs": [
-		  {
-			"headerName": "x-test-env",
-			"headerValue": "*",
-			"serviceName": "testservice"
-		  },
-		  {
-			"headerName": "x-container",
-			"headerValue": "container*",
-			"serviceName": "relayer"
-		  }
-		],
-		"servicesDetail": {
-		  "testservice": {
-			"ip": "127.0.0.1",
-			"port": 5000
-		  },
-		  "relayer": {
-			"ip": "127.0.0.1",
-			"port": 12000
-		  }
+		"clients.rider-presentation.alternates": {
+			"routingConfigs": [
+				{
+					"headerName": "x-test-env",
+					"headerValue": "*",
+					"serviceName": "testservice"
+				},
+				{
+					"headerName": "x-container",
+					"headerValue": "container*",
+					"serviceName": "relayer"
+				}
+			],
+			"servicesDetail": {
+				"testservice": {
+					"ip": "127.0.0.1",
+					"port": 5000
+				},
+				"relayer": {
+					"ip": "127.0.0.1",
+					"port": 12000
+				}
+			}
 		}
-	  }
 	}*/
 	var re ruleengine.RuleEngine
 	var headerPatterns []string
@@ -354,11 +354,11 @@ type {{$clientName}} struct {
 			"client" : "{{$clientID}}",
 			"methodName" : "{{$methodName}}",
 			})
-		  start := time.Now()
+			start := time.Now()
 			circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
 			err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
-			  elapsed := time.Now().Sub(start)
-			  scope.Timer("hystrix-timer").Record(elapsed)
+				elapsed := time.Now().Sub(start)
+				scope.Timer("hystrix-timer").Record(elapsed)
 				success, respHeaders, clientErr = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)

--- a/examples/example-gateway/config/production.json
+++ b/examples/example-gateway/config/production.json
@@ -28,29 +28,29 @@
 	"clients.corge-http.maxConcurrentRequests": 1000,
 	"clients.corge-http.errorPercentThreshold": 20,
 	"clients.corge-http.alternates": {
-	  "routingConfigs": [
-		{
-		  "headerName": "x-api-environment",
-		  "headerValue": "^staging",
-		  "serviceName": "CorgeHttp-staging"
-		},
-		{
-		  "headerName": "x-api-environment",
-		  "headerValue": "^canary",
-		  "serviceName": "CorgeHttp-canary"
-		},
-		{
-		  "headerName": "x-alt-router",
-		  "headerValue": "^alternate",
-		  "serviceName": "CorgeHttp-alt"
+		"routingConfigs": [
+			{
+				"headerName": "x-api-environment",
+				"headerValue": "^staging",
+				"serviceName": "CorgeHttp-staging"
+			},
+			{
+				"headerName": "x-api-environment",
+				"headerValue": "^canary",
+				"serviceName": "CorgeHttp-canary"
+			},
+			{
+				"headerName": "x-alt-router",
+				"headerValue": "^alternate",
+				"serviceName": "CorgeHttp-alt"
+			}
+		],
+		"servicesDetail": {
+			"corge-http-staging": {
+				"ip": "127.0.0.1",
+				"port": 5436
+			}
 		}
-	  ],
-	  "servicesDetail": {
-		"corge-http-staging": {
-		  "ip": "127.0.0.1",
-		  "port": 5436
-		}
-	  }
 	},
 	"clients.google-now.ip": "127.0.0.1",
 	"clients.google-now.port": 14120,


### PR DESCRIPTION
Verified that the build is now passing lint steps. `GO111MODULE=off make lint`