### PR TITLE
Optimized template generated code for maxAttempts(retry count)

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2998,6 +2998,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+// DefaultMaxAttempts is the default retries for a client
 const DefaultMaxAttempts = 5
 
 // Client defines {{$clientID}} client interface.
@@ -3365,7 +3366,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14626, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14684, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3133,7 +3133,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
 	}else{
-	    maxAttempts = 5
+		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,
@@ -3366,7 +3366,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14609, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14606, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3129,51 +3129,31 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-
-	var client *zanzibar.TChannelClient
-
+	var maxAttempts int
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
-		maxAttempts := int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
-		client = zanzibar.NewTChannelClientContext(
-				channel,
-				deps.Default.ContextLogger,
-				deps.Default.ContextMetrics,
-				deps.Default.ContextExtractor,
-				&zanzibar.TChannelClientOption{
-					ServiceName:          serviceName,
-					ClientID:             "{{$clientID}}",
-					MethodNames:          methodNames,
-					Timeout:              timeout,
-					TimeoutPerAttempt:    timeoutPerAttempt,
-					RoutingKey:           &routingKey,
-					RuleEngine:           re,
-					HeaderPatterns:       headerPatterns,
-					RequestUUIDHeaderKey: requestUUIDHeaderKey,
-					AltChannelMap:        altChannelMap,
-					MaxAttempts:          maxAttempts,
-				},
-			)
+		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
 	}else{
-		client = zanzibar.NewTChannelClientContext(
-				channel,
-				deps.Default.ContextLogger,
-				deps.Default.ContextMetrics,
-				deps.Default.ContextExtractor,
-				&zanzibar.TChannelClientOption{
-					ServiceName:          serviceName,
-					ClientID:             "{{$clientID}}",
-					MethodNames:          methodNames,
-					Timeout:              timeout,
-					TimeoutPerAttempt:    timeoutPerAttempt,
-					RoutingKey:           &routingKey,
-					RuleEngine:           re,
-					HeaderPatterns:       headerPatterns,
-					RequestUUIDHeaderKey: requestUUIDHeaderKey,
-					AltChannelMap:        altChannelMap,
-				},
-			)
+	    maxAttempts = 5
 	}
-
+	client := zanzibar.NewTChannelClientContext(
+		channel,
+		deps.Default.ContextLogger,
+		deps.Default.ContextMetrics,
+		deps.Default.ContextExtractor,
+		&zanzibar.TChannelClientOption{
+			ServiceName:          serviceName,
+			ClientID:             "{{$clientID}}",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			RuleEngine:           re,
+			HeaderPatterns:       headerPatterns,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
+			AltChannelMap:        altChannelMap,
+			MaxAttempts:          maxAttempts,
+		},
+	)
 	return &{{$clientName}}{
 		client: client,
 		circuitBreakerDisabled: circuitBreakerDisabled,
@@ -3386,7 +3366,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 15262, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14609, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2998,6 +2998,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+const DefaultMaxAttempts = 5
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -3129,11 +3130,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-	var maxAttempts int
+	var maxAttempts = DefaultMaxAttempts
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
-	}else{
-		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,
@@ -3366,7 +3365,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14606, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 14626, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -170,7 +170,7 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
 	}else{
-	    maxAttempts = 5
+		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -35,6 +35,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+// DefaultMaxAttempts is the default retries for a client
 const DefaultMaxAttempts = 5
 
 // Client defines {{$clientID}} client interface.

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -166,51 +166,31 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-
-	var client *zanzibar.TChannelClient
-
+	var maxAttempts int
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
-		maxAttempts := int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
-		client = zanzibar.NewTChannelClientContext(
-				channel,
-				deps.Default.ContextLogger,
-				deps.Default.ContextMetrics,
-				deps.Default.ContextExtractor,
-				&zanzibar.TChannelClientOption{
-					ServiceName:          serviceName,
-					ClientID:             "{{$clientID}}",
-					MethodNames:          methodNames,
-					Timeout:              timeout,
-					TimeoutPerAttempt:    timeoutPerAttempt,
-					RoutingKey:           &routingKey,
-					RuleEngine:           re,
-					HeaderPatterns:       headerPatterns,
-					RequestUUIDHeaderKey: requestUUIDHeaderKey,
-					AltChannelMap:        altChannelMap,
-					MaxAttempts:          maxAttempts,
-				},
-			)
+		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
 	}else{
-		client = zanzibar.NewTChannelClientContext(
-				channel,
-				deps.Default.ContextLogger,
-				deps.Default.ContextMetrics,
-				deps.Default.ContextExtractor,
-				&zanzibar.TChannelClientOption{
-					ServiceName:          serviceName,
-					ClientID:             "{{$clientID}}",
-					MethodNames:          methodNames,
-					Timeout:              timeout,
-					TimeoutPerAttempt:    timeoutPerAttempt,
-					RoutingKey:           &routingKey,
-					RuleEngine:           re,
-					HeaderPatterns:       headerPatterns,
-					RequestUUIDHeaderKey: requestUUIDHeaderKey,
-					AltChannelMap:        altChannelMap,
-				},
-			)
+	    maxAttempts = 5
 	}
