### PR TITLE
Add Client ID in scope tag against latency metrics

### DIFF
--- a/codegen/module_system.go
+++ b/codegen/module_system.go
@@ -48,6 +48,7 @@ type EndpointMeta struct {
 	Method                 *MethodSpec
 	ClientName             string
 	ClientID               string
+	ClientType             string
 	ClientMethodName       string
 	WorkflowPkg            string
 	ReqHeaders             map[string]*TypedHeader
@@ -142,7 +143,6 @@ func (fb *FixtureBody) String() string {
 		return fb.BodyString
 	case "json":
 		if fb.BodyJSON == nil {
-
 			panic(errors.New("invalid http body type"))
 		}
 		return fb.BodyJSON.String()
@@ -1396,8 +1396,10 @@ func (g *EndpointGenerator) generateEndpointFile(e *EndpointSpec, instance *Modu
 
 	clientID := e.ClientID
 	clientName := ""
+	clientType := "clientless"
 	if e.ClientSpec != nil {
 		clientName = e.ClientSpec.ClientName
+		clientType = e.ClientSpec.ClientType
 	}
 
 	// TODO: http client needs to support multiple thrift services
@@ -1416,6 +1418,7 @@ func (g *EndpointGenerator) generateEndpointFile(e *EndpointSpec, instance *Modu
 		ResHeaders:             e.ResHeaders,
 		ClientID:               clientID,
 		ClientName:             clientName,
+		ClientType:             clientType,
 		ClientMethodName:       e.ClientMethod,
 		WorkflowPkg:            workflowPkg,
 		TraceKey:               g.packageHelper.traceKey,
@@ -1859,9 +1862,11 @@ type sortByClientName []*ClientSpec
 func (c sortByClientName) Len() int {
 	return len(c)
 }
+
 func (c sortByClientName) Swap(i, j int) {
 	c[i], c[j] = c[j], c[i]
 }
+
 func (c sortByClientName) Less(i, j int) bool {
 	return c[i].ClientName < c[j].ClientName
 }

--- a/codegen/templates/clientless-workflow.tmpl
+++ b/codegen/templates/clientless-workflow.tmpl
@@ -11,6 +11,7 @@ package clientlessworkflow
 {{- $clientlessEndpoint := .IsClientlessEndpoint }}
 {{- $clientID := .ClientID }}
 {{- $clientName := title .ClientName }}
+{{- $clientType := .ClientType }}
 {{- $clientMethodName := title .ClientMethodName }}
 {{- $serviceMethod := printf "%s%s" (title .Method.ThriftService) (title .Method.Name) }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
@@ -129,6 +130,7 @@ func (w {{$workflowStruct}}) Handle(
 	{{- else -}}
 	resHeaders := zanzibar.ServerHTTPHeader{}
 	{{- end -}}
+
 	{{range $i, $k := $resHeaderMapKeys}}
 	{{- $resHeaderVal := index $resHeaderMap $k}}
 	h, ok = clientlessHeaders["{{$k}}"]
@@ -140,6 +142,8 @@ func (w {{$workflowStruct}}) Handle(
 	{{if eq .ResponseType "" -}}
 	return ctx, resHeaders, nil
 	{{- else -}}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "{{$clientType}}")
 	return ctx, response, resHeaders, nil
 	{{end}}
 

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -178,6 +178,20 @@ func (h *{{$handlerName}}) HandleRequest(
 	{{else}}
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
 
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
+
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {
 		zfields := []zapcore.Field{

--- a/codegen/templates/workflow.tmpl
+++ b/codegen/templates/workflow.tmpl
@@ -11,6 +11,7 @@ package workflow
 {{- $resHeaderMapKeys := .ResHeadersKeys }}
 {{- $clientID := .ClientID }}
 {{- $clientName := title .ClientName }}
+{{- $clientType := .ClientType }}
 {{- $clientMethodName := title .ClientMethodName }}
 {{- $serviceMethod := printf "%s%s" (title .Method.ThriftService) (title .Method.Name) }}
 {{- $workflowInterface := printf "%sWorkflow" $serviceMethod }}
@@ -175,7 +176,7 @@ func (w {{$workflowStruct}}) Handle(
 		{{- end }}
 	{{else if eq $clientReqType ""}}
 		{{if (eq (len $resHeaderMap) 0) -}}
-		ctx, clientRespBody, _, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(
+		ctx, clientRespBody, cliRespHeaders, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(
 			ctx, clientHeaders,
 		)
 		{{else}}
@@ -195,7 +196,7 @@ func (w {{$workflowStruct}}) Handle(
 		{{- end }}
 	{{else}}
 		{{if (eq (len $resHeaderMap) 0) -}}
-		ctx, clientRespBody, _, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(
+		ctx, clientRespBody, cliRespHeaders, err := w.Clients.{{$clientName}}.{{$clientMethodName}}(
 			ctx, clientHeaders, clientRequest,
 		)
 		{{else}}
@@ -254,6 +255,11 @@ func (w {{$workflowStruct}}) Handle(
 	return ctx, resHeaders, nil
 	{{- else -}}
 	response := convert{{.DownstreamService}}{{title .Name}}ClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "{{$clientType}}")
 	return ctx, response, resHeaders, nil
 	{{- end -}}
 }

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithmanyqueryparams.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -439,6 +440,20 @@ func (h *BarArgWithManyQueryParamsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithneardupqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithneardupqueryparams.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -162,6 +163,20 @@ func (h *BarArgWithNearDupQueryParamsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithnestedqueryparams.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -218,6 +219,20 @@ func (h *BarArgWithNestedQueryParamsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparams.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -133,6 +134,20 @@ func (h *BarArgWithParamsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparamsandduplicatefields.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithparamsandduplicatefields.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -129,6 +130,20 @@ func (h *BarArgWithParamsAndDuplicateFieldsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryheader.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -130,6 +131,20 @@ func (h *BarArgWithQueryHeaderHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_argwithqueryparams.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -163,6 +164,20 @@ func (h *BarArgWithQueryParamsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_listandenum.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -169,6 +170,20 @@ func (h *BarListAndEnumHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_normal.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -134,6 +135,20 @@ func (h *BarNormalHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/bar_bar_method_toomanyargs.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -128,6 +129,20 @@ func (h *BarTooManyArgsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithheaders.go
@@ -112,7 +112,7 @@ func (w barArgWithHeadersWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithHeaders(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithHeaders(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -134,6 +134,11 @@ func (w barArgWithHeadersWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithHeadersClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithmanyqueryparams.go
@@ -108,7 +108,7 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithManyQueryParams(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithManyQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithManyQueryParamsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithManyQueryParamsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithneardupqueryparams.go
@@ -108,7 +108,7 @@ func (w barArgWithNearDupQueryParamsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithNearDupQueryParams(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithNearDupQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithNearDupQueryParamsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithNearDupQueryParamsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithnestedqueryparams.go
@@ -108,7 +108,7 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithNestedQueryParams(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithNestedQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithNestedQueryParamsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithNestedQueryParamsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparams.go
@@ -108,7 +108,7 @@ func (w barArgWithParamsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithParams(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithParamsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithParamsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithparamsandduplicatefields.go
@@ -108,7 +108,7 @@ func (w barArgWithParamsAndDuplicateFieldsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithParamsAndDuplicateFields(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithParamsAndDuplicateFields(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithParamsAndDuplicateFieldsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithParamsAndDuplicateFieldsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryheader.go
@@ -108,7 +108,7 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithQueryHeader(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithQueryHeader(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -130,6 +130,11 @@ func (w barArgWithQueryHeaderWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithQueryHeaderClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_argwithqueryparams.go
@@ -116,7 +116,7 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ArgWithQueryParams(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ArgWithQueryParams(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -138,6 +138,11 @@ func (w barArgWithQueryParamsWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarArgWithQueryParamsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_helloworld.go
@@ -105,7 +105,7 @@ func (w barHelloWorldWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.Hello(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.Hello(
 		ctx, clientHeaders,
 	)
 
@@ -141,6 +141,11 @@ func (w barHelloWorldWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarHelloWorldClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_listandenum.go
@@ -108,7 +108,7 @@ func (w barListAndEnumWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.ListAndEnum(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.ListAndEnum(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -137,6 +137,11 @@ func (w barListAndEnumWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarListAndEnumClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_missingarg.go
@@ -105,7 +105,7 @@ func (w barMissingArgWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.MissingArg(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.MissingArg(
 		ctx, clientHeaders,
 	)
 
@@ -134,6 +134,11 @@ func (w barMissingArgWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarMissingArgClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_norequest.go
@@ -105,7 +105,7 @@ func (w barNoRequestWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.NoRequest(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.NoRequest(
 		ctx, clientHeaders,
 	)
 
@@ -134,6 +134,11 @@ func (w barNoRequestWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarNoRequestClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_normal.go
@@ -108,7 +108,7 @@ func (w barNormalWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Bar.Normal(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Bar.Normal(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -137,6 +137,11 @@ func (w barNormalWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertBarNormalClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
+++ b/examples/example-gateway/build/endpoints/bar/workflow/bar_bar_method_toomanyargs.go
@@ -161,6 +161,11 @@ func (w barTooManyArgsWorkflow) Handle(
 	}
 
 	response := convertBarTooManyArgsClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_compare.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *SimpleServiceCompareHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_getprofile.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *SimpleServiceGetProfileHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_headerschema.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -130,6 +131,20 @@ func (h *SimpleServiceHeaderSchemaHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_trans.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *SimpleServiceTransHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaders.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *SimpleServiceTransHeadersHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/baz_simpleservice_method_transheaderstype.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *SimpleServiceTransHeadersTypeHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_compare.go
@@ -109,7 +109,7 @@ func (w simpleServiceCompareWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.Compare(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.Compare(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -145,6 +145,11 @@ func (w simpleServiceCompareWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceCompareClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_getprofile.go
@@ -108,7 +108,7 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.GetProfile(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.GetProfile(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -137,6 +137,11 @@ func (w simpleServiceGetProfileWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceGetProfileClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_headerschema.go
@@ -124,7 +124,7 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.HeaderSchema(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.HeaderSchema(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -160,6 +160,11 @@ func (w simpleServiceHeaderSchemaWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceHeaderSchemaClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_ping.go
@@ -105,7 +105,7 @@ func (w simpleServicePingWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.Ping(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.Ping(
 		ctx, clientHeaders,
 	)
 
@@ -127,6 +127,11 @@ func (w simpleServicePingWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServicePingClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_trans.go
@@ -109,7 +109,7 @@ func (w simpleServiceTransWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.Trans(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.Trans(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -145,6 +145,11 @@ func (w simpleServiceTransWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceTransClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaders.go
@@ -118,7 +118,7 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.TransHeaders(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.TransHeaders(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -154,6 +154,11 @@ func (w simpleServiceTransHeadersWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceTransHeadersClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheadersnoreq.go
@@ -120,7 +120,7 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.TransHeadersNoReq(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.TransHeadersNoReq(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -149,6 +149,11 @@ func (w simpleServiceTransHeadersNoReqWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceTransHeadersNoReqClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
+++ b/examples/example-gateway/build/endpoints/baz/workflow/baz_simpleservice_method_transheaderstype.go
@@ -110,7 +110,7 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Baz.TransHeadersType(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Baz.TransHeadersType(
 		ctx, clientHeaders, clientRequest,
 	)
 
@@ -146,6 +146,11 @@ func (w simpleServiceTransHeadersTypeWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertSimpleServiceTransHeadersTypeClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "tchannel")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/clientless/clientless_clientless_method_beta.go
+++ b/examples/example-gateway/build/endpoints/clientless/clientless_clientless_method_beta.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -127,6 +128,20 @@ func (h *ClientlessBetaHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/clientless/clientless_clientless_method_clientlessargwithheaders.go
+++ b/examples/example-gateway/build/endpoints/clientless/clientless_clientless_method_clientlessargwithheaders.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -138,6 +139,20 @@ func (h *ClientlessClientlessArgWithHeadersHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/clientless/workflow/clientless_clientless_method_beta.go
+++ b/examples/example-gateway/build/endpoints/clientless/workflow/clientless_clientless_method_beta.go
@@ -76,6 +76,7 @@ func (w clientlessBetaWorkflow) Handle(
 	// Filter and map response headers from client to server response.
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
+	resHeaders.Set(zanzibar.ClientTypeKey, "clientless")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/clientless/workflow/clientless_clientless_method_clientlessargwithheaders.go
+++ b/examples/example-gateway/build/endpoints/clientless/workflow/clientless_clientless_method_clientlessargwithheaders.go
@@ -88,6 +88,7 @@ func (w clientlessClientlessArgWithHeadersWorkflow) Handle(
 		resHeaders.Set("X-Uuid", h)
 	}
 
+	resHeaders.Set(zanzibar.ClientTypeKey, "clientless")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
+++ b/examples/example-gateway/build/endpoints/contacts/contacts_contacts_method_savecontacts.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -132,6 +133,20 @@ func (h *ContactsSaveContactsHandler) HandleRequest(
 	}
 
 	ctx, response, cliRespHeaders, err := w.Handle(ctx, req.Header, &requestBody)
+
+	// map useful client response headers to server response
+	if cliRespHeaders != nil {
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientResponseDurationKey); ok {
+			if duration, err := time.ParseDuration(val); err == nil {
+				res.DownstreamFinishTime = duration
+			}
+			cliRespHeaders.Unset(zanzibar.ClientResponseDurationKey)
+		}
+		if val, ok := cliRespHeaders.Get(zanzibar.ClientTypeKey); ok {
+			res.ClientType = val
+			cliRespHeaders.Unset(zanzibar.ClientTypeKey)
+		}
+	}
 
 	// log downstream response to endpoint
 	if ce := h.Dependencies.Default.ContextLogger.Check(zapcore.DebugLevel, "stub"); ce != nil {

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_serviceafront_method_hello.go
@@ -102,7 +102,7 @@ func (w serviceAFrontHelloWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Multi.HelloA(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Multi.HelloA(
 		ctx, clientHeaders,
 	)
 
@@ -124,6 +124,11 @@ func (w serviceAFrontHelloWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertServiceABackHelloClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
+++ b/examples/example-gateway/build/endpoints/multi/workflow/multi_servicebfront_method_hello.go
@@ -102,7 +102,7 @@ func (w serviceBFrontHelloWorkflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Multi.HelloB(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Multi.HelloB(
 		ctx, clientHeaders,
 	)
 
@@ -124,6 +124,11 @@ func (w serviceBFrontHelloWorkflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertServiceBBackHelloClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
+++ b/examples/example-gateway/build/endpoints/withexceptions/workflow/withexceptions_withexceptions_method_func1.go
@@ -105,7 +105,7 @@ func (w withExceptionsFunc1Workflow) Handle(
 		}
 	}
 
-	ctx, clientRespBody, _, err := w.Clients.Withexceptions.Func1(
+	ctx, clientRespBody, cliRespHeaders, err := w.Clients.Withexceptions.Func1(
 		ctx, clientHeaders,
 	)
 
@@ -141,6 +141,11 @@ func (w withExceptionsFunc1Workflow) Handle(
 	resHeaders := zanzibar.ServerHTTPHeader{}
 
 	response := convertWithExceptionsFunc1ClientResponse(clientRespBody)
+	if val, ok := cliRespHeaders[zanzibar.ClientResponseDurationKey]; ok {
+		resHeaders.Set(zanzibar.ClientResponseDurationKey, val)
+	}
+
+	resHeaders.Set(zanzibar.ClientTypeKey, "http")
 	return ctx, response, resHeaders, nil
 }
 

--- a/runtime/constants.go
+++ b/runtime/constants.go
@@ -69,6 +69,8 @@ const (
 
 	// ClientResponseDurationKey is the key denoting a downstream response duration
 	ClientResponseDurationKey = "client.response.duration"
+	// ClientTypeKey denotes the type of the client, usually http / tchannel / client-less / custom
+	ClientTypeKey = "client.type"
 )
 
 var knownMetrics = []string{

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -71,6 +71,7 @@ const (
 	scopeTagClientMethod    = "clientmethod"
 	scopeTagEndpointMethod  = "endpointmethod"
 	scopeTagClient          = "clientid"
+	scopeTagClientType      = "clienttype"
 	scopeTagEndpoint        = "endpointid"
 	scopeTagHandler         = "handlerid"
 	scopeTagError           = "error"
@@ -292,7 +293,7 @@ func (c *ContextExtractors) ExtractLogFields(ctx context.Context) []zap.Field {
 }
 
 // ContextLogger is a logger that extracts some log fields from the context before passing through to underlying zap logger.
-//In cases it also updates the context instead of logging
+// In cases it also updates the context instead of logging
 type ContextLogger interface {
 	Debug(ctx context.Context, msg string, fields ...zap.Field) context.Context
 	Error(ctx context.Context, msg string, fields ...zap.Field) context.Context

--- a/test/endpoints/bar/bar_metrics_test.go
+++ b/test/endpoints/bar/bar_metrics_test.go
@@ -62,7 +62,7 @@ func TestCallMetrics(t *testing.T) {
 		},
 	)
 
-	numMetrics := 13
+	numMetrics := 16
 	cg := gateway.(*testGateway.ChildProcessGateway)
 	cg.MetricsWaitGroup.Add(numMetrics)
 
@@ -110,7 +110,8 @@ func TestCallMetrics(t *testing.T) {
 		"apienvironment": "production",
 	}
 	statusTags := map[string]string{
-		"status": "200",
+		"status":     "200",
+		"clienttype": "http",
 	}
 	for k, v := range endpointTags {
 		statusTags[k] = v

--- a/test/endpoints/baz/baz_metrics_test.go
+++ b/test/endpoints/baz/baz_metrics_test.go
@@ -127,7 +127,8 @@ func TestCallMetrics(t *testing.T) {
 		"apienvironment": "production",
 	}
 	statusTags := map[string]string{
-		"status": "204",
+		"status":     "204",
+		"clienttype": "",
 	}
 	for k, v := range endpointTags {
 		statusTags[k] = v

--- a/test/health_test.go
+++ b/test/health_test.go
@@ -68,7 +68,6 @@ func BenchmarkHealthCall(b *testing.B) {
 		},
 		exampleGateway.CreateGateway,
 	)
-
 	if err != nil {
 		b.Error("got bootstrap err: " + err.Error())
 		return
@@ -145,7 +144,8 @@ func TestHealthMetrics(t *testing.T) {
 		"apienvironment": "production",
 	}
 	statusTags := map[string]string{
-		"status": "200",
+		"status":     "200",
+		"clienttype": "",
 	}
 	for k, v := range tags {
 		statusTags[k] = v
@@ -160,6 +160,7 @@ func TestHealthMetrics(t *testing.T) {
 
 	key := tally.KeyForPrefixedStringMap("endpoint.request", tags)
 	assert.Contains(t, metrics, key, "expected metric: %s", key)
+
 	key = tally.KeyForPrefixedStringMap("endpoint.latency", statusTags)
 	assert.Contains(t, metrics, key, "expected metric: %s", key)
 	key = tally.KeyForPrefixedStringMap("endpoint.latency-hist", histogramTags)


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Observability | Medium |

## Description
- Introduce client type tag on server endpoint response status/latency metrics.

## Note to reviewers
There are 2 commits in total.

- To save time, only review [this commit](https://github.com/uber/zanzibar/pull/807/commits/853b6c2812d3dd4a54ceaef9f71d0ceafd14690a) which is the real change (Only 7 files changed)
- Rest 51 files are all generated and are added as part of the [2nd commit](https://github.com/uber/zanzibar/pull/807/commits/7a111efaa68c058cae2f36c6c07c0b1363f49941)

## Motivation 
After our work on #805 and #806, we'd like to be able to setup observability on metrics by client type. This will help us identify the overhead per client type. TChannel clients for example need different optimizations as compared to HTTP

As you can see, all we have when it comes to protocol information is `http` since all Gateway endpoints are mostly HTTP traffic.

![image](https://user-images.githubusercontent.com/12872673/149316475-44e861dc-3c05-4c43-999b-9421e142354f.png)

## How was this tested
- Unit tests
- Ran example gateway on local and issued requests against endpoints with `clientless, tchannel and http` clients. Could see the `clienttype` tag being marked.
![productionserviceexample-gateway](https://user-images.githubusercontent.com/12872673/149316436-ded3f1f4-3258-4972-a313-fd329577ae52.png)
