### PR TITLE
Expose overhead metric

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1809,6 +1809,10 @@ func (c *{{$clientName}}) {{$methodName}}(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	{{- if .ResHeaders }}
 	// TODO(jakev): verify mandatory response headers
 	{{- end}}
@@ -1912,9 +1916,6 @@ func (c *{{$clientName}}) {{$methodName}}(
 			}
 	}
 	{{else}}
-	defer func() {
-		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
-	}()
 
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
@@ -1996,7 +1997,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 18887, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 18888, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -327,6 +327,9 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
+	for k, v := range cliRespHeaders {
+		resHeaders.Set(k, v)
+	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}
@@ -365,7 +368,7 @@ func clientlessWorkflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4260, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4322, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1912,6 +1915,10 @@ func (c *{{$clientName}}) {{$methodName}}(
 			}
 	}
 	{{else}}
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
 		{{- if or (eq (.OKStatusCode.Code) 204) (eq (.OKStatusCode.Code) 304) }}
@@ -1992,7 +1999,7 @@ func http_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "http_client.tmpl", size: 18791, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "http_client.tmpl", size: 18887, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3954,6 +3961,9 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
+	for k, v := range cliRespHeaders {
+		resHeaders.Set(k, v)
+	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}
@@ -4018,7 +4028,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 8906, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 8968, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -327,9 +327,6 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
-	for k, v := range cliRespHeaders {
-		resHeaders.Set(k, v)
-	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}
@@ -368,7 +365,7 @@ func clientlessWorkflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4322, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "clientless-workflow.tmpl", size: 4260, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3961,9 +3958,6 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
-	for k, v := range cliRespHeaders {
-		resHeaders.Set(k, v)
-	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}
@@ -4028,7 +4022,7 @@ func workflowTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "workflow.tmpl", size: 8968, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "workflow.tmpl", size: 8906, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/clientless-workflow.tmpl
+++ b/codegen/templates/clientless-workflow.tmpl
@@ -126,9 +126,6 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
-	for k, v := range cliRespHeaders {
-		resHeaders.Set(k, v)
-	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}

