### PR TITLE
Log utils for error tagging

### DIFF
--- a/runtime/context.go
+++ b/runtime/context.go
@@ -65,6 +65,8 @@ const (
 	logFieldEndpointHandler    = "endpointHandler"
 	logFieldClientStatusCode   = "client_status_code"
 	logFieldClientRemoteAddr   = "client_remote_addr"
+	logFieldErrorType          = "error_type"
+	logFieldErrorLocation      = "error_location"
 
 	logFieldClientRequestHeaderPrefix    = "Client-Req-Header"
 	logFieldClientResponseHeaderPrefix   = "Client-Res-Header"

--- a/runtime/utils.go
+++ b/runtime/utils.go
@@ -23,7 +23,13 @@ package zanzibar
 import (
 	"math"
 	"time"
+
+	"go.uber.org/zap"
 )
+
+// LogFieldErrTypeClientException is a log field used to tag errors corresponding
+// to exceptions defined in client thrifts.
+var LogFieldErrTypeClientException = LogFieldErrorType("client_exception")
 
 // BuildTimeoutAndRetryConfig encapsulates timeout and retry configs in TimeoutAndRetryOptions struct
 func BuildTimeoutAndRetryConfig(timeoutPerAttemptConf int, backOffTimeAcrossRetriesConf int,
@@ -40,4 +46,14 @@ func BuildTimeoutAndRetryConfig(timeoutPerAttemptConf int, backOffTimeAcrossRetr
 		MaxAttempts:                  maxAttempts,
 		BackOffTimeAcrossRetriesInMs: backOffTimeAcrossRetries,
 	}
+}
+
+// LogFieldErrorType returns error_type log field with given value.
+func LogFieldErrorType(errType string) zap.Field {
+	return zap.String(logFieldErrorType, errType)
+}
+
+// LogFieldErrorLocation returns error_location log field with given value.
+func LogFieldErrorLocation(loc string) zap.Field {
+	return zap.String(logFieldErrorLocation, loc)
 }

--- a/runtime/utils_test.go
+++ b/runtime/utils_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zanzibar_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
+	"go.uber.org/zap"
+)
+
+func TestLogFieldErrorType(t *testing.T) {
+	field := zanzibar.LogFieldErrorType("foo")
+	assert.Equal(t, zap.String("error_type", "foo"), field)
+}
+
+func TestLogFieldErrorLocation(t *testing.T) {
+	field := zanzibar.LogFieldErrorLocation("bar")
+	assert.Equal(t, zap.String("error_location", "bar"), field)
+}


### PR DESCRIPTION
Changes include log utils to create log fields "error_location" and "error_type".