### PR TITLE
Update the import path of OpenTelemetry

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -112,13 +112,8 @@ imports:
   subpackages:
   - ext
   - log
-- name: go.opentelemetry.io/otel/trace
-  version: e0852d609c4a4205d550e2de45afdbf80d43557b
 - name: go.opentelemetry.io/otel
   version: e0852d609c4a4205d550e2de45afdbf80d43557b
-  subpackages:
-  - attribute
-  - codes
 - name: github.com/pborman/uuid
   version: 5b6091a6a160ee5ce12917b21ab96acec2a4fdc0
 - name: github.com/pkg/errors

--- a/runtime/tracing.go
+++ b/runtime/tracing.go
@@ -23,7 +23,7 @@ package zanzibar
 import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
-	"go.opentelemetry.io/otel/trace/trace"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Explicitly adding package - `go.opentelemetry.io/otel/trace` to glide.lock make the import path in code be `go.opentelemetry.io/otel/trace/trace`, which is conflict with the import path internally used (`go.opentelemetry.io/otel/trace`) in the company.

Adding `go.opentelemetry.io/otel` should be enough.
