### PR TITLE
Log request headers during panic for debug

### DIFF
--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -98,6 +98,7 @@ func (s *routerSuite) TestRouter() {
 
 	for i, testCase := range cases {
 		req := httptest.NewRequest(testCase.RequestMethod, testCase.RequestPath, bytes.NewBuffer(testCase.RequestBody))
+		req.Header.Set("Test_Key", "Test_Value")
 		w := httptest.NewRecorder()
 		s.router.ServeHTTP(w, req)
 		s.Equal(testCase.ResponseCode, w.Code, "expected response code for %dth test case to be equal", i)


### PR DESCRIPTION
Logged request.Header during panic which may help to debug https://t3.uberinternal.com/browse/LOCATION-4808 .