### PR TITLE
Add gauge calculating overhead percentage

### DIFF
--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -31,7 +31,7 @@ const (
 	endpointLatencyHist         = "endpoint.latency-hist"
 	endpointOverheadLatency     = "endpoint.overhead.latency"
 	endpointOverheadLatencyHist = "endpoint.overhead.latency-hist"
-	endpointOverheadRatio       = "endpoint.overhead.ratio"
+	endpointOverheadRatio       = "endpoint.overhead.latency.ratio"
 
 	// MetricEndpointPanics is endpoint level panic counter
 	MetricEndpointPanics = "endpoint.panic"

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -31,6 +31,7 @@ const (
 	endpointLatencyHist         = "endpoint.latency-hist"
 	endpointOverheadLatency     = "endpoint.overhead.latency"
 	endpointOverheadLatencyHist = "endpoint.overhead.latency-hist"
+	endpointOverheadRatio       = "endpoint.overhead.ratio"
 
 	// MetricEndpointPanics is endpoint level panic counter
 	MetricEndpointPanics = "endpoint.panic"

--- a/runtime/server_http_response.go
+++ b/runtime/server_http_response.go
@@ -105,8 +105,10 @@ func (res *ServerHTTPResponse) finish(ctx context.Context) {
 
 	if res.DownstreamFinishTime != 0 {
 		overhead := delta - res.DownstreamFinishTime
+		overheadRatio := overhead.Seconds() / delta.Seconds()
 		tagged.Timer(endpointOverheadLatency).Record(overhead)
 		tagged.Histogram(endpointOverheadLatencyHist, tally.DefaultBuckets).RecordDuration(overhead)
+		tagged.Gauge(endpointOverheadRatio).Update(overheadRatio)
 	}
 
 	if !known {


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Observability | Medium |

## Description
- Introduce  a new metrics `endpoint.overhead.latency.ratio` corresponding to the ratio of the time spent solely doing gateway specific overhead vs the whole response.

## Motivation 
Refer #805 where we added latency metrics on overhead. We also need the overhead percentage. Deriving this value at runtime is a lot cheaper and would lead to easier queries
