### PR TITLE
add additional logs for debug

### DIFF
--- a/runtime/router.go
+++ b/runtime/router.go
@@ -220,6 +220,8 @@ func (router *httpRouter) handlePanic(
 		"A http request handler paniced",
 		zap.Error(err),
 		zap.String("pathname", r.URL.RequestURI()),
+		zap.String("host", r.Host),
+		zap.String("remoteAddr", r.RemoteAddr),
 	)
 	router.panicCount.Inc(1)
 


### PR DESCRIPTION
added logs to log request.host and request.remoteaddr during panic which may help to debug https://t3.uberinternal.com/browse/LOCATION-4808 .
