### PR TITLE
update benchmark cpu param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ test-only:
 .PHONY: fast-bench
 fast-bench:
 	@rm -f bench.log bench-fail.log
-	time -p sh -c "go test -run _NONE_ -bench . -benchmem -benchtime 1s -cpu 2 ./test/... | grep -v '^ok ' | grep -v '\[no test files\]' | grep -v '^PASS'  | tee -a bench.log"
+	time -p sh -c "go test -run _NONE_ -bench . -benchmem -benchtime 1s -cpu 1 ./test/... | grep -v '^ok ' | grep -v '\[no test files\]' | grep -v '^PASS'  | tee -a bench.log"
 	@cat bench.log | grep "FAIL" | tee -a bench-fail.log
 	@[ ! -s bench-fail.log ]
 


### PR DESCRIPTION
- Making benchmark CPU param to 1 from 2.
- These benchmarks are pretty flaky in nature and marking CPU param as 1 is fixing the issue. **refer -** https://github.com/uber/zanzibar/actions/runs/3272024477/jobs/5382526571