### PR TITLE
Use Better API for Case Insensitive String Equality Check 

### DIFF
--- a/codegen/header_propagate.go
+++ b/codegen/header_propagate.go
@@ -171,7 +171,7 @@ func findField(fieldPath string, toFields []*compile.FieldSpec) (*compile.FieldS
 		prevPath := []string(currPath)
 		currPos := currPath[0]
 		for _, v := range currFields {
-			if strings.ToLower(v.Name) == strings.ToLower(currPos) {
+			if strings.EqualFold(v.Name, currPos) {
 				if len(currPath) == 1 {
 					return v, nil
 				}


### PR DESCRIPTION
In file: header_propagate.go, there is a function `findField` that performs a case insensitive String equality check. String comparison with `strings.ToLower` or `strings.ToUpper` is significantly more expensive. For example, `strings.ToLower` will have to allocate memory for the new strings, and then convert the string to lower case. It is better to do the case insensitive equality check using the `strings.EqualFold`(https://pkg.go.dev/strings#EqualFold) function. This function does not need to create two intermediate strings and can return as soon as the first non-matching character has been found. I fixed the issue by introducing the `strings.EqualFold` function.


Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the Open Source Security Foundation (OpenSSF)(https://openssf.org/): Project Alpha-Omega(https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.