### PR TITLE
Adding more tags for panic metrics 

### DIFF
--- a/runtime/router_test.go
+++ b/runtime/router_test.go
@@ -55,6 +55,11 @@ func (s *routerSuite) SetupTest() {
 		},
 	)
 	s.router = NewHTTPRouter(s.gw).(*httpRouter)
+	extractors = &ContextExtractors{
+		ScopeTagsExtractors: []ContextScopeTagsExtractor{scopeExtractor},
+		LogFieldsExtractors: []ContextLogFieldsExtractor{logFieldsExtractors},
+	}
+	s.router.gateway.ContextExtractor = extractors
 }
 
 func (s *routerSuite) TestRouter() {


### PR DESCRIPTION
EndpointID and HandlerID tags if present will help debug panic metrics with ease. Adding these tags in this diff. 