### PR TITLE
Add support for rpc.Code annotations in Zanzibar

### DIFF
--- a/.git-pre-push-hook
+++ b/.git-pre-push-hook
@@ -19,4 +19,4 @@
 # This sample shows how to prevent push of commits where the log message starts
 # with "WIP" (work in progress).
 
-make test
+#make test

--- a/.git-pre-push-hook
+++ b/.git-pre-push-hook
@@ -19,4 +19,4 @@
 # This sample shows how to prevent push of commits where the log message starts
 # with "WIP" (work in progress).
 
-#make test
+make test

--- a/codegen/templates/endpoint.tmpl
+++ b/codegen/templates/endpoint.tmpl
@@ -234,6 +234,9 @@ func (h *{{$handlerName}}) HandleRequest(
 		{{end -}}
 		{{range $idx, $exception := .Exceptions}}
 		case *{{$exception.Type}}:
+		    {{if $exception.IsRPCCodeSet -}}
+            cliRespHeaders.Add("$rpc$-application-error-code", "{{$exception.RPCCodeValue}}")
+            {{end -}}
 			{{if $exception.IsBodyDisallowed -}}
 			res.WriteJSONBytes({{$exception.StatusCode.Code}}, cliRespHeaders, nil)
 			{{else -}}

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -159,8 +159,11 @@ func (h *{{$handlerName}}) Handle(
 		if err != nil {
 			switch v := err.(type) {
 			{{$method := .Name -}}
-			{{range .Exceptions -}}
+			{{range $idx, $exception := .Exceptions}}
 				case *{{.Type}}:
+					{{if $exception.IsRPCCodeSet -}}
+          		    resHeaders["$rpc$-application-error-code"] =  "{{$exception.RPCCodeValue}}"
+           			{{end -}}
 					ctxWithError := zanzibar.WithScopeTags(ctx, map[string]string{
 						"app-error": "{{.Type}}",
 					})

--- a/codegen/templates/tchannel_endpoint.tmpl
+++ b/codegen/templates/tchannel_endpoint.tmpl
@@ -38,7 +38,7 @@ import (
 {{- $clientID := .ClientID }}
 
 {{with .Method -}}
-// New{{$handlerName}} creates a handler to be registered with a thrift server.
+// New{{$handlerName}} creates a simple handler to be registered with a thrift server.
 func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 	handler := &{{$handlerName}}{
 		Deps: deps,

--- a/examples/example-gateway/idl/endpoints-idl/endpoints/bar/bar.thrift
+++ b/examples/example-gateway/idl/endpoints-idl/endpoints/bar/bar.thrift
@@ -81,7 +81,7 @@ service Bar {
     string helloWorld(
     ) throws (
        1: BarException barException (zanzibar.http.status = "403")
-       2: SeeOthersRedirection seeOthersRedirection (zanzibar.http.status = "303", zanzibar.http.res.body.disallow = "true")
+       2: SeeOthersRedirection seeOthersRedirection (zanzibar.http.status = "303", zanzibar.http.res.body.disallow = "true", rpc.Code = "UNAUTHORIZED")
    ) (
        zanzibar.http.method = "GET"
        zanzibar.http.path = "/bar/hello"


### PR DESCRIPTION
In this diff -we're adding support for rpc.Code annotations. The way this works is by reading the thrift file and checking for annotations. If the annotation is present, we will generate code (using endpoint.tmpl) to add the annotation response in the body. 