### PR TITLE
Add missing import for thriftrw stream package

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -3522,8 +3522,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/thriftrw/wire"
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
 	tchannel "github.com/uber/tchannel-go"
 	zanzibar "github.com/uber/zanzibar/runtime"
 
@@ -3795,7 +3796,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8930, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8942, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -10,8 +10,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.uber.org/thriftrw/wire"
+	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
 	tchannel "github.com/uber/tchannel-go"
 	zanzibar "github.com/uber/zanzibar/runtime"
 

--- a/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/app/demo/endpoints/abc/abc_appdemoservice_method_call_tchannel.go
@@ -28,9 +28,10 @@ import (
 	"runtime/debug"
 
 	"github.com/pkg/errors"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	customAbc "github.com/uber/zanzibar/examples/example-gateway/app/demo/endpoints/abc"
 	endpointsIDlEndpointsAppDemoEndpointsAbc "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/app/demo/endpoints/abc"

--- a/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/example-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -29,10 +29,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsBounceBounce "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/bounce/bounce"
 	customBounce "github.com/uber/zanzibar/examples/example-gateway/endpoints/bounce"

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_call_tchannel.go
@@ -30,10 +30,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsTchannelBazBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/baz/baz"
 	customBaz "github.com/uber/zanzibar/examples/example-gateway/endpoints/tchannel/baz"

--- a/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/baz/baz_simpleservice_method_echo_tchannel.go
@@ -29,10 +29,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsTchannelBazBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/baz/baz"
 	customBaz "github.com/uber/zanzibar/examples/example-gateway/endpoints/tchannel/baz"

--- a/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/echo/echo_echo_method_echo_tchannel.go
@@ -29,10 +29,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsTchannelEchoEcho "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/echo/echo"
 	customEcho "github.com/uber/zanzibar/examples/example-gateway/endpoints/tchannel/echo"

--- a/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/panic/panic_simpleservice_method_anothercall_tchannel.go
@@ -30,10 +30,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsTchannelBazBaz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/baz/baz"
 	customBaz "github.com/uber/zanzibar/examples/example-gateway/endpoints/tchannel/panic"

--- a/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
+++ b/examples/example-gateway/build/endpoints/tchannel/quux/quux_simpleservice_method_echostring_tchannel.go
@@ -29,10 +29,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsIDlEndpointsTchannelQuuxQuux "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/endpoints-idl/endpoints/tchannel/quux/quux"
 	customQuux "github.com/uber/zanzibar/examples/example-gateway/endpoints/tchannel/quux"

--- a/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
+++ b/examples/selective-gateway/build/endpoints/bounce/bounce_bounce_method_bounce_tchannel.go
@@ -29,10 +29,11 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	tchannel "github.com/uber/tchannel-go"
-	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/thriftrw/protocol/stream"
 	"go.uber.org/zap"
+
+	tchannel "github.com/uber/tchannel-go"
+	zanzibar "github.com/uber/zanzibar/runtime"
 
 	endpointsBounceBounce "github.com/uber/zanzibar/examples/selective-gateway/build/gen-code/endpoints/bounce/bounce"
 	customBounce "github.com/uber/zanzibar/examples/selective-gateway/endpoints/bounce"


### PR DESCRIPTION
## Summary
| PR Status  | Type  | Impact level |
| :---: | :---: | :---: |
| Ready  | Chore | Low |

## Description
- Add a dedicated import for `"go.uber.org/thriftrw/protocol/stream"``
- Remove unused import `"go.uber.org/thriftrw/wire"`
- Only one line is changed in `tchannel_endpoint.tmpl`. Rest is auto generated.

## Motivation 
- When we enabled streaming interfaces in Zanzibar, #811 we missed adding an import in the template. Usually this isn't a problem because we run `goimports` on the generated code. However, some other repositories aren't smart enough and fail to resolve the `stream.Reader` imports


