### PR TITLE
Deep-copy context fields in ContextLogger

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -213,7 +213,10 @@ func GetScopeTagsFromCtx(ctx context.Context) map[string]string {
 
 func accumulateLogFields(ctx context.Context, newFields []zap.Field) []zap.Field {
 	previousFields := GetLogFieldsFromCtx(ctx)
-	return append(previousFields, newFields...)
+	previousFieldsLen := len(previousFields)
+	accumulatedFields := make([]zap.Field, previousFieldsLen, previousFieldsLen+len(newFields))
+	copy(accumulatedFields, previousFields)
+	return append(accumulatedFields, newFields...)
 }
 
 func accumulateLogMsgAndFieldsInContext(ctx context.Context, msg string, newFields []zap.Field, logLevel zapcore.Level) context.Context {

--- a/runtime/context_test.go
+++ b/runtime/context_test.go
@@ -395,3 +395,22 @@ func TestGetCtxLogLevelOrDebugLevelFromCtx(t *testing.T) {
 	assert.Equal(t, zapcore.DebugLevel, logLevel)
 	assert.Equal(t, 0, logCounter)
 }
+
+func TestAccumulateLogField(t *testing.T) {
+	ctxFields := []zapcore.Field{zap.String("ctxField1", "ctxValue1"), zap.String("ctxField2", "ctxValue2")}
+	ctx := context.Background()
+	// append fields in a way s.t. len(log fields) != cap(log fields)
+	ctxWithField := WithLogFields(ctx, ctxFields...)
+	ctxWithField = WithLogFields(ctxWithField, zap.String("ctxField3", "ctxValue3"))
+
+	fields1 := accumulateLogFields(ctxWithField, []zapcore.Field{zap.String("argField", "one")})
+	fields2 := accumulateLogFields(ctxWithField, []zapcore.Field{zap.String("argField", "two")})
+
+	assert.Len(t, fields1, 4)
+	assert.Len(t, fields2, 4)
+
+	// concurrent logs shouldn't affect each other
+	assert.Equal(t, "one", fields1[3].String)
+	assert.Equal(t, "two", fields2[3].String)
+}
+


### PR DESCRIPTION
Cherry-picking commit on main onto internal version.

Summary:
`append()` modifies the slice in-place if the slice has sufficient capacity to hold the new fields which can cause a race condition when using a shared `ContextLogger`