### PR TITLE
ContextMetrics slowness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,6 @@ lint: check-licence eclint-check
 	@./vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | $(FILTER_LINT) | tee -a lint.log
-	ls -al lint.log
-	cat lint.log
 	@[ ! -s lint.log ]
 
 # .PHONY: verify_deps

--- a/Makefile
+++ b/Makefile
@@ -78,26 +78,34 @@ cyclo-check:
 	@gocyclo -over 15 $(filter-out examples ,$(PKG_FILES))
 
 .PHONY: lint
-lint: check-licence eclint-check
+lint:
+	cat lint.log
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@$(GOIMPORTS)/goimports -d $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log
+	cat lint.log
 	@echo "Installing test dependencies for vet..."
 	@go test -i $(PKGS)
 	@echo "Checking printf statements..."
 	@git grep -E 'Fprintf\(os.Std(err|out)' | $(FILTER_LINT) | tee -a lint.log
+	cat lint.log
 	@echo "Checking vet..."
 	@$(foreach dir,$(PKG_FILES),go vet $(VET_RULES) ./$(dir)/... 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
+	cat lint.log
 	@echo "Checking lint..."
 	@go get golang.org/x/lint/golint
 	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
+	cat lint.log
 	@echo "Checking errcheck..."
 	@go run vendor/github.com/kisielk/errcheck/main.go $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
+	cat lint.log
 	@echo "Checking staticcheck..."
 	@go build -o vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck.go
 	@./vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
+	cat lint.log
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | $(FILTER_LINT) | tee -a lint.log
+	cat lint.log
 	@[ ! -s lint.log ]
 
 # .PHONY: verify_deps

--- a/Makefile
+++ b/Makefile
@@ -79,9 +79,8 @@ cyclo-check:
 
 .PHONY: lint
 lint:
-	@rm -f lint.log
-	echo "XXX" > lint.log
 	cat lint.log
+	@rm -f lint.log
 	@echo "Checking formatting..."
 	@$(GOIMPORTS)/goimports -d $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log
 	cat lint.log

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,8 @@ lint: check-licence eclint-check
 	@./vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | $(FILTER_LINT) | tee -a lint.log
+	ls -al lint.log
+	cat lint.log
 	@[ ! -s lint.log ]
 
 # .PHONY: verify_deps

--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,9 @@ cyclo-check:
 
 .PHONY: lint
 lint:
-	cat lint.log
 	@rm -f lint.log
+	echo "XXX" > lint.log
+	cat lint.log
 	@echo "Checking formatting..."
 	@$(GOIMPORTS)/goimports -d $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log
 	cat lint.log

--- a/Makefile
+++ b/Makefile
@@ -78,34 +78,26 @@ cyclo-check:
 	@gocyclo -over 15 $(filter-out examples ,$(PKG_FILES))
 
 .PHONY: lint
-lint:
-	cat lint.log
+lint: check-licence eclint-check
 	@rm -f lint.log
 	@echo "Checking formatting..."
 	@$(GOIMPORTS)/goimports -d $(PKG_FILES) 2>&1 | $(FILTER_LINT) | tee -a lint.log
-	cat lint.log
 	@echo "Installing test dependencies for vet..."
 	@go test -i $(PKGS)
 	@echo "Checking printf statements..."
 	@git grep -E 'Fprintf\(os.Std(err|out)' | $(FILTER_LINT) | tee -a lint.log
-	cat lint.log
 	@echo "Checking vet..."
 	@$(foreach dir,$(PKG_FILES),go vet $(VET_RULES) ./$(dir)/... 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
-	cat lint.log
 	@echo "Checking lint..."
 	@go get golang.org/x/lint/golint
 	@$(foreach dir,$(PKGS),golint $(dir) 2>&1 | $(FILTER_LINT) | tee -a lint.log;)
-	cat lint.log
 	@echo "Checking errcheck..."
 	@go run vendor/github.com/kisielk/errcheck/main.go $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
-	cat lint.log
 	@echo "Checking staticcheck..."
 	@go build -o vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck.go
 	@./vendor/honnef.co/go/tools/cmd/staticcheck/staticcheck $(PKGS) 2>&1 | $(FILTER_LINT) | tee -a lint.log
-	cat lint.log
 	@echo "Checking for unresolved FIXMEs..."
 	@git grep -i fixme | grep -v -e vendor -e Makefile | $(FILTER_LINT) | tee -a lint.log
-	cat lint.log
 	@[ ! -s lint.log ]
 
 # .PHONY: verify_deps

--- a/runtime/context.go
+++ b/runtime/context.go
@@ -437,7 +437,7 @@ type Logger interface {
 // Methods that update metrics create a new tally scope on each call. This is unnecessary slow in scenarios that update
 // multiple metrics.
 type ContextMetrics interface {
-	Scope() tally.Scope
+	Scope(ctx context.Context) tally.Scope
 	IncCounter(ctx context.Context, name string, value int64)
 	RecordTimer(ctx context.Context, name string, d time.Duration)
 	RecordHistogramDuration(ctx context.Context, name string, d time.Duration)
@@ -456,8 +456,8 @@ func NewContextMetrics(scope tally.Scope) ContextMetrics {
 
 // Scope returns associated tally scope. This is useful for clients that want to bypass the implementation owing to its
 // slowness.
-func (c *contextMetrics) Scope() tally.Scope {
-	return c.scope
+func (c *contextMetrics) Scope(ctx context.Context) tally.Scope {
+	return c.scope.Tagged(GetScopeTagsFromCtx(ctx))
 }
 
 // IncCounter increments the counter with current tags from context

--- a/runtime/grpc_client.go
+++ b/runtime/grpc_client.go
@@ -98,7 +98,7 @@ func NewGRPCClientCallHelper(ctx context.Context, serviceMethod string, opts *GR
 		contextLogger: opts.ContextLogger,
 		metrics:       opts.Metrics,
 		extractor:     opts.ContextExtractor,
-		scope:         opts.Metrics.Scope().Tagged(GetScopeTagsFromCtx(ctx)),
+		scope:         opts.Metrics.Scope(ctx),
 	}
 }
 

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go"
 	"github.com/uber/zanzibar/runtime/ruleengine"
 	netContext "golang.org/x/net/context"
 )

--- a/runtime/tchannel_client.go
+++ b/runtime/tchannel_client.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/uber-go/tally"
-	"github.com/uber/tchannel-go"
 	"github.com/uber/zanzibar/runtime/ruleengine"
 	netContext "golang.org/x/net/context"
 )
@@ -163,14 +162,15 @@ func (c *TChannelClient) Call(
 		scopeTagsTargetEndpoint: serviceMethod,
 	}
 	ctx = WithScopeTags(ctx, scopeTags)
-	call := &tchannelOutboundCall{
-		client:        c,
-		methodName:    c.methodNames[serviceMethod],
-		serviceMethod: serviceMethod,
-		reqHeaders:    reqHeaders,
-		contextLogger: c.ContextLogger,
-		metrics:       c.metrics,
-	}
+	call := newTchannelOutboundCall(
+		ctx,
+		c,
+		c.methodNames[serviceMethod],
+		serviceMethod,
+		reqHeaders,
+		c.ContextLogger,
+		c.metrics,
+	)
 
 	return c.call(ctx, call, reqHeaders, req, resp, timeoutAndRetryOptions)
 }

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -24,7 +24,6 @@ import (
 	"context"
 
 	"github.com/uber-go/tally"
-	"github.com/uber/tchannel-go"
 )
 
 const rawClient = "raw"
@@ -72,14 +71,15 @@ func (r *RawTChannelClient) Call(
 ) (success bool, resHeaders map[string]string, err error) {
 	serviceMethod := thriftService + "::" + methodName
 
-	call := &tchannelOutboundCall{
-		client:        r.tc,
-		methodName:    serviceMethod,
-		serviceMethod: serviceMethod,
-		reqHeaders:    reqHeaders,
-		contextLogger: r.tc.ContextLogger,
-		metrics:       r.metrics,
-	}
+	call := newTchannelOutboundCall(
+		ctx,
+		r.tc,
+		serviceMethod,
+		serviceMethod,
+		reqHeaders,
+		r.tc.ContextLogger,
+		r.metrics,
+	)
 
 	if m, ok := r.tc.methodNames[serviceMethod]; ok {
 		call.methodName = m

--- a/runtime/tchannel_client_raw.go
+++ b/runtime/tchannel_client_raw.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go"
 )
 
 const rawClient = "raw"

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -22,12 +22,13 @@ package zanzibar
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
-	"testing"
-	"time"
 )
 
 func TestNilCallReferenceForLogger(t *testing.T) {

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -21,9 +21,9 @@
 package zanzibar
 
 import (
-	"code.uber.internal/rt/eg/go-build/.go/src/gb2/src/github.com/uber-go/tally"
 	"context"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 	"testing"

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -21,13 +21,11 @@
 package zanzibar
 
 import (
+	"code.uber.internal/rt/eg/go-build/.go/src/gb2/src/github.com/uber-go/tally"
 	"context"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
-	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
+	"testing"
 )
 
 func TestNilCallReferenceForLogger(t *testing.T) {
@@ -35,16 +33,21 @@ func TestNilCallReferenceForLogger(t *testing.T) {
 		"header-key": "header-value",
 	}
 	staticTestTime := time.Unix(1500000000, 0)
-	outboundCall := &tchannelOutboundCall{
-		methodName:    "Get",
-		serviceMethod: "Test",
-		startTime:     staticTestTime,
-		finishTime:    staticTestTime,
-		reqHeaders:    headers,
-		resHeaders:    headers,
-	}
 	ctx := context.TODO()
 	ctx = WithLogFields(ctx, zap.String("foo", "bar"))
+
+	outboundCall := newTchannelOutboundCall(
+		ctx,
+		nil,
+		"Get",
+		"Test",
+		headers,
+		nil,
+		NewContextMetrics(tally.NoopScope),
+	)
+	outboundCall.resHeaders = headers
+	outboundCall.startTime = staticTestTime
+	outboundCall.finishTime = staticTestTime
 
 	fields := outboundCall.logFields(ctx)
 

--- a/runtime/tchannel_client_test.go
+++ b/runtime/tchannel_client_test.go
@@ -24,8 +24,10 @@ import (
 	"code.uber.internal/rt/eg/go-build/.go/src/gb2/src/github.com/uber-go/tally"
 	"context"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 	"testing"
+	"time"
 )
 
 func TestNilCallReferenceForLogger(t *testing.T) {

--- a/runtime/tchannel_inbound_call.go
+++ b/runtime/tchannel_inbound_call.go
@@ -60,7 +60,8 @@ func (c *tchannelInboundCall) finish(ctx context.Context, err error) {
 	if err != nil {
 		errCause := tchannel.GetSystemErrorCode(errors.Cause(err))
 		errTag := map[string]string{scopeTagError: errCause.MetricsKey()}
-		c.scope.Tagged(errTag).Counter(endpointSystemErrors).Inc(1)
+		c.scope = c.scope.Tagged(errTag) // errTag will be part of all following metrics
+		c.scope.Counter(endpointSystemErrors).Inc(1)
 	} else if !c.success {
 		// The endpoint already has emitted an app-error stat in the template
 	} else {

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -30,6 +30,8 @@ import (
 	"go.uber.org/thriftrw/protocol/binary"
 
 	"github.com/pkg/errors"
+	"github.com/uber-go/tally"
+	"github.com/uber/tchannel-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -61,7 +61,7 @@ func newTchannelOutboundCall(ctx context.Context, client *TChannelClient, method
 		reqHeaders:    reqHeaders,
 		contextLogger: contextLogger,
 		metrics:       contextMetrics,
-		scope:         contextMetrics.Scope().Tagged(GetScopeTagsFromCtx(ctx)),
+		scope:         contextMetrics.Scope(ctx),
 	}
 	return call
 }

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -77,7 +77,7 @@ func (c *tchannelOutboundCall) finish(ctx context.Context, err error) {
 	if err != nil {
 		errCause := tchannel.GetSystemErrorCode(errors.Cause(err))
 		scopeTags := map[string]string{scopeTagError: errCause.MetricsKey()}
-		ctx = WithScopeTags(ctx, scopeTags)
+		c.scope = c.scope.Tagged(scopeTags) // scopeTagError will be part of all following metrics
 		c.scope.Counter(clientSystemErrors).Inc(1)
 	} else if !c.success {
 		c.scope.Counter(clientAppErrors).Inc(1)

--- a/runtime/tchannel_server.go
+++ b/runtime/tchannel_server.go
@@ -220,10 +220,7 @@ func (s *TChannelRouter) handleHeader(
 	ctx = WithEndpointRequestHeadersField(ctx, c.reqHeaders)
 
 	// use user-provided extractor function to decide metric tags
-	scopeTags := make(map[string]string)
-	for k, v := range s.extractor.ExtractScopeTags(ctx) {
-		scopeTags[k] = v
-	}
+	scopeTags := s.extractor.ExtractScopeTags(ctx)
 	ctx = WithScopeTags(ctx, scopeTags)
 	if len(scopeTags) != 0 {
 		c.scope = c.scope.Tagged(scopeTags)


### PR DESCRIPTION
ContextMetrics is a slow interface that is unfortunately used by many high throughput clients. This change provides an option to users to bypass it, and replaces it in calls internal to Zanzibar.

### Why is it not removed?
ContextMetrics is part of many Zanzibar API calls and structures. Removing it will break those interface. 