-
+	client := zanzibar.NewTChannelClientContext(
+		channel,
+		deps.Default.ContextLogger,
+		deps.Default.ContextMetrics,
+		deps.Default.ContextExtractor,
+		&zanzibar.TChannelClientOption{
+			ServiceName:          serviceName,
+			ClientID:             "{{$clientID}}",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			RuleEngine:           re,
+			HeaderPatterns:       headerPatterns,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
+			AltChannelMap:        altChannelMap,
+			MaxAttempts:          maxAttempts,
+		},
+	)
 	return &{{$clientName}}{
 		client: client,
 		circuitBreakerDisabled: circuitBreakerDisabled,

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -35,6 +35,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+const DefaultMaxAttempts = 5
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -166,11 +167,9 @@ func {{$exportName}}(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-	var maxAttempts int
+	var maxAttempts = DefaultMaxAttempts
 	if  deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.{{$clientID}}.retryCount") && int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount")) > 0{
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.{{$clientID}}.retryCount"))
-	}else{
-		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -46,6 +46,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+const DefaultMaxAttempts = 5
 
 // Client defines baz client interface.
 type Client interface {
@@ -328,11 +329,9 @@ func NewClient(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-	var maxAttempts int
+	var maxAttempts = DefaultMaxAttempts
 	if deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.baz.retryCount") && int(deps.Default.Config.MustGetInt("clients.baz.retryCount")) > 0 {
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.baz.retryCount"))
-	} else {
-		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -46,6 +46,8 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+
+// DefaultMaxAttempts is the default retries for a client
 const DefaultMaxAttempts = 5
 
 // Client defines baz client interface.

--- a/examples/example-gateway/build/clients/baz/baz.go
+++ b/examples/example-gateway/build/clients/baz/baz.go
@@ -328,51 +328,31 @@ func NewClient(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-
-	var client *zanzibar.TChannelClient
-
+	var maxAttempts int
 	if deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.baz.retryCount") && int(deps.Default.Config.MustGetInt("clients.baz.retryCount")) > 0 {
-		maxAttempts := int(deps.Default.Config.MustGetInt("clients.baz.retryCount"))
-		client = zanzibar.NewTChannelClientContext(
-			channel,
-			deps.Default.ContextLogger,
-			deps.Default.ContextMetrics,
-			deps.Default.ContextExtractor,
-			&zanzibar.TChannelClientOption{
-				ServiceName:          serviceName,
-				ClientID:             "baz",
-				MethodNames:          methodNames,
-				Timeout:              timeout,
-				TimeoutPerAttempt:    timeoutPerAttempt,
-				RoutingKey:           &routingKey,
-				RuleEngine:           re,
-				HeaderPatterns:       headerPatterns,
-				RequestUUIDHeaderKey: requestUUIDHeaderKey,
-				AltChannelMap:        altChannelMap,
-				MaxAttempts:          maxAttempts,
-			},
-		)
+		maxAttempts = int(deps.Default.Config.MustGetInt("clients.baz.retryCount"))
 	} else {
-		client = zanzibar.NewTChannelClientContext(
-			channel,
-			deps.Default.ContextLogger,
-			deps.Default.ContextMetrics,
-			deps.Default.ContextExtractor,
-			&zanzibar.TChannelClientOption{
-				ServiceName:          serviceName,
-				ClientID:             "baz",
-				MethodNames:          methodNames,
-				Timeout:              timeout,
-				TimeoutPerAttempt:    timeoutPerAttempt,
-				RoutingKey:           &routingKey,
-				RuleEngine:           re,
-				HeaderPatterns:       headerPatterns,
-				RequestUUIDHeaderKey: requestUUIDHeaderKey,
-				AltChannelMap:        altChannelMap,
-			},
-		)
+		maxAttempts = 5
 	}
-
+	client := zanzibar.NewTChannelClientContext(
+		channel,
+		deps.Default.ContextLogger,
+		deps.Default.ContextMetrics,
+		deps.Default.ContextExtractor,
+		&zanzibar.TChannelClientOption{
+			ServiceName:          serviceName,
+			ClientID:             "baz",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			RuleEngine:           re,
+			HeaderPatterns:       headerPatterns,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
+			AltChannelMap:        altChannelMap,
+			MaxAttempts:          maxAttempts,
+		},
+	)
 	return &bazClient{
 		client:                 client,
 		circuitBreakerDisabled: circuitBreakerDisabled,

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -45,6 +45,7 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+const DefaultMaxAttempts = 5
 
 // Client defines corge client interface.
 type Client interface {
@@ -147,11 +148,9 @@ func NewClient(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-	var maxAttempts int
+	var maxAttempts = DefaultMaxAttempts
 	if deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.corge.retryCount") && int(deps.Default.Config.MustGetInt("clients.corge.retryCount")) > 0 {
 		maxAttempts = int(deps.Default.Config.MustGetInt("clients.corge.retryCount"))
-	} else {
-		maxAttempts = 5
 	}
 	client := zanzibar.NewTChannelClientContext(
 		channel,

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -45,6 +45,8 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+
+// DefaultMaxAttempts is the default retries for a client
 const DefaultMaxAttempts = 5
 
 // Client defines corge client interface.

--- a/examples/example-gateway/build/clients/corge/corge.go
+++ b/examples/example-gateway/build/clients/corge/corge.go
@@ -147,51 +147,31 @@ func NewClient(deps *module.Dependencies) Client {
 			configureCircuitBreaker(deps, timeoutVal, circuitBreakerName, qpsLevel)
 		}
 	}
-
-	var client *zanzibar.TChannelClient
-
+	var maxAttempts int
 	if deps.Default.Config.ContainsKey("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.MustGetBoolean("tchannelclients.retryCount.feature.enabled") && deps.Default.Config.ContainsKey("clients.corge.retryCount") && int(deps.Default.Config.MustGetInt("clients.corge.retryCount")) > 0 {
-		maxAttempts := int(deps.Default.Config.MustGetInt("clients.corge.retryCount"))
-		client = zanzibar.NewTChannelClientContext(
-			channel,
-			deps.Default.ContextLogger,
-			deps.Default.ContextMetrics,
-			deps.Default.ContextExtractor,
-			&zanzibar.TChannelClientOption{
-				ServiceName:          serviceName,
-				ClientID:             "corge",
-				MethodNames:          methodNames,
-				Timeout:              timeout,
-				TimeoutPerAttempt:    timeoutPerAttempt,
-				RoutingKey:           &routingKey,
-				RuleEngine:           re,
-				HeaderPatterns:       headerPatterns,
-				RequestUUIDHeaderKey: requestUUIDHeaderKey,
-				AltChannelMap:        altChannelMap,
-				MaxAttempts:          maxAttempts,
-			},
-		)
+		maxAttempts = int(deps.Default.Config.MustGetInt("clients.corge.retryCount"))
 	} else {
-		client = zanzibar.NewTChannelClientContext(
-			channel,
-			deps.Default.ContextLogger,
-			deps.Default.ContextMetrics,
-			deps.Default.ContextExtractor,
-			&zanzibar.TChannelClientOption{
-				ServiceName:          serviceName,
-				ClientID:             "corge",
-				MethodNames:          methodNames,
-				Timeout:              timeout,
-				TimeoutPerAttempt:    timeoutPerAttempt,
-				RoutingKey:           &routingKey,
-				RuleEngine:           re,
-				HeaderPatterns:       headerPatterns,
-				RequestUUIDHeaderKey: requestUUIDHeaderKey,
-				AltChannelMap:        altChannelMap,
-			},
-		)
+		maxAttempts = 5
 	}
-
+	client := zanzibar.NewTChannelClientContext(
+		channel,
+		deps.Default.ContextLogger,
+		deps.Default.ContextMetrics,
+		deps.Default.ContextExtractor,
+		&zanzibar.TChannelClientOption{
+			ServiceName:          serviceName,
+			ClientID:             "corge",
+			MethodNames:          methodNames,
+			Timeout:              timeout,
+			TimeoutPerAttempt:    timeoutPerAttempt,
+			RoutingKey:           &routingKey,
+			RuleEngine:           re,
+			HeaderPatterns:       headerPatterns,
+			RequestUUIDHeaderKey: requestUUIDHeaderKey,
+			AltChannelMap:        altChannelMap,
+			MaxAttempts:          maxAttempts,
+		},
+	)
 	return &corgeClient{
 		client:                 client,
 		circuitBreakerDisabled: circuitBreakerDisabled,


### PR DESCRIPTION
With this pull request we are trying to optimize the code that get generated for every tchannel client. 
Since by default the maxAttempts should be 5 for all tchannel clients if not specifically mentioned, so through this change we will be passing 5 if it is not set.