### PR TITLE
Propagated context returned from middleware

### DIFF
--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -110,7 +110,8 @@ func (m *MiddlewareStack) Handle(
 	shared := NewSharedState(m.middlewares)
 
 	for i := 0; i < len(m.middlewares); i++ {
-		ctx, ok := m.middlewares[i].HandleRequest(ctx, req, res, shared)
+		var ok bool
+		ctx, ok = m.middlewares[i].HandleRequest(ctx, req, res, shared)
 		// If a middleware errors and writes to the response header
 		// then abort the rest of the stack and evaluate the response
 		// handlers for the middlewares seen so far.


### PR DESCRIPTION
The current code was calling HandleRequest method on middlewares but the returned context was not passed to next middleware and to the actual handler itself.

The way the code was written was leading to creation of new context instead of setting the value of already defined context.

This is leading to issues like some fields (like start timestamp) added by logging middleware were not being present in emitted log as the context returned by HandleRequest method was never propagated further.