### PR TITLE
add logs

### DIFF
--- a/runtime/router.go
+++ b/runtime/router.go
@@ -220,6 +220,8 @@ func (router *httpRouter) handlePanic(
 		"A http request handler paniced",
 		zap.Error(err),
 		zap.String("pathname", r.URL.RequestURI()),
+		zap.String("host", r.Host),
+		zap.String("remoteAddr", r.RemoteAddr),
 	)
 	router.panicCount.Inc(1)
 


### PR DESCRIPTION
Log request.Host and request.RemoteAddr during panic .
as far as we know only logging  Host and RemoteAddr fields from request   may help us to debug during panic .

=>RemoteAddr allows HTTP servers and other software to record
the network address that sent the request, usually for
 logging. This field is not filled in by ReadRequest and
 has no defined format. The HTTP server in this package
 sets RemoteAddr to an "IP:port" address before invoking a
 handler. 

