### PR TITLE
Event collection - efficiency

### DIFF
--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -230,10 +230,10 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 				HTTPCapture: HTTPCapture{
 					ReqURL:        req.httpReq.URL.String(),
 					ReqMethod:     req.httpReq.Method,
-					ReqHeaders:    req.httpReq.Header.Clone(), // TODO: clone or not?
+					ReqHeaders:    req.httpReq.Header.Clone(), // cloning headers maybe inefficient
 					ReqBody:       req.rawBody,
 					RspStatusCode: res.StatusCode,
-					RspHeaders:    res.Header.Clone(), // TODO: clone or not?
+					RspHeaders:    res.Header.Clone(), // cloning headers maybe inefficient
 					RspBody:       rspBytes,
 				},
 			}

--- a/runtime/client_http_request.go
+++ b/runtime/client_http_request.go
@@ -220,8 +220,8 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 	req.res.setRawHTTPResponse(res)
 
 	// generate events
-	if GetToCapture(req.ctx) {
-
+	if GetToCapture(ctx) {
+		// ReadAll, caches bytes internally so multiple calls will return the same data
 		rspBytes, err := req.res.ReadAll()
 		if err == nil {
 			event := &HTTPOutgoingEvent{
@@ -230,10 +230,10 @@ func (req *ClientHTTPRequest) Do() (*ClientHTTPResponse, error) {
 				HTTPCapture: HTTPCapture{
 					ReqURL:        req.httpReq.URL.String(),
 					ReqMethod:     req.httpReq.Method,
-					ReqHeaders:    req.httpReq.Header.Clone(),
+					ReqHeaders:    req.httpReq.Header.Clone(), // TODO: clone or not?
 					ReqBody:       req.rawBody,
 					RspStatusCode: res.StatusCode,
-					RspHeaders:    res.Header.Clone(),
+					RspHeaders:    res.Header.Clone(), // TODO: clone or not?
 					RspBody:       rspBytes,
 				},
 			}

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -35,7 +35,7 @@ const (
 )
 
 type EventHandlerFn func([]Event) error
-type EventSamplerFn func(string, string) bool
+type EnableEventGenFn func(string, string) bool
 
 type Event interface {
 	Name() string
@@ -104,7 +104,7 @@ func NoOpEventHandler(events []Event) error {
 	return nil
 }
 
-// NoOpEventSampler will not sample
-func NoOpEventSampler(_, _ string) bool {
+// NoOpEventGen will not sample
+func NoOpEventGen(_, _ string) bool {
 	return false
 }

--- a/runtime/events.go
+++ b/runtime/events.go
@@ -20,6 +20,8 @@
 
 package zanzibar
 
+import "go.uber.org/thriftrw/wire"
+
 // Context Variables
 const (
 	// ToCapture set to true if events have to be captured
@@ -49,11 +51,11 @@ type ThriftOutgoingEvent struct {
 	MethodName  string
 	ServiceName string
 
-	ReqHeaders map[string]string
-	ReqBody    []byte
+	ReqHeaders   map[string]string
+	ReqWireValue *wire.Value
 
-	RspHeaders map[string]string
-	RspBody    []byte
+	RspHeaders   map[string]string
+	RspWireValue *wire.Value
 }
 
 func (tce *ThriftOutgoingEvent) Name() string {

--- a/runtime/gateway.go
+++ b/runtime/gateway.go
@@ -82,7 +82,7 @@ type Options struct {
 	JSONWrapper               jsonwrapper.JSONWrapper
 	NotFoundHandler           func(*Gateway) http.HandlerFunc
 	TracerProvider            func(*Gateway) (opentracing.Tracer, io.Closer, error)
-	EventProvider             func(*Gateway) (EventSamplerFn, EventHandlerFn)
+	EventProvider             func(*Gateway) (EnableEventGenFn, EventHandlerFn)
 	// If present, request uuid is retrieved from the incoming request
 	// headers using the key, and put on the context. Otherwise, a new
 	// uuid is created for the incoming request.
@@ -113,7 +113,7 @@ type Gateway struct {
 	Tracer                 opentracing.Tracer
 	JSONWrapper            jsonwrapper.JSONWrapper
 	EventHandler           EventHandlerFn
-	EventSampler           EventSamplerFn
+	EnableEventGen         EnableEventGenFn
 	// gRPC client dispatcher for gRPC client lifecycle management
 	GRPCClientDispatcher *yarpc.Dispatcher
 
@@ -266,11 +266,11 @@ func CreateGateway(
 	}
 
 	if opts.EventProvider != nil {
-		samplerFn, handlerFn := opts.EventProvider(gateway)
-		gateway.EventSampler = samplerFn
+		eventGenFn, handlerFn := opts.EventProvider(gateway)
+		gateway.EnableEventGen = eventGenFn
 		gateway.EventHandler = handlerFn
 	} else {
-		gateway.EventSampler = NoOpEventSampler
+		gateway.EnableEventGen = NoOpEventGen
 		gateway.EventHandler = NoOpEventHandler
 	}
 

--- a/runtime/gateway_test.go
+++ b/runtime/gateway_test.go
@@ -353,17 +353,17 @@ func TestGatewayWithEventHandler(t *testing.T) {
 			return nil
 		}
 
-		eventSamplerFn := func(_, _ string) bool {
+		enableEventGenFn := func(_, _ string) bool {
 			return false
 		}
-		opts.EventProvider = func(gateway *Gateway) (EventSamplerFn, EventHandlerFn) {
-			return eventSamplerFn, eventHandlerFn
+		opts.EventProvider = func(gateway *Gateway) (EnableEventGenFn, EventHandlerFn) {
+			return enableEventGenFn, eventHandlerFn
 		}
 		cfg := NewStaticConfigOrDie(nil, rawCfgMap)
 		g, err := CreateGateway(cfg, opts)
 		assert.Nil(t, err)
 		assert.Equal(t, eventHandlerFn, g.EventHandler)
-		assert.Equal(t, eventSamplerFn, g.EventSampler)
+		assert.Equal(t, enableEventGenFn, g.EnableEventGen)
 
 	})
 }

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -90,7 +90,7 @@ type RouterEndpoint struct {
 	tracer           opentracing.Tracer
 	config           *StaticConfig
 	eventHandler     EventHandlerFn
-	enableEventGenFn EnableEventGenFn
+	enableEventGen   EnableEventGenFn
 }
 
 // NewRouterEndpoint creates an endpoint that can be registered to HTTPRouter
@@ -122,7 +122,7 @@ func NewRouterEndpoint(
 		JSONWrapper:      deps.JSONWrapper,
 		config:           deps.Config,
 		eventHandler:     eh,
-		enableEventGenFn: eg,
+		enableEventGen:   eg,
 	}
 }
 
@@ -144,7 +144,7 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	ctx := req.Context()
 
 	// setting up event container
-	if endpoint.enableEventGenFn(endpoint.EndpointName, endpoint.HandlerName) {
+	if endpoint.enableEventGen(endpoint.EndpointName, endpoint.HandlerName) {
 		ctx = WithEventContainer(ctx, &EventContainer{})
 		ctx = WithToCapture(ctx)
 	}
@@ -152,7 +152,7 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	// make a copy of request headers since it could be mutated within the endpoint handler
 	var reqHeadersOriginal map[string][]string
 	if GetToCapture(ctx) {
-		reqHeadersOriginal = r.Header.Clone() // TODO: check if really required
+		reqHeadersOriginal = r.Header.Clone()
 	}
 
 	endpoint.HandlerFn(ctx, req, req.res)

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -143,16 +143,16 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	req := NewServerHTTPRequest(w, r, urlValues, endpoint)
 	ctx := req.Context()
 
-	// setting up capture for endpoint
+	// setting up event container
 	if endpoint.eventSampler(endpoint.EndpointName, endpoint.HandlerName) {
-		ctx = WithToCapture(ctx)
 		ctx = WithEventContainer(ctx, &EventContainer{})
+		ctx = WithToCapture(ctx)
 	}
 
 	// make a copy of request headers since it could be mutated within the endpoint handler
-	var reqHeaders map[string][]string
+	var reqHeadersOriginal map[string][]string
 	if GetToCapture(ctx) {
-		reqHeaders = r.Header.Clone()
+		reqHeadersOriginal = r.Header.Clone() // TODO: check if really required
 	}
 
 	endpoint.HandlerFn(ctx, req, req.res)
@@ -172,7 +172,7 @@ func (endpoint *RouterEndpoint) HandleRequest(
 			HTTPCapture: HTTPCapture{
 				ReqURL:        r.URL.String(),
 				ReqMethod:     r.Method,
-				ReqHeaders:    reqHeaders,
+				ReqHeaders:    reqHeadersOriginal,
 				ReqBody:       req.rawBody,
 				RspStatusCode: req.res.StatusCode,
 				RspHeaders:    w.Header().Clone(),

--- a/runtime/tchannel_helpers.go
+++ b/runtime/tchannel_helpers.go
@@ -72,7 +72,7 @@ func PutBuffer(buf *bytes.Buffer) {
 }
 
 // ReadStruct reads the given Thriftrw struct.
-func ReadStruct(reader io.Reader, s RWTStruct) error {
+func ReadStruct(reader io.Reader, s RWTStruct) (*wire.Value, error) {
 	readerAt, ok := reader.(io.ReaderAt)
 
 	// do not read all to buffer if reader already is type of io.ReaderAt
@@ -81,15 +81,15 @@ func ReadStruct(reader io.Reader, s RWTStruct) error {
 		defer PutBuffer(buf)
 
 		if _, err := buf.ReadFrom(reader); err != nil {
-			return err
+			return nil, err
 		}
 		readerAt = bytes.NewReader(buf.Bytes())
 	}
 
 	wireValue, err := binary.Default.Decode(readerAt, wire.TStruct)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	err = s.FromWire(wireValue)
-	return err
+	return &wireValue, err
 }

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -23,6 +23,7 @@ package zanzibar
 import (
 	"context"
 	"fmt"
+	"go.uber.org/thriftrw/wire"
 	"time"
 
 	"github.com/pkg/errors"
@@ -136,14 +137,14 @@ func (c *tchannelOutboundCall) writeReqHeaders(reqHeaders map[string]string) err
 }
 
 // writeReqBody writes request body to arg3
-func (c *tchannelOutboundCall) writeReqBody(ctx context.Context, req RWTStruct) error {
-	structWireValue, err := req.ToWire()
-	if err != nil {
-		return errors.Wrapf(
-			err, "Could not write request for outbound %s.%s (%s %s) request",
-			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
-		)
-	}
+func (c *tchannelOutboundCall) writeReqBody(ctx context.Context, reqWireValue *wire.Value) error {
+	//structWireValue, err := req.ToWire()
+	//if err != nil {
+	//	return errors.Wrapf(
+	//		err, "Could not write request for outbound %s.%s (%s %s) request",
+	//		c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
+	//	)
+	//}
 
 	twriter, err := c.call.Arg3Writer()
 	if err != nil {
@@ -152,7 +153,7 @@ func (c *tchannelOutboundCall) writeReqBody(ctx context.Context, req RWTStruct) 
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
 		)
 	}
-	if err := binary.Default.Encode(structWireValue, twriter); err != nil {
+	if err := binary.Default.Encode(*reqWireValue, twriter); err != nil {
 		_ = twriter.Close()
 		return errors.Wrapf(
 			err, "Could not write request for outbound %s.%s (%s %s) request",
@@ -211,35 +212,39 @@ func (c *tchannelOutboundCall) readResHeaders(response *tchannel.OutboundCallRes
 }
 
 // readResBody read response body from arg3
-func (c *tchannelOutboundCall) readResBody(ctx context.Context, response *tchannel.OutboundCallResponse, resp RWTStruct) error {
+func (c *tchannelOutboundCall) readResBody(ctx context.Context, response *tchannel.OutboundCallResponse, resp RWTStruct) (*wire.Value, error) {
 	treader, err := response.Arg3Reader()
 	if err != nil {
-		return errors.Wrapf(
+		return nil, errors.Wrapf(
 			err, "Could not create arg3Reader for outbound %s.%s (%s %s) response",
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
 		)
 	}
-	if err := ReadStruct(treader, resp); err != nil {
+
+	wireValue, err := ReadStruct(treader, resp)
+	if err != nil {
 		_ = treader.Close()
 		c.metrics.IncCounter(ctx, clientTchannelUnmarshalError, 1)
-		return errors.Wrapf(
+		return nil, errors.Wrapf(
 			err, "Could not read outbound %s.%s (%s %s) response",
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
 		)
 	}
+
 	if err := EnsureEmpty(treader, "reading response body"); err != nil {
 		_ = treader.Close()
-		return errors.Wrapf(
+		return nil, errors.Wrapf(
 			err, "Could not ensure arg3reader is empty for outbound %s.%s (%s %s) response",
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
 		)
 	}
+
 	if err := treader.Close(); err != nil {
-		return errors.Wrapf(
+		return nil, errors.Wrapf(
 			err, "Could not close arg3reader outbound %s.%s (%s %s) response",
 			c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
 		)
 	}
 
-	return nil
+	return wireValue, nil
 }

--- a/runtime/tchannel_outbound_call.go
+++ b/runtime/tchannel_outbound_call.go
@@ -136,16 +136,8 @@ func (c *tchannelOutboundCall) writeReqHeaders(reqHeaders map[string]string) err
 	return nil
 }
 
-// writeReqBody writes request body to arg3
+// writeReqBody writes request's wire Value to arg3
 func (c *tchannelOutboundCall) writeReqBody(ctx context.Context, reqWireValue *wire.Value) error {
-	//structWireValue, err := req.ToWire()
-	//if err != nil {
-	//	return errors.Wrapf(
-	//		err, "Could not write request for outbound %s.%s (%s %s) request",
-	//		c.client.ClientID, c.methodName, c.client.serviceName, c.serviceMethod,
-	//	)
-	//}
-
 	twriter, err := c.call.Arg3Writer()
 	if err != nil {
 		return errors.Wrapf(


### PR DESCRIPTION
This change improves the efficiency of the the event collection framework to enable all events to be collected cheaply without significant impact to memory and CPU. This enables the sampling decision to be taken based on the event data - example http response code.

Points:

1. The primary change has been to `tchannel_client.go` where instead of `[]bytes`, `*.wire.Value` is store. This approach avoids the expensive conversion to `[]bytes` for all data.  Event handlers can convert `wire.Value` to `[]bytes` when required. 
2. Headers are not stored as is; they are cloned. This is mostly because they are being mutated in few instances. The overall impact of header cloning is expected to be minor (couple of milliseconds added to latency). 


