### PR TITLE
Expose tracer& tracer closer options in gateway

### DIFF
--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -81,6 +81,8 @@ type Options struct {
 	GetContextFieldExtractors func() []ContextLogFieldsExtractor
 	JSONWrapper               jsonwrapper.JSONWrapper
 	NotFoundHandler           func(*Gateway) http.HandlerFunc
+	Tracer                    opentracing.Tracer
+	TracerCloser              io.Closer
 
 	// If present, request uuid is retrieved from the incoming request
 	// headers using the key, and put on the context. Otherwise, a new
@@ -248,8 +250,16 @@ func CreateGateway(
 		return nil, err
 	}
 
-	if err := gateway.setupTracer(config); err != nil {
-		return nil, err
+	if opts.Tracer != nil &&
+		opts.TracerCloser != nil &&
+		config.ContainsKey("jaeger.tracer.custom") &&
+		config.MustGetBoolean("jaeger.tracer.custom") {
+		gateway.Tracer = opts.Tracer
+		gateway.tracerCloser = opts.TracerCloser
+	} else {
+		if err := gateway.setupTracer(config); err != nil {
+			return nil, err
+		}
 	}
 
 	if opts.NotFoundHandler != nil &&


### PR DESCRIPTION
Today zanzibar creates its own Jaeger Tracer in the gateway component. However at Uber, we use a more customized tracer, and we want to make sure services that consume zanzibar use the same tracer.

Expose the tracer& tracer closer options to create gateway so that we are able to inject the customized tracer.