### PR TITLE
Revert context propagation in middlewares

### DIFF
--- a/runtime/middlewares.go
+++ b/runtime/middlewares.go
@@ -110,8 +110,7 @@ func (m *MiddlewareStack) Handle(
 	shared := NewSharedState(m.middlewares)
 
 	for i := 0; i < len(m.middlewares); i++ {
-		var ok bool
-		ctx, ok = m.middlewares[i].HandleRequest(ctx, req, res, shared)
+		ctx, ok := m.middlewares[i].HandleRequest(ctx, req, res, shared)
 		// If a middleware errors and writes to the response header
 		// then abort the rest of the stack and evaluate the response
 		// handlers for the middlewares seen so far.


### PR DESCRIPTION
Since context propagation created issues, reverting it until context corruption is fixed.