### PR TITLE
Add trace log fields to tchannel request context

### DIFF
--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -56,6 +56,13 @@ const (
 	shadowEnvironment = "shadow"
 	environmentKey    = "env"
 	apienvironmentKey = "apienvironment"
+
+	// TraceIDKey is the log field key containing the associated trace id
+	TraceIDKey = "trace.traceId"
+	// TraceSpanKey is the log field key containing the associated span id
+	TraceSpanKey = "trace.span"
+	// TraceSampledKey is the log field key for whether a trace was sampled or not
+	TraceSampledKey = "trace.sampled"
 )
 
 var knownMetrics = []string{

--- a/runtime/server_http_request_test.go
+++ b/runtime/server_http_request_test.go
@@ -2375,9 +2375,9 @@ func testIncomingHTTPRequestServerLog(t *testing.T, isShadowRequest bool, enviro
 		"host",
 		"pid",
 		"timestamp-finished",
-		"trace.span",
-		"trace.traceId",
-		"trace.sampled",
+		zanzibar.TraceIDKey,
+		zanzibar.TraceSpanKey,
+		zanzibar.TraceSampledKey,
 	}
 
 	if isShadowRequest {

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -143,9 +143,9 @@ func serverHTTPLogFields(req *ServerHTTPRequest, res *ServerHTTPResponse) []zapc
 		jc, ok := span.Context().(jaeger.SpanContext)
 		if ok {
 			fields = append(fields,
-				zap.String("trace.span", jc.SpanID().String()),
-				zap.String("trace.traceId", jc.TraceID().String()),
-				zap.Bool("trace.sampled", jc.IsSampled()),
+				zap.String(TraceSpanKey, jc.SpanID().String()),
+				zap.String(TraceIDKey, jc.TraceID().String()),
+				zap.Bool(TraceSampledKey, jc.IsSampled()),
 			)
 		}
 	}

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -26,8 +26,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
+	"github.com/uber/jaeger-client-go"
 	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 	netContext "golang.org/x/net/context"
@@ -244,6 +246,16 @@ func (s *TChannelRouter) handleBody(
 	// trace request
 	tracer := tchannel.TracerFromRegistrar(s.registrar)
 	ctx = tchannel.ExtractInboundSpan(ctx, c.call, c.reqHeaders, tracer)
+
+	if s := opentracing.SpanFromContext(ctx); s != nil {
+		if jaegerCtx, ok := s.Context().(jaeger.SpanContext); ok {
+			logFields := make([]zap.Field, 3)
+			logFields[0] = zap.String(TraceIDKey, jaegerCtx.TraceID().String())
+			logFields[1] = zap.String(TraceSpanKey, jaegerCtx.SpanID().String())
+			logFields[2] = zap.Bool(TraceSampledKey, jaegerCtx.IsSampled())
+			ctx = WithLogFields(ctx, logFields...)
+		}
+	}
 
 	// handle request
 	resp, err := c.handle(ctx, &wireValue)

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -33,6 +33,7 @@ import (
 	bazClient "github.com/uber/zanzibar/examples/example-gateway/build/clients/baz"
 	clientsBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/baz/baz"
 	endpointsBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/baz/baz"
+	zanzibar "github.com/uber/zanzibar/runtime"
 	testGateway "github.com/uber/zanzibar/test/lib/test_gateway"
 	"github.com/uber/zanzibar/test/lib/util"
 )
@@ -159,6 +160,9 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 		"timestamp-finished",
 		"Client-Req-Header-x-request-uuid",
 		"Client-Req-Header-$tracing$uber-trace-id",
+		zanzibar.TraceIDKey,
+		zanzibar.TraceSpanKey,
+		zanzibar.TraceSampledKey,
 	}
 	for _, dynamicValue := range dynamicHeaders {
 		assert.Contains(t, logs, dynamicValue)


### PR DESCRIPTION
TChannel requests are missing trace related fields in the logs, which makes
debugging difficult. This commit adds trace related log fields and
moves the keys to common constants so that they can be shared
between HTTP and TChannel requests/responses.