### PR TITLE
Expose DepsTree through the main fx module

### DIFF
--- a/codegen/templates/main.tmpl
+++ b/codegen/templates/main.tmpl
@@ -55,6 +55,8 @@ type Result struct {
 	Gateway *zanzibar.Gateway
 	// Provider is an abstraction over the Zanzibar config store
 	Provider uberconfig.Provider `name:"zanzibarConfig"`
+	// Deps is a reference to the dependency tree inside zanzibar gateway
+	Deps *service.DependenciesTree
 }
 
 func main() {
@@ -74,7 +76,7 @@ func run(gateway *zanzibar.Gateway) {
 // or modify Result. Most users should use Module instead.
 func New(p Params) (Result, error) {
 	readFlags()
-	gateway, err := createGateway()
+	gateway, deps, err := createGateway()
 	if err != nil {
 		return Result{}, errors.Wrap(err, "failed to create gateway server")
 	}
@@ -113,16 +115,17 @@ func New(p Params) (Result, error) {
 	return Result{
 		Gateway: gateway,
 		Provider: provider,
+		Deps: deps,
 	}, nil
 }
 
-func createGateway() (*zanzibar.Gateway, error) {
+func createGateway() (*zanzibar.Gateway, *service.DependenciesTree, error) {
 	cfg := getConfig()
-	gateway, _, err := service.CreateGateway(cfg, app.AppOptions)
+	gateway, deps, err := service.CreateGateway(cfg, app.AppOptions)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return gateway, nil
+	return gateway, deps.(*service.DependenciesTree), nil
 }
 
 func getConfig() *zanzibar.StaticConfig {

--- a/codegen/templates/main_test.tmpl
+++ b/codegen/templates/main_test.tmpl
@@ -13,9 +13,10 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	zanzibar "github.com/uber/zanzibar/runtime"
 
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 )
@@ -57,7 +58,7 @@ func TestStartGateway(t *testing.T) {
 		),
 	)
 
-	gateway, err := createGateway()
+	gateway, deps, err := createGateway()
 	if err != nil {
 		testLogger.Error(
 			"Failed to CreateGateway in TestStartGateway()",
@@ -65,6 +66,7 @@ func TestStartGateway(t *testing.T) {
 		)
 		return
 	}
+	assert.NotNil(t, deps)
 
 	cachedServer = gateway
 	err = gateway.Bootstrap()


### PR DESCRIPTION
Updates the main.tmpl file to expose the server's dependency tree so
that each of the underlying components can be pluggable into other applications.

This change should not be merged back into the main
branch because it leaks internal abstractions from the main
server. The change is needed for internal reasons.