### PR TITLE
Fix grpc client

### DIFF
--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1419,16 +1419,16 @@ func (e *{{$clientName}}) {{$methodName}}(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
-	ctx, cancel := context.WithTimeout(ctx, e.opts.Timeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
 	runFunc := e.{{camel $svc.Name}}Client.{{$method.Name}}
 	callHelper.Start()
 	if e.opts.CircuitBreakerDisabled {
-		result, err = runFunc(ctx, request, opts...)
+		result, err = runFunc(ctxWithTimeout, request, opts...)
 	} else {
 		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
-		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
+		err = hystrix.DoC(ctxWithTimeout, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)
@@ -1452,7 +1452,7 @@ func grpc_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "grpc_client.tmpl", size: 8439, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "grpc_client.tmpl", size: 8472, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -1419,6 +1419,8 @@ func (e *{{$clientName}}) {{$methodName}}(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
+	// Creating a new child context with timeout for the yarpc call as this gets cancelled as soon as call is returned
+	// from this client or deadline exceeded after timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
@@ -1452,7 +1454,7 @@ func grpc_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "grpc_client.tmpl", size: 8472, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "grpc_client.tmpl", size: 8644, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/codegen/templates/grpc_client.tmpl
+++ b/codegen/templates/grpc_client.tmpl
@@ -200,16 +200,16 @@ func (e *{{$clientName}}) {{$methodName}}(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
-	ctx, cancel := context.WithTimeout(ctx, e.opts.Timeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
 	runFunc := e.{{camel $svc.Name}}Client.{{$method.Name}}
 	callHelper.Start()
 	if e.opts.CircuitBreakerDisabled {
-		result, err = runFunc(ctx, request, opts...)
+		result, err = runFunc(ctxWithTimeout, request, opts...)
 	} else {
 		circuitBreakerName := "{{$clientID}}" + "-" + "{{$methodName}}"
-		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
+		err = hystrix.DoC(ctxWithTimeout, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)

--- a/codegen/templates/grpc_client.tmpl
+++ b/codegen/templates/grpc_client.tmpl
@@ -200,6 +200,8 @@ func (e *{{$clientName}}) {{$methodName}}(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
+	// Creating a new child context with timeout for the yarpc call as this gets cancelled as soon as call is returned
+	// from this client or deadline exceeded after timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 

--- a/examples/example-gateway/build/clients/bar/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/bar/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	bar "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/bar/bar"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +37,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ArgNotStruct mocks base method.
-func (m *MockClient) ArgNotStruct(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgNotStruct_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) ArgNotStruct(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgNotStruct_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgNotStruct", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -53,7 +53,7 @@ func (mr *MockClientMockRecorder) ArgNotStruct(arg0, arg1, arg2, arg3 interface{
 }
 
 // ArgWithHeaders mocks base method.
-func (m *MockClient) ArgWithHeaders(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithHeaders_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithHeaders(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithHeaders_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithHeaders", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -70,7 +70,7 @@ func (mr *MockClientMockRecorder) ArgWithHeaders(arg0, arg1, arg2, arg3 interfac
 }
 
 // ArgWithManyQueryParams mocks base method.
-func (m *MockClient) ArgWithManyQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithManyQueryParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithManyQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithManyQueryParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithManyQueryParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -87,7 +87,7 @@ func (mr *MockClientMockRecorder) ArgWithManyQueryParams(arg0, arg1, arg2, arg3 
 }
 
 // ArgWithNearDupQueryParams mocks base method.
-func (m *MockClient) ArgWithNearDupQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithNearDupQueryParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithNearDupQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithNearDupQueryParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithNearDupQueryParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -104,7 +104,7 @@ func (mr *MockClientMockRecorder) ArgWithNearDupQueryParams(arg0, arg1, arg2, ar
 }
 
 // ArgWithNestedQueryParams mocks base method.
-func (m *MockClient) ArgWithNestedQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithNestedQueryParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithNestedQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithNestedQueryParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithNestedQueryParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -121,7 +121,7 @@ func (mr *MockClientMockRecorder) ArgWithNestedQueryParams(arg0, arg1, arg2, arg
 }
 
 // ArgWithParams mocks base method.
-func (m *MockClient) ArgWithParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -138,7 +138,7 @@ func (mr *MockClientMockRecorder) ArgWithParams(arg0, arg1, arg2, arg3 interface
 }
 
 // ArgWithParamsAndDuplicateFields mocks base method.
-func (m *MockClient) ArgWithParamsAndDuplicateFields(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithParamsAndDuplicateFields_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithParamsAndDuplicateFields(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithParamsAndDuplicateFields_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithParamsAndDuplicateFields", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -155,7 +155,7 @@ func (mr *MockClientMockRecorder) ArgWithParamsAndDuplicateFields(arg0, arg1, ar
 }
 
 // ArgWithQueryHeader mocks base method.
-func (m *MockClient) ArgWithQueryHeader(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithQueryHeader_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithQueryHeader(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithQueryHeader_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithQueryHeader", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -172,7 +172,7 @@ func (mr *MockClientMockRecorder) ArgWithQueryHeader(arg0, arg1, arg2, arg3 inte
 }
 
 // ArgWithQueryParams mocks base method.
-func (m *MockClient) ArgWithQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithQueryParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) ArgWithQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ArgWithQueryParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ArgWithQueryParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -189,7 +189,7 @@ func (mr *MockClientMockRecorder) ArgWithQueryParams(arg0, arg1, arg2, arg3 inte
 }
 
 // DeleteFoo mocks base method.
-func (m *MockClient) DeleteFoo(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteFoo_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) DeleteFoo(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteFoo_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteFoo", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -205,7 +205,7 @@ func (mr *MockClientMockRecorder) DeleteFoo(arg0, arg1, arg2, arg3 interface{}) 
 }
 
 // DeleteWithBody mocks base method.
-func (m *MockClient) DeleteWithBody(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteWithBody_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) DeleteWithBody(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteWithBody_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteWithBody", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -221,7 +221,7 @@ func (mr *MockClientMockRecorder) DeleteWithBody(arg0, arg1, arg2, arg3 interfac
 }
 
 // DeleteWithQueryParams mocks base method.
-func (m *MockClient) DeleteWithQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteWithQueryParams_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) DeleteWithQueryParams(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_DeleteWithQueryParams_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteWithQueryParams", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -237,7 +237,7 @@ func (mr *MockClientMockRecorder) DeleteWithQueryParams(arg0, arg1, arg2, arg3 i
 }
 
 // EchoBinary mocks base method.
-func (m *MockClient) EchoBinary(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoBinary_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []byte, map[string]string, error) {
+func (m *MockClient) EchoBinary(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoBinary_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []byte, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoBinary", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -254,7 +254,7 @@ func (mr *MockClientMockRecorder) EchoBinary(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoBool mocks base method.
-func (m *MockClient) EchoBool(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoBool_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, bool, map[string]string, error) {
+func (m *MockClient) EchoBool(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoBool_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, bool, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoBool", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -271,7 +271,7 @@ func (mr *MockClientMockRecorder) EchoBool(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // EchoDouble mocks base method.
-func (m *MockClient) EchoDouble(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoDouble_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, float64, map[string]string, error) {
+func (m *MockClient) EchoDouble(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoDouble_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, float64, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoDouble", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -288,7 +288,7 @@ func (mr *MockClientMockRecorder) EchoDouble(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoEnum mocks base method.
-func (m *MockClient) EchoEnum(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoEnum_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, bar.Fruit, map[string]string, error) {
+func (m *MockClient) EchoEnum(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoEnum_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, bar.Fruit, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoEnum", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -305,7 +305,7 @@ func (mr *MockClientMockRecorder) EchoEnum(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // EchoI16 mocks base method.
-func (m *MockClient) EchoI16(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI16_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int16, map[string]string, error) {
+func (m *MockClient) EchoI16(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI16_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int16, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI16", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -322,7 +322,7 @@ func (mr *MockClientMockRecorder) EchoI16(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI32 mocks base method.
-func (m *MockClient) EchoI32(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI32_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int32, map[string]string, error) {
+func (m *MockClient) EchoI32(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI32_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int32, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI32", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -339,7 +339,7 @@ func (mr *MockClientMockRecorder) EchoI32(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI32Map mocks base method.
-func (m *MockClient) EchoI32Map(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI32Map_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[int32]*bar.BarResponse, map[string]string, error) {
+func (m *MockClient) EchoI32Map(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI32Map_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[int32]*bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI32Map", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -356,7 +356,7 @@ func (mr *MockClientMockRecorder) EchoI32Map(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoI64 mocks base method.
-func (m *MockClient) EchoI64(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI64_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int64, map[string]string, error) {
+func (m *MockClient) EchoI64(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI64_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int64, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI64", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -373,7 +373,7 @@ func (mr *MockClientMockRecorder) EchoI64(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI8 mocks base method.
-func (m *MockClient) EchoI8(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI8_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int8, map[string]string, error) {
+func (m *MockClient) EchoI8(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoI8_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int8, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI8", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -390,7 +390,7 @@ func (mr *MockClientMockRecorder) EchoI8(arg0, arg1, arg2, arg3 interface{}) *go
 }
 
 // EchoString mocks base method.
-func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoString_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoString_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoString", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -407,7 +407,7 @@ func (mr *MockClientMockRecorder) EchoString(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoStringList mocks base method.
-func (m *MockClient) EchoStringList(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringList_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []string, map[string]string, error) {
+func (m *MockClient) EchoStringList(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringList_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringList", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -424,7 +424,7 @@ func (mr *MockClientMockRecorder) EchoStringList(arg0, arg1, arg2, arg3 interfac
 }
 
 // EchoStringMap mocks base method.
-func (m *MockClient) EchoStringMap(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringMap_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]*bar.BarResponse, map[string]string, error) {
+func (m *MockClient) EchoStringMap(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringMap_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]*bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringMap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -441,7 +441,7 @@ func (mr *MockClientMockRecorder) EchoStringMap(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoStringSet mocks base method.
-func (m *MockClient) EchoStringSet(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringSet_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]struct{}, map[string]string, error) {
+func (m *MockClient) EchoStringSet(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStringSet_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]struct{}, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringSet", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -458,7 +458,7 @@ func (mr *MockClientMockRecorder) EchoStringSet(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoStructList mocks base method.
-func (m *MockClient) EchoStructList(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStructList_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []*bar.BarResponse, map[string]string, error) {
+func (m *MockClient) EchoStructList(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStructList_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []*bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStructList", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -475,7 +475,7 @@ func (mr *MockClientMockRecorder) EchoStructList(arg0, arg1, arg2, arg3 interfac
 }
 
 // EchoStructSet mocks base method.
-func (m *MockClient) EchoStructSet(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStructSet_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []*bar.BarResponse, map[string]string, error) {
+func (m *MockClient) EchoStructSet(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoStructSet_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []*bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStructSet", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -492,7 +492,7 @@ func (mr *MockClientMockRecorder) EchoStructSet(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoTypedef mocks base method.
-func (m *MockClient) EchoTypedef(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoTypedef_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, bar.UUID, map[string]string, error) {
+func (m *MockClient) EchoTypedef(arg0 context.Context, arg1 map[string]string, arg2 *bar.Echo_EchoTypedef_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, bar.UUID, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoTypedef", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -509,10 +509,10 @@ func (mr *MockClientMockRecorder) EchoTypedef(arg0, arg1, arg2, arg3 interface{}
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 
@@ -523,7 +523,7 @@ func (mr *MockClientMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // Hello mocks base method.
-func (m *MockClient) Hello(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) Hello(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Hello", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -540,7 +540,7 @@ func (mr *MockClientMockRecorder) Hello(arg0, arg1, arg2 interface{}) *gomock.Ca
 }
 
 // ListAndEnum mocks base method.
-func (m *MockClient) ListAndEnum(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ListAndEnum_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) ListAndEnum(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_ListAndEnum_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAndEnum", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -557,7 +557,7 @@ func (mr *MockClientMockRecorder) ListAndEnum(arg0, arg1, arg2, arg3 interface{}
 }
 
 // MissingArg mocks base method.
-func (m *MockClient) MissingArg(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) MissingArg(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MissingArg", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -574,7 +574,7 @@ func (mr *MockClientMockRecorder) MissingArg(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // NoRequest mocks base method.
-func (m *MockClient) NoRequest(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) NoRequest(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NoRequest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -591,7 +591,7 @@ func (mr *MockClientMockRecorder) NoRequest(arg0, arg1, arg2 interface{}) *gomoc
 }
 
 // Normal mocks base method.
-func (m *MockClient) Normal(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_Normal_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) Normal(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_Normal_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Normal", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -608,7 +608,7 @@ func (mr *MockClientMockRecorder) Normal(arg0, arg1, arg2, arg3 interface{}) *go
 }
 
 // NormalRecur mocks base method.
-func (m *MockClient) NormalRecur(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_NormalRecur_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponseRecur, map[string]string, error) {
+func (m *MockClient) NormalRecur(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_NormalRecur_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponseRecur, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NormalRecur", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -625,7 +625,7 @@ func (mr *MockClientMockRecorder) NormalRecur(arg0, arg1, arg2, arg3 interface{}
 }
 
 // TooManyArgs mocks base method.
-func (m *MockClient) TooManyArgs(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_TooManyArgs_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
+func (m *MockClient) TooManyArgs(arg0 context.Context, arg1 map[string]string, arg2 *bar.Bar_TooManyArgs_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *bar.BarResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TooManyArgs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/baz/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/baz/mock-client/mock_client.go
@@ -11,7 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	base "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/baz/base"
 	baz "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/baz/baz"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -38,7 +38,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockClient) Call(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Call_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) Call(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Call_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Call", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -54,7 +54,7 @@ func (mr *MockClientMockRecorder) Call(arg0, arg1, arg2, arg3 interface{}) *gomo
 }
 
 // Compare mocks base method.
-func (m *MockClient) Compare(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Compare_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *base.BazResponse, map[string]string, error) {
+func (m *MockClient) Compare(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Compare_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *base.BazResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Compare", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -71,7 +71,7 @@ func (mr *MockClientMockRecorder) Compare(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // DeliberateDiffNoop mocks base method.
-func (m *MockClient) DeliberateDiffNoop(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) DeliberateDiffNoop(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeliberateDiffNoop", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -87,7 +87,7 @@ func (mr *MockClientMockRecorder) DeliberateDiffNoop(arg0, arg1, arg2 interface{
 }
 
 // EchoBinary mocks base method.
-func (m *MockClient) EchoBinary(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoBinary_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []byte, map[string]string, error) {
+func (m *MockClient) EchoBinary(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoBinary_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []byte, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoBinary", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -104,7 +104,7 @@ func (mr *MockClientMockRecorder) EchoBinary(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoBool mocks base method.
-func (m *MockClient) EchoBool(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoBool_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, bool, map[string]string, error) {
+func (m *MockClient) EchoBool(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoBool_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, bool, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoBool", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -121,7 +121,7 @@ func (mr *MockClientMockRecorder) EchoBool(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // EchoDouble mocks base method.
-func (m *MockClient) EchoDouble(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoDouble_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, float64, map[string]string, error) {
+func (m *MockClient) EchoDouble(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoDouble_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, float64, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoDouble", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -138,7 +138,7 @@ func (mr *MockClientMockRecorder) EchoDouble(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoEnum mocks base method.
-func (m *MockClient) EchoEnum(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoEnum_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, baz.Fruit, map[string]string, error) {
+func (m *MockClient) EchoEnum(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoEnum_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, baz.Fruit, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoEnum", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -155,7 +155,7 @@ func (mr *MockClientMockRecorder) EchoEnum(arg0, arg1, arg2, arg3 interface{}) *
 }
 
 // EchoI16 mocks base method.
-func (m *MockClient) EchoI16(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI16_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int16, map[string]string, error) {
+func (m *MockClient) EchoI16(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI16_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int16, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI16", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -172,7 +172,7 @@ func (mr *MockClientMockRecorder) EchoI16(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI32 mocks base method.
-func (m *MockClient) EchoI32(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI32_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int32, map[string]string, error) {
+func (m *MockClient) EchoI32(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI32_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int32, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI32", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -189,7 +189,7 @@ func (mr *MockClientMockRecorder) EchoI32(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI64 mocks base method.
-func (m *MockClient) EchoI64(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI64_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int64, map[string]string, error) {
+func (m *MockClient) EchoI64(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI64_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int64, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI64", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -206,7 +206,7 @@ func (mr *MockClientMockRecorder) EchoI64(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // EchoI8 mocks base method.
-func (m *MockClient) EchoI8(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI8_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, int8, map[string]string, error) {
+func (m *MockClient) EchoI8(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoI8_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, int8, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoI8", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -223,7 +223,7 @@ func (mr *MockClientMockRecorder) EchoI8(arg0, arg1, arg2, arg3 interface{}) *go
 }
 
 // EchoString mocks base method.
-func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoString_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoString_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoString", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -240,7 +240,7 @@ func (mr *MockClientMockRecorder) EchoString(arg0, arg1, arg2, arg3 interface{})
 }
 
 // EchoStringList mocks base method.
-func (m *MockClient) EchoStringList(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringList_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []string, map[string]string, error) {
+func (m *MockClient) EchoStringList(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringList_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringList", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -257,7 +257,7 @@ func (mr *MockClientMockRecorder) EchoStringList(arg0, arg1, arg2, arg3 interfac
 }
 
 // EchoStringMap mocks base method.
-func (m *MockClient) EchoStringMap(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringMap_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]*base.BazResponse, map[string]string, error) {
+func (m *MockClient) EchoStringMap(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringMap_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]*base.BazResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringMap", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -274,7 +274,7 @@ func (mr *MockClientMockRecorder) EchoStringMap(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoStringSet mocks base method.
-func (m *MockClient) EchoStringSet(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringSet_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]struct{}, map[string]string, error) {
+func (m *MockClient) EchoStringSet(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStringSet_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]struct{}, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStringSet", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -291,7 +291,7 @@ func (mr *MockClientMockRecorder) EchoStringSet(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoStructList mocks base method.
-func (m *MockClient) EchoStructList(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStructList_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []*base.BazResponse, map[string]string, error) {
+func (m *MockClient) EchoStructList(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStructList_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []*base.BazResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStructList", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -308,7 +308,7 @@ func (mr *MockClientMockRecorder) EchoStructList(arg0, arg1, arg2, arg3 interfac
 }
 
 // EchoStructSet mocks base method.
-func (m *MockClient) EchoStructSet(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStructSet_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, []*base.BazResponse, map[string]string, error) {
+func (m *MockClient) EchoStructSet(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoStructSet_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, []*base.BazResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoStructSet", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -325,7 +325,7 @@ func (mr *MockClientMockRecorder) EchoStructSet(arg0, arg1, arg2, arg3 interface
 }
 
 // EchoTypedef mocks base method.
-func (m *MockClient) EchoTypedef(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoTypedef_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, base.UUID, map[string]string, error) {
+func (m *MockClient) EchoTypedef(arg0 context.Context, arg1 map[string]string, arg2 *baz.SecondService_EchoTypedef_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, base.UUID, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoTypedef", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -342,7 +342,7 @@ func (mr *MockClientMockRecorder) EchoTypedef(arg0, arg1, arg2, arg3 interface{}
 }
 
 // GetProfile mocks base method.
-func (m *MockClient) GetProfile(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_GetProfile_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *baz.GetProfileResponse, map[string]string, error) {
+func (m *MockClient) GetProfile(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_GetProfile_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *baz.GetProfileResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetProfile", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -359,7 +359,7 @@ func (mr *MockClientMockRecorder) GetProfile(arg0, arg1, arg2, arg3 interface{})
 }
 
 // HeaderSchema mocks base method.
-func (m *MockClient) HeaderSchema(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_HeaderSchema_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *baz.HeaderSchema, map[string]string, error) {
+func (m *MockClient) HeaderSchema(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_HeaderSchema_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *baz.HeaderSchema, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HeaderSchema", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -376,7 +376,7 @@ func (mr *MockClientMockRecorder) HeaderSchema(arg0, arg1, arg2, arg3 interface{
 }
 
 // Ping mocks base method.
-func (m *MockClient) Ping(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, *base.BazResponse, map[string]string, error) {
+func (m *MockClient) Ping(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, *base.BazResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ping", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -393,7 +393,7 @@ func (mr *MockClientMockRecorder) Ping(arg0, arg1, arg2 interface{}) *gomock.Cal
 }
 
 // TestUUID mocks base method.
-func (m *MockClient) TestUUID(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) TestUUID(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestUUID", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -409,7 +409,7 @@ func (mr *MockClientMockRecorder) TestUUID(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // Trans mocks base method.
-func (m *MockClient) Trans(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Trans_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *base.TransStruct, map[string]string, error) {
+func (m *MockClient) Trans(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_Trans_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *base.TransStruct, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Trans", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -426,7 +426,7 @@ func (mr *MockClientMockRecorder) Trans(arg0, arg1, arg2, arg3 interface{}) *gom
 }
 
 // TransHeaders mocks base method.
-func (m *MockClient) TransHeaders(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeaders_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *base.TransHeaders, map[string]string, error) {
+func (m *MockClient) TransHeaders(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeaders_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *base.TransHeaders, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransHeaders", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -443,7 +443,7 @@ func (mr *MockClientMockRecorder) TransHeaders(arg0, arg1, arg2, arg3 interface{
 }
 
 // TransHeadersNoReq mocks base method.
-func (m *MockClient) TransHeadersNoReq(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeadersNoReq_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *base.TransHeaders, map[string]string, error) {
+func (m *MockClient) TransHeadersNoReq(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeadersNoReq_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *base.TransHeaders, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransHeadersNoReq", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -460,7 +460,7 @@ func (mr *MockClientMockRecorder) TransHeadersNoReq(arg0, arg1, arg2, arg3 inter
 }
 
 // TransHeadersType mocks base method.
-func (m *MockClient) TransHeadersType(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeadersType_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *baz.TransHeaderType, map[string]string, error) {
+func (m *MockClient) TransHeadersType(arg0 context.Context, arg1 map[string]string, arg2 *baz.SimpleService_TransHeadersType_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *baz.TransHeaderType, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TransHeadersType", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -477,7 +477,7 @@ func (mr *MockClientMockRecorder) TransHeadersType(arg0, arg1, arg2, arg3 interf
 }
 
 // URLTest mocks base method.
-func (m *MockClient) URLTest(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) URLTest(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "URLTest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/contacts/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/contacts/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	contacts "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/contacts/contacts"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,10 +37,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 
@@ -51,7 +51,7 @@ func (mr *MockClientMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // SaveContacts mocks base method.
-func (m *MockClient) SaveContacts(arg0 context.Context, arg1 map[string]string, arg2 *contacts.Contacts_SaveContacts_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *contacts.SaveContactsResponse, map[string]string, error) {
+func (m *MockClient) SaveContacts(arg0 context.Context, arg1 map[string]string, arg2 *contacts.Contacts_SaveContacts_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *contacts.SaveContactsResponse, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveContacts", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -68,7 +68,7 @@ func (mr *MockClientMockRecorder) SaveContacts(arg0, arg1, arg2, arg3 interface{
 }
 
 // TestURLURL mocks base method.
-func (m *MockClient) TestURLURL(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) TestURLURL(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestURLURL", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/corge-http/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/corge-http/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	corge "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/corge/corge"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +37,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CorgeNoContentOnException mocks base method.
-func (m *MockClient) CorgeNoContentOnException(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContentOnException_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, *corge.Foo, map[string]string, error) {
+func (m *MockClient) CorgeNoContentOnException(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContentOnException_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, *corge.Foo, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CorgeNoContentOnException", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -54,7 +54,7 @@ func (mr *MockClientMockRecorder) CorgeNoContentOnException(arg0, arg1, arg2, ar
 }
 
 // EchoString mocks base method.
-func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_EchoString_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_EchoString_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoString", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -71,10 +71,10 @@ func (mr *MockClientMockRecorder) EchoString(arg0, arg1, arg2, arg3 interface{})
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 
@@ -85,7 +85,7 @@ func (mr *MockClientMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // NoContent mocks base method.
-func (m *MockClient) NoContent(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContent_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) NoContent(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContent_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NoContent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -101,7 +101,7 @@ func (mr *MockClientMockRecorder) NoContent(arg0, arg1, arg2, arg3 interface{}) 
 }
 
 // NoContentNoException mocks base method.
-func (m *MockClient) NoContentNoException(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContentNoException_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) NoContentNoException(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_NoContentNoException_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NoContentNoException", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/corge/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/corge/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	corge "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/corge/corge"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +37,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // EchoString mocks base method.
-func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_EchoString_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) EchoString(arg0 context.Context, arg1 map[string]string, arg2 *corge.Corge_EchoString_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EchoString", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/google-now/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/google-now/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	googlenow "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/googlenow/googlenow"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +37,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddCredentials mocks base method.
-func (m *MockClient) AddCredentials(arg0 context.Context, arg1 map[string]string, arg2 *googlenow.GoogleNowService_AddCredentials_Args, arg3 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) AddCredentials(arg0 context.Context, arg1 map[string]string, arg2 *googlenow.GoogleNowService_AddCredentials_Args, arg3 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddCredentials", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(context.Context)
@@ -53,7 +53,7 @@ func (mr *MockClientMockRecorder) AddCredentials(arg0, arg1, arg2, arg3 interfac
 }
 
 // CheckCredentials mocks base method.
-func (m *MockClient) CheckCredentials(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
+func (m *MockClient) CheckCredentials(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckCredentials", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -69,10 +69,10 @@ func (mr *MockClientMockRecorder) CheckCredentials(arg0, arg1, arg2 interface{})
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 

--- a/examples/example-gateway/build/clients/multi/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/multi/mock-client/mock_client.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -36,10 +36,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 
@@ -50,7 +50,7 @@ func (mr *MockClientMockRecorder) HTTPClient() *gomock.Call {
 }
 
 // HelloA mocks base method.
-func (m *MockClient) HelloA(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) HelloA(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HelloA", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -67,7 +67,7 @@ func (mr *MockClientMockRecorder) HelloA(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // HelloB mocks base method.
-func (m *MockClient) HelloB(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
+func (m *MockClient) HelloB(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, string, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HelloB", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)

--- a/examples/example-gateway/build/clients/withexceptions/mock-client/mock_client.go
+++ b/examples/example-gateway/build/clients/withexceptions/mock-client/mock_client.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	withexceptions "github.com/uber/zanzibar/examples/example-gateway/build/gen-code/clients-idl/clients/withexceptions/withexceptions"
-	runtime "github.com/uber/zanzibar/runtime"
+	zanzibar "github.com/uber/zanzibar/runtime"
 )
 
 // MockClient is a mock of Client interface.
@@ -37,7 +37,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // Func1 mocks base method.
-func (m *MockClient) Func1(arg0 context.Context, arg1 map[string]string, arg2 *runtime.TimeoutAndRetryOptions) (context.Context, *withexceptions.Response, map[string]string, error) {
+func (m *MockClient) Func1(arg0 context.Context, arg1 map[string]string, arg2 *zanzibar.TimeoutAndRetryOptions) (context.Context, *withexceptions.Response, map[string]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Func1", arg0, arg1, arg2)
 	ret0, _ := ret[0].(context.Context)
@@ -54,10 +54,10 @@ func (mr *MockClientMockRecorder) Func1(arg0, arg1, arg2 interface{}) *gomock.Ca
 }
 
 // HTTPClient mocks base method.
-func (m *MockClient) HTTPClient() *runtime.HTTPClient {
+func (m *MockClient) HTTPClient() *zanzibar.HTTPClient {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HTTPClient")
-	ret0, _ := ret[0].(*runtime.HTTPClient)
+	ret0, _ := ret[0].(*zanzibar.HTTPClient)
 	return ret0
 }
 

--- a/examples/selective-gateway/build/clients/echo/echo.go
+++ b/examples/selective-gateway/build/clients/echo/echo.go
@@ -186,16 +186,16 @@ func (e *echoClient) EchoEcho(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
-	ctx, cancel := context.WithTimeout(ctx, e.opts.Timeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
 	runFunc := e.echoClient.Echo
 	callHelper.Start()
 	if e.opts.CircuitBreakerDisabled {
-		result, err = runFunc(ctx, request, opts...)
+		result, err = runFunc(ctxWithTimeout, request, opts...)
 	} else {
 		circuitBreakerName := "echo" + "-" + "EchoEcho"
-		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
+		err = hystrix.DoC(ctxWithTimeout, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)

--- a/examples/selective-gateway/build/clients/echo/echo.go
+++ b/examples/selective-gateway/build/clients/echo/echo.go
@@ -186,6 +186,8 @@ func (e *echoClient) EchoEcho(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
+	// Creating a new child context with timeout for the yarpc call as this gets cancelled as soon as call is returned
+	// from this client or deadline exceeded after timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 

--- a/examples/selective-gateway/build/clients/mirror/mirror.go
+++ b/examples/selective-gateway/build/clients/mirror/mirror.go
@@ -196,6 +196,8 @@ func (e *mirrorClient) MirrorMirror(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
+	// Creating a new child context with timeout for the yarpc call as this gets cancelled as soon as call is returned
+	// from this client or deadline exceeded after timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
@@ -235,6 +237,8 @@ func (e *mirrorClient) MirrorInternalMirror(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
+	// Creating a new child context with timeout for the yarpc call as this gets cancelled as soon as call is returned
+	// from this client or deadline exceeded after timeout
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 

--- a/examples/selective-gateway/build/clients/mirror/mirror.go
+++ b/examples/selective-gateway/build/clients/mirror/mirror.go
@@ -196,16 +196,16 @@ func (e *mirrorClient) MirrorMirror(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
-	ctx, cancel := context.WithTimeout(ctx, e.opts.Timeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
 	runFunc := e.mirrorClient.Mirror
 	callHelper.Start()
 	if e.opts.CircuitBreakerDisabled {
-		result, err = runFunc(ctx, request, opts...)
+		result, err = runFunc(ctxWithTimeout, request, opts...)
 	} else {
 		circuitBreakerName := "mirror" + "-" + "MirrorMirror"
-		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
+		err = hystrix.DoC(ctxWithTimeout, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)
@@ -235,16 +235,16 @@ func (e *mirrorClient) MirrorInternalMirror(
 			opts = append(opts, yarpc.WithHeader(e.opts.RequestUUIDHeaderKey, reqUUID))
 		}
 	}
-	ctx, cancel := context.WithTimeout(ctx, e.opts.Timeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, e.opts.Timeout)
 	defer cancel()
 
 	runFunc := e.mirrorInternalClient.Mirror
 	callHelper.Start()
 	if e.opts.CircuitBreakerDisabled {
-		result, err = runFunc(ctx, request, opts...)
+		result, err = runFunc(ctxWithTimeout, request, opts...)
 	} else {
 		circuitBreakerName := "mirror" + "-" + "MirrorInternalMirror"
-		err = hystrix.DoC(ctx, circuitBreakerName, func(ctx context.Context) error {
+		err = hystrix.DoC(ctxWithTimeout, circuitBreakerName, func(ctx context.Context) error {
 			result, err = runFunc(ctx, request, opts...)
 			return err
 		}, nil)


### PR DESCRIPTION
The GRPC Clients return cancelled context to callers which creates a problem if they read it and use it. Ideally, the scope of the child context created inside the client should be local so making that fix in the template. 
TChannel and HTTP clients handle this correctly.