--- a/codegen/templates/clientless-workflow.tmpl
+++ b/codegen/templates/clientless-workflow.tmpl
@@ -126,6 +126,9 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
+	for k, v := range cliRespHeaders {
+		resHeaders.Set(k, v)
+	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -368,6 +368,10 @@ func (c *{{$clientName}}) {{$methodName}}(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	{{- if .ResHeaders }}
 	// TODO(jakev): verify mandatory response headers
 	{{- end}}
@@ -471,9 +475,6 @@ func (c *{{$clientName}}) {{$methodName}}(
 			}
 	}
 	{{else}}
-	defer func() {
-		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
-	}()
 
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:

--- a/codegen/templates/http_client.tmpl
+++ b/codegen/templates/http_client.tmpl
@@ -471,6 +471,10 @@ func (c *{{$clientName}}) {{$methodName}}(
 			}
 	}
 	{{else}}
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 		case {{.OKStatusCode.Code}}:
 		{{- if or (eq (.OKStatusCode.Code) 204) (eq (.OKStatusCode.Code) 304) }}

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -240,6 +240,9 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
+	for k, v := range cliRespHeaders {
+		resHeaders.Set(k, v)
+	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -240,9 +240,6 @@ func (w {{$workflowStruct}}) Handle(
 	// Filter and map response headers from client to server response.
 	{{if eq $endpointType "tchannel" -}}
 	resHeaders := zanzibar.ServerTChannelHeader{}
-	for k, v := range cliRespHeaders {
-		resHeaders.Set(k, v)
-	}
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -1706,6 +1706,10 @@ func (c *barClient) Hello(
 
 	res.CheckOKResponse([]int{200, 303, 403})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
@@ -1819,6 +1823,10 @@ func (c *barClient) ListAndEnum(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody string
@@ -1913,6 +1921,10 @@ func (c *barClient) MissingArg(
 	}
 
 	res.CheckOKResponse([]int{200, 403})
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	switch res.StatusCode {
 	case 200:
@@ -2009,6 +2021,10 @@ func (c *barClient) NoRequest(
 	}
 
 	res.CheckOKResponse([]int{200, 403})
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	switch res.StatusCode {
 	case 200:
@@ -2107,6 +2123,10 @@ func (c *barClient) Normal(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsIDlClientsBarBar.BarResponse
@@ -2204,6 +2224,10 @@ func (c *barClient) NormalRecur(
 
 	res.CheckOKResponse([]int{200, 403})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsIDlClientsBarBar.BarResponseRecur
@@ -2299,6 +2323,10 @@ func (c *barClient) TooManyArgs(
 	}
 
 	res.CheckOKResponse([]int{200, 403, 418})
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	switch res.StatusCode {
 	case 200:

--- a/examples/example-gateway/build/clients/bar/bar.go
+++ b/examples/example-gateway/build/clients/bar/bar.go
@@ -491,6 +491,10 @@ func (c *barClient) ArgNotStruct(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
@@ -596,6 +600,10 @@ func (c *barClient) ArgWithHeaders(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -778,6 +786,10 @@ func (c *barClient) ArgWithManyQueryParams(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -880,6 +892,10 @@ func (c *barClient) ArgWithNearDupQueryParams(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -1008,6 +1024,10 @@ func (c *barClient) ArgWithNestedQueryParams(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -1093,6 +1113,10 @@ func (c *barClient) ArgWithParams(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -1180,6 +1204,10 @@ func (c *barClient) ArgWithParamsAndDuplicateFields(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -1265,6 +1293,10 @@ func (c *barClient) ArgWithQueryHeader(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -1369,6 +1401,10 @@ func (c *barClient) ArgWithQueryParams(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -1461,6 +1497,10 @@ func (c *barClient) DeleteFoo(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -1538,6 +1578,10 @@ func (c *barClient) DeleteWithBody(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -1626,6 +1670,10 @@ func (c *barClient) DeleteWithQueryParams(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -1704,11 +1752,11 @@ func (c *barClient) Hello(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 303, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 303, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -1821,11 +1869,11 @@ func (c *barClient) ListAndEnum(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -1920,11 +1968,11 @@ func (c *barClient) MissingArg(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -2020,11 +2068,11 @@ func (c *barClient) NoRequest(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -2121,11 +2169,11 @@ func (c *barClient) Normal(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -2222,11 +2270,11 @@ func (c *barClient) NormalRecur(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403})
 
 	switch res.StatusCode {
 	case 200:
@@ -2322,11 +2370,11 @@ func (c *barClient) TooManyArgs(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 403, 418})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 403, 418})
 
 	switch res.StatusCode {
 	case 200:
@@ -2437,6 +2485,10 @@ func (c *barClient) EchoBinary(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -2520,6 +2572,10 @@ func (c *barClient) EchoBool(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -2611,6 +2667,10 @@ func (c *barClient) EchoDouble(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -2700,6 +2760,10 @@ func (c *barClient) EchoEnum(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -2791,6 +2855,10 @@ func (c *barClient) EchoI16(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -2880,6 +2948,10 @@ func (c *barClient) EchoI32(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -2971,6 +3043,10 @@ func (c *barClient) EchoI32Map(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -3060,6 +3136,10 @@ func (c *barClient) EchoI64(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -3151,6 +3231,10 @@ func (c *barClient) EchoI8(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -3240,6 +3324,10 @@ func (c *barClient) EchoString(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -3331,6 +3419,10 @@ func (c *barClient) EchoStringList(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -3420,6 +3512,10 @@ func (c *barClient) EchoStringMap(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -3511,6 +3607,10 @@ func (c *barClient) EchoStringSet(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -3600,6 +3700,10 @@ func (c *barClient) EchoStructList(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 
@@ -3691,6 +3795,10 @@ func (c *barClient) EchoStructSet(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -3780,6 +3888,10 @@ func (c *barClient) EchoTypedef(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -258,11 +258,11 @@ func (c *contactsClient) SaveContacts(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{202, 400, 404})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{202, 400, 404})
 
 	switch res.StatusCode {
 	case 202:
@@ -351,6 +351,10 @@ func (c *contactsClient) TestURLURL(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 

--- a/examples/example-gateway/build/clients/contacts/contacts.go
+++ b/examples/example-gateway/build/clients/contacts/contacts.go
@@ -260,6 +260,10 @@ func (c *contactsClient) SaveContacts(
 
 	res.CheckOKResponse([]int{202, 400, 404})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 202:
 		var responseBody clientsIDlClientsContactsContacts.SaveContactsResponse

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -331,6 +331,10 @@ func (c *corgeHTTPClient) EchoString(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -435,6 +439,10 @@ func (c *corgeHTTPClient) NoContent(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{204, 304})
 
 	switch res.StatusCode {
@@ -534,6 +542,10 @@ func (c *corgeHTTPClient) NoContentNoException(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{204})
 
 	switch res.StatusCode {
@@ -629,11 +641,11 @@ func (c *corgeHTTPClient) CorgeNoContentOnException(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 304})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 304})
 
 	switch res.StatusCode {
 	case 200:

--- a/examples/example-gateway/build/clients/corge-http/corge-http.go
+++ b/examples/example-gateway/build/clients/corge-http/corge-http.go
@@ -631,6 +631,10 @@ func (c *corgeHTTPClient) CorgeNoContentOnException(
 
 	res.CheckOKResponse([]int{200, 304})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsIDlClientsCorgeCorge.Foo

--- a/examples/example-gateway/build/clients/google-now/google-now.go
+++ b/examples/example-gateway/build/clients/google-now/google-now.go
@@ -261,6 +261,10 @@ func (c *googleNowClient) AddCredentials(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 	// TODO(jakev): verify mandatory response headers
 
 	res.CheckOKResponse([]int{202})
@@ -344,6 +348,10 @@ func (c *googleNowClient) CheckCredentials(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 	// TODO(jakev): verify mandatory response headers
 
 	res.CheckOKResponse([]int{202})

--- a/examples/example-gateway/build/clients/multi/multi.go
+++ b/examples/example-gateway/build/clients/multi/multi.go
@@ -255,6 +255,10 @@ func (c *multiClient) HelloA(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	res.CheckOKResponse([]int{200})
 
 	switch res.StatusCode {
@@ -338,6 +342,10 @@ func (c *multiClient) HelloB(
 	for k := range res.Header {
 		respHeaders[k] = res.Header.Get(k)
 	}
+
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
 
 	res.CheckOKResponse([]int{200})
 

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -252,6 +252,10 @@ func (c *withexceptionsClient) Func1(
 
 	res.CheckOKResponse([]int{200, 401})
 
+	defer func() {
+		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
+	}()
+
 	switch res.StatusCode {
 	case 200:
 		var responseBody clientsIDlClientsWithexceptionsWithexceptions.Response

--- a/examples/example-gateway/build/clients/withexceptions/withexceptions.go
+++ b/examples/example-gateway/build/clients/withexceptions/withexceptions.go
@@ -250,11 +250,11 @@ func (c *withexceptionsClient) Func1(
 		respHeaders[k] = res.Header.Get(k)
 	}
 
-	res.CheckOKResponse([]int{200, 401})
-
 	defer func() {
 		respHeaders[zanzibar.ClientResponseDurationKey] = res.Duration.String()
 	}()
+
+	res.CheckOKResponse([]int{200, 401})
 
 	switch res.StatusCode {
 	case 200:

--- a/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
+++ b/examples/example-gateway/endpoints/tchannel/baz/baz_call_test.go
@@ -45,6 +45,14 @@ func TestBazCall(t *testing.T) {
 	success, resHeaders, err := ms.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
+	dynamicRespHeaders := []string{
+		"client.response.duration",
+	}
+	for _, dynamicValue := range dynamicRespHeaders {
+		assert.Contains(t, resHeaders, dynamicValue)
+		delete(resHeaders, dynamicValue)
+	}
+
 	if !assert.NoError(t, err, "got tchannel error") {
 		return
 	}

--- a/runtime/client_http_response.go
+++ b/runtime/client_http_response.go
@@ -44,6 +44,7 @@ type ClientHTTPResponse struct {
 	rawResponse      *http.Response
 	rawResponseBytes []byte
 	StatusCode       int
+	Duration         time.Duration
 	Header           http.Header
 	jsonWrapper      jsonwrapper.JSONWrapper
 }
@@ -182,6 +183,8 @@ func (res *ClientHTTPResponse) finish() {
 	delta := res.finishTime.Sub(res.req.startTime)
 	res.req.Metrics.RecordTimer(res.req.ctx, clientLatency, delta)
 	res.req.Metrics.RecordHistogramDuration(res.req.ctx, clientLatencyHist, delta)
+	res.Duration = delta
+
 	_, known := knownStatusCodes[res.StatusCode]
 	if !known {
 		res.req.ContextLogger.Error(res.req.ctx,

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -23,12 +23,14 @@ package zanzibar
 import "net/http"
 
 const (
-	endpointRequest      = "endpoint.request"
-	endpointSuccess      = "endpoint.success"
-	endpointStatus       = "endpoint.status"
-	endpointSystemErrors = "endpoint.system-errors"
-	endpointLatency      = "endpoint.latency"
-	endpointLatencyHist  = "endpoint.latency-hist"
+	endpointRequest             = "endpoint.request"
+	endpointSuccess             = "endpoint.success"
+	endpointStatus              = "endpoint.status"
+	endpointSystemErrors        = "endpoint.system-errors"
+	endpointLatency             = "endpoint.latency"
+	endpointLatencyHist         = "endpoint.latency-hist"
+	endpointOverheadLatency     = "endpoint.overhead.latency"
+	endpointOverheadLatencyHist = "endpoint.overhead.latency-hist"
 
 	// MetricEndpointPanics is endpoint level panic counter
 	MetricEndpointPanics = "endpoint.panic"
@@ -63,6 +65,9 @@ const (
 	TraceSpanKey = "trace.span"
 	// TraceSampledKey is the log field key for whether a trace was sampled or not
 	TraceSampledKey = "trace.sampled"
+
+	// ClientResponseDurationKey is the key denoting a downstream response duration
+	ClientResponseDurationKey = "client.response.duration"
 )
 
 var knownMetrics = []string{
@@ -151,6 +156,6 @@ var knownStatusCodes = map[int]bool{
 }
 
 var noContentStatusCodes = map[int]bool{
-	http.StatusNoContent:   true, //204
-	http.StatusNotModified: true, //304
+	http.StatusNoContent:   true, // 204
+	http.StatusNotModified: true, // 304
 }

--- a/runtime/middlewares_tchannel_test.go
+++ b/runtime/middlewares_tchannel_test.go
@@ -70,6 +70,14 @@ func TestTchannelHandlers(t *testing.T) {
 	success, resHeaders, err := ms.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
+	dynamicRespHeaders := []string{
+		"client.response.duration",
+	}
+	for _, dynamicValue := range dynamicRespHeaders {
+		assert.Contains(t, resHeaders, dynamicValue)
+		delete(resHeaders, dynamicValue)
+	}
+
 	if !assert.NoError(t, err, "got tchannel error") {
 		return
 	}

--- a/runtime/server_header.go
+++ b/runtime/server_header.go
@@ -43,6 +43,8 @@ type Header interface {
 	Values(key string) ([]string, bool)
 	Add(key string, value string)
 	Set(key string, value string)
+	// Unset unsets the value for a given header. Can be safely called multiple times
+	Unset(key string)
 	Keys() []string
 	// Deprecated: Use EnsureContext instead
 	Ensure(keys []string, logger *zap.Logger) error
@@ -107,6 +109,12 @@ func (zh ServerHTTPHeader) Add(key string, value string) {
 func (zh ServerHTTPHeader) Set(key string, value string) {
 	httpKey := textproto.CanonicalMIMEHeaderKey(key)
 	zh[httpKey] = []string{value}
+}
+
+// Unset unsets the value for a given header. Can be safely called multiple times
+func (zh ServerHTTPHeader) Unset(key string) {
+	httpKey := textproto.CanonicalMIMEHeaderKey(key)
+	delete(zh, httpKey)
 }
 
 // Keys returns a slice of header keys.
@@ -190,6 +198,11 @@ func (th ServerTChannelHeader) Add(key string, value string) {
 // Set sets a value for a given header, overwriting the previous value.
 func (th ServerTChannelHeader) Set(key string, value string) {
 	th[key] = value
+}
+
+// Unset unsets the value for a given header. Can be safely called multiple times
+func (th ServerTChannelHeader) Unset(key string) {
+	delete(th, key)
 }
 
 // Keys returns a slice of header keys.

--- a/runtime/server_header_test.go
+++ b/runtime/server_header_test.go
@@ -181,6 +181,17 @@ func TestSetNewKey(t *testing.T) {
 	assert.Equal(t, "headOne", zh.GetOrEmptyStr("foo"))
 }
 
+func TestUnsetKey(t *testing.T) {
+	zh := zanzibar.NewServerHTTPHeader(http.Header{})
+	zh.Set("foo", "bar")
+	assert.Equal(t, "bar", zh.GetOrEmptyStr("foo"))
+
+	zh.Unset("foo")
+	v, ok := zh.Get("foo")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
+}
+
 func TestSetOverwriteMultiKey(t *testing.T) {
 	zh := zanzibar.NewServerHTTPHeader(http.Header{})
 	zh.Set("foo", "headOne")
@@ -322,6 +333,19 @@ func TestSTHSetNewKey(t *testing.T) {
 	v, ok := zh.Get("foo")
 	assert.True(t, ok)
 	assert.Equal(t, "headOne", v)
+}
+
+func TestSTHUnset(t *testing.T) {
+	zh := zanzibar.ServerTChannelHeader{}
+	zh.Add("foo", "bar")
+	v, ok := zh.Get("foo")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", v)
+
+	zh.Unset("foo")
+	v, ok = zh.Get("foo")
+	assert.False(t, ok)
+	assert.Equal(t, "", v)
 }
 
 func TestSTHMissingKey(t *testing.T) {

--- a/runtime/server_http_response_test.go
+++ b/runtime/server_http_response_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
@@ -148,8 +149,7 @@ func TestCallingWriteJSONWithNil(t *testing.T) {
 	assert.Equal(t, 1, len(logLines))
 }
 
-type failingJsonObj struct {
-}
+type failingJsonObj struct{}
 
 func (f failingJsonObj) MarshalJSON() ([]byte, error) {
 	return nil, errors.New("cannot serialize")
@@ -499,6 +499,7 @@ func TestPendingResponseBody(t *testing.T) {
 				statusCode := 200
 				assert.NoError(t, err)
 				res.WriteJSON(statusCode, nil, obj)
+				res.DownstreamFinishTime = 1 * time.Microsecond
 
 				pendingBytes, pendingStatusCode := res.GetPendingResponse()
 				assert.Equal(t, bytes, pendingBytes)
@@ -589,7 +590,7 @@ func TestPendingResponseBody204StatusNoContent(t *testing.T) {
 		return
 	}
 
-	//The body would become blank
+	// The body would become blank
 	assert.Equal(
 		t,
 		"",
@@ -661,7 +662,7 @@ func TestPendingResponseBody304StatusNoContent(t *testing.T) {
 		return
 	}
 
-	//The body would become blank
+	// The body would become blank
 	assert.Equal(
 		t,
 		``,

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -72,7 +72,7 @@ type TChannelClientOption struct {
 	// AltChannelMap is a map for dynamic lookup of alternative channels
 	AltChannelMap map[string]*tchannel.SubChannel
 
-	//MaxAttempts is the maximum retry count for a client
+	// MaxAttempts is the maximum retry count for a client
 	MaxAttempts int
 }
 
@@ -180,7 +180,13 @@ func (c *TChannelClient) call(
 	reqHeaders map[string]string,
 	req, resp RWTStruct,
 ) (success bool, resHeaders map[string]string, err error) {
-	defer func() { call.finish(ctx, err) }()
+	defer func() {
+		call.finish(ctx, err)
+		if call.resHeaders == nil {
+			call.resHeaders = make(map[string]string)
+		}
+		call.resHeaders[ClientResponseDurationKey] = call.duration.String()
+	}()
 	call.start()
 
 	reqUUID := RequestUUIDFromCtx(ctx)
@@ -191,9 +197,9 @@ func (c *TChannelClient) call(
 		reqHeaders[c.requestUUIDHeaderKey] = reqUUID
 	}
 
-	//Start passing the MaxAttempt field which will be used while creating the RetryOptions.
-	//Note : No impact on the existing clients because MaxAttempt will be passed as 0 and it will default to 5 while retrying the execution.
-	//More details can be found at https://t3.uberinternal.com/browse/EDGE-8526
+	// Start passing the MaxAttempt field which will be used while creating the RetryOptions.
+	// Note : No impact on the existing clients because MaxAttempt will be passed as 0 and it will default to 5 while retrying the execution.
+	// More details can be found at https://t3.uberinternal.com/browse/EDGE-8526
 	retryOpts := tchannel.RetryOptions{
 		TimeoutPerAttempt: c.timeoutPerAttempt,
 		MaxAttempts:       c.maxAttempts,

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -40,6 +40,7 @@ type tchannelOutboundCall struct {
 	success       bool
 	startTime     time.Time
 	finishTime    time.Time
+	duration      time.Duration
 	reqHeaders    map[string]string
 	resHeaders    map[string]string
 	contextLogger ContextLogger
@@ -67,6 +68,7 @@ func (c *tchannelOutboundCall) finish(ctx context.Context, err error) {
 	delta := c.finishTime.Sub(c.startTime)
 	c.metrics.RecordTimer(ctx, clientLatency, delta)
 	c.metrics.RecordHistogramDuration(ctx, clientLatencyHist, delta)
+	c.duration = delta
 
 	// write logs
 	fields := c.logFields(ctx)

--- a/test/endpoints/tchannel/baz/baz_metrics_test.go
+++ b/test/endpoints/tchannel/baz/baz_metrics_test.go
@@ -99,6 +99,13 @@ func TestCallMetrics(t *testing.T) {
 	success, resHeaders, err := gateway.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
+	dynamicRespHeaders := []string{
+		"client.response.duration",
+	}
+	for _, dynamicValue := range dynamicRespHeaders {
+		assert.Contains(t, resHeaders, dynamicValue)
+		delete(resHeaders, dynamicValue)
+	}
 
 	if !assert.NoError(t, err, "got tchannel error") {
 		return

--- a/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
+++ b/test/endpoints/tchannel/baz/baz_simpleservice_method_call_test.go
@@ -94,6 +94,13 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	success, resHeaders, err := gateway.MakeTChannelRequest(
 		ctx, "SimpleService", "Call", reqHeaders, args, &result,
 	)
+	dynamicRespHeaders := []string{
+		"client.response.duration",
+	}
+	for _, dynamicValue := range dynamicRespHeaders {
+		assert.Contains(t, resHeaders, dynamicValue)
+		delete(resHeaders, dynamicValue)
+	}
 
 	if !assert.NoError(t, err, "got tchannel error") {
 		return
@@ -119,6 +126,7 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 		"ts",
 		"hostname",
 		"pid",
+		"Res-Header-client.response.duration",
 	}
 	for _, dynamicValue := range dynamicHeaders {
 		assert.Contains(t, logs, dynamicValue)
@@ -126,20 +134,19 @@ func TestCallTChannelSuccessfulRequestOKResponse(t *testing.T) {
 	}
 
 	expectedValues := map[string]string{
-		"level":                "debug",
-		"msg":                  "Finished an incoming server TChannel request",
-		"env":                  "test",
-		"service":              "example-gateway",
-		"endpointID":           "bazTChannel",
-		"endpointHandler":      "call",
-		"endpointThriftMethod": "SimpleService::Call",
-		"x-uuid":               "uuid",
-		"calling-service":      "test-gateway",
-		"zone":                 "unknown",
-		"Device":               "ios",
-		"Regionname":           "sf",
-		"Deviceversion":        "1.0",
-
+		"level":                      "debug",
+		"msg":                        "Finished an incoming server TChannel request",
+		"env":                        "test",
+		"service":                    "example-gateway",
+		"endpointID":                 "bazTChannel",
+		"endpointHandler":            "call",
+		"endpointThriftMethod":       "SimpleService::Call",
+		"x-uuid":                     "uuid",
+		"calling-service":            "test-gateway",
+		"zone":                       "unknown",
+		"Device":                     "ios",
+		"Regionname":                 "sf",
+		"Deviceversion":              "1.0",
 		"Res-Header-some-res-header": "something",
 	}
 	for actualKey, actualValue := range logs {


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Observability | Medium |

## Description
- Introduce  two new metrics `endpoint.overhead.latency` and  `endpoint.overhead.latency-hist` metrics for each TChannel/HTTP endpoint. These correspond to the time spent solely doing gateway specific overhead.

## Motivation 
Currently, Zanzibar Gateways expose no metric to figure out the exact overhead being added by

- Gateway middlewares (including default) and request / response path middlewares
- runtime serde overhead
- other baggage.

This is essential and should have been a key indicator in all endpoint dashboards right from the start. Every team should have key visibility into knowing the exact overhead that Zanzibar gateways add so that they have a better understanding of their resource utilization and the cost of the middlewares they add.

Additionally, when we perform runtime optimizations at Zanzibar Gateways, it is invaluable to know whether the Gateway overhead has increased or decreased for high RPS / business critical endpoints.

## How was this tested?

#### Tested that for both TChannel and HTTP flows, the `delta` metric is being populated. 
More details on the internal diff. 
![image](https://user-images.githubusercontent.com/12872673/148723519-c09d37a6-b12a-4b99-bedd-537b11aa953a.png)

