### PR TITLE
Update tracer option as a tracer provider func

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install-packages:
 	@echo "Mounting git pre-push hook"
 	cp .git-pre-push-hook .git/hooks/pre-push
 	@echo "Installing python packages..."
-	pip install --user yq
+	pip3 install --user yq
 
 .PHONY: install-tools
 # set GO111MODULE to off to compile ancient tools within the vendor directory

--- a/codegen/runner/pre-steps.sh
+++ b/codegen/runner/pre-steps.sh
@@ -16,7 +16,7 @@ if [[ -z "$3" ]]; then
 	exit 1
 fi
 
-YQ=$(pip show yq | grep Location | cut -d' ' -f2 | sed 's/lib\/.*/bin\/yq/')
+YQ=$(pip3 show yq | grep Location | cut -d' ' -f2 | sed 's/lib\/.*/bin\/yq/')
 BUILD_DIR="$1"
 CONFIG_DIR="$2"
 ANNOPREFIX="$3"

--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -290,8 +290,9 @@ func TestGatewayWithTracerOverride(t *testing.T) {
 		NotFoundHandler: func(gateway *Gateway) http.HandlerFunc {
 			return func(writer http.ResponseWriter, request *http.Request) {}
 		},
-		Tracer:       tracer,
-		TracerCloser: tracerCloser,
+		TracerProvider: func(gateway *Gateway) (opentracing.Tracer, io.Closer, error) {
+			return tracer, tracerCloser, nil
+		},
 	}
 
 	t.Run("without config", func(t *testing.T) {


### PR DESCRIPTION
The problem of previous gateway option to provide a tracer and a tracer closer is that when creating the tracer, the service name, logger, metric scope are not available.

This PR update the option to be a tracer provider function and takes the gateway as input so that the service name, logger and metric scope all are available similar to `NotFoundHandler` - `func(*Gateway) http.HandlerFunc`.

With this change, now we can provide the tracer like below:
```
var AppOptions = &zanzibar.Options{
     ...
    TracerProvider: func(g *zanzibar.Gateway) (opentracing.Tracer, io.Closer, error) {
        // actual logic to instantiate the tracer with the service name, logger, scope available in gateway
    }
}
```