### PR TITLE
Add rpc.status to client response context for annotated thrift exceptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,8 @@ lint: check-licence eclint-check
 # 	@[ ! -s deps.log ]
 
 .PHONY: generate
+# set GO111MODULE to off to compile ancient tools within the vendor directory
+generate: export GO111MODULE = off
 generate:
 	@ls ./node_modules/.bin/uber-licence >/dev/null 2>&1 || npm i uber-licence
 	@chmod 644 ./codegen/templates/*.tmpl

--- a/codegen/template.go
+++ b/codegen/template.go
@@ -51,19 +51,19 @@ func (*defaultAssetCollection) Asset(assetName string) ([]byte, error) {
 }
 
 var defaultFuncMap = tmpl.FuncMap{
-	"lower":                strings.ToLower,
-	"title":                strings.Title,
-	"fullTypeName":         fullTypeName,
-	"camel":                CamelCase,
-	"split":                strings.Split,
-	"dec":                  decrement,
-	"basePath":             filepath.Base,
-	"pascal":               PascalCase,
-	"isPointerType":        IsPointerType,
-	"unref":                Unref,
-	"lintAcronym":          LintAcronym,
-	"args":                 args,
-	"firstIsClientOrEmpty": firstIsClientOrEmpty,
+	"lower":                  strings.ToLower,
+	"title":                  strings.Title,
+	"fullTypeName":           fullTypeName,
+	"camel":                  CamelCase,
+	"split":                  strings.Split,
+	"dec":                    decrement,
+	"basePath":               filepath.Base,
+	"pascal":                 PascalCase,
+	"isPointerType":          IsPointerType,
+	"unref":                  Unref,
+	"lintAcronym":            LintAcronym,
+	"args":                   args,
+	"firstIsClientOrEmpty":   firstIsClientOrEmpty,
 }
 
 func fullTypeName(typeName, packageName string) string {

--- a/codegen/template_bundle/template_files.go
+++ b/codegen/template_bundle/template_files.go
@@ -2203,9 +2203,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	zanzibar "github.com/uber/zanzibar/runtime"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	zanzibar "github.com/uber/zanzibar/runtime"
 
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 )
@@ -2987,6 +2987,7 @@ import (
 
 
 	"go.uber.org/zap"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 	{{range $idx, $pkg := .IncludedPackages -}}
@@ -3003,6 +3004,22 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+
+const _errorCodeAnnotationKey = "rpc.code"
+
+var (
+	// _tchannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
+	_tchannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
+		tchannel.ErrCodeTimeout:    yarpcerrors.CodeDeadlineExceeded,
+		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
+		tchannel.ErrCodeBusy:       yarpcerrors.CodeResourceExhausted,
+		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
+		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
+		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,
+	}
+)
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -3286,7 +3303,7 @@ type {{$clientName}} struct {
 }
 
 {{range $svc := .Services}}
-{{range .Methods}}
+{{range $method := .Methods}}
 {{$serviceMethod := printf "%s::%s" $svc.Name .Name -}}
 {{$methodName := (title (index $exposedMethods $serviceMethod)) -}}
 {{if $methodName -}}
@@ -3315,6 +3332,9 @@ type {{$clientName}} struct {
 			success, respHeaders, err = c.client.Call(
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
+			if isSystemError(err) {
+				ctx = setContextSystemErrorCode(ctx, err)
+			}
 		} else {
 			// We want hystrix ckt-breaker to count errors only for system issues
 			var clientErr error
@@ -3330,10 +3350,11 @@ type {{$clientName}} struct {
 				success, respHeaders, clientErr = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
-				if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				if isSystemError(clientErr) {
 					// Declare ok if it is not a system-error
 					return nil
 				}
+				ctx = setContextSystemErrorCode(ctx, clientErr)
 				return clientErr
 			}, nil)
 			if err == nil {
@@ -3344,16 +3365,23 @@ type {{$clientName}} struct {
 
 		if err == nil && !success {
 			switch {
-				{{range .Exceptions -}}
+				{{range $exc := .Exceptions -}}
 				case result.{{title .Name}} != nil:
 					err = result.{{title .Name}}
+					{{range $annotation, $statusCode := $exc.Annotations -}}
+					{{if eq $annotation "rpc.code" -}}
+						ctx = setContextStatusCode(ctx, {{$statusCode}})
+					{{end -}}
+					{{end -}}
 				{{end -}}
 				{{if ne .ResponseType "" -}}
 				case result.Success != nil:
+					ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
 					ctx = logger.ErrorZ(ctx, "Internal error. Success flag is not set for {{title .Name}}. Overriding", zap.Error(err))
 					success = true
 				{{end -}}
 				default:
+					ctx = setContextStatusCode(ctx, yarpcerrors.CodeUnknown)
 					err = errors.New("{{$clientName}} received no result or unknown exception for {{title .Name}}")
 			}
 		}
@@ -3365,6 +3393,8 @@ type {{$clientName}} struct {
 			return ctx, resp, respHeaders, err
 		{{end -}}
 		}
+
+		ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
 
 		{{if eq .ResponseType "" -}}
 			return ctx, respHeaders, err
@@ -3379,6 +3409,37 @@ type {{$clientName}} struct {
 {{end -}}
 {{end -}}
 {{end}}
+
+func isSystemError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, isSysErr := err.(tchannel.SystemError)
+	return isSysErr
+}
+
+func setContextSystemErrorCode(ctx context.Context, err error) context.Context {
+	if ctx != nil && err != nil {
+		if systemErr, ok := err.(tchannel.SystemError); ok {
+			if code, ok := _tchannelCodeToCode[systemErr.Code()]; ok {
+				ctx = setContextStatusCode(ctx, code)
+			} else {
+				// same as yarpc-go https://github.com/yarpc/yarpc-go/blob/d33ff85d687eb11de3324507ffdc817a39001b3f/transport/tchannel/error.go#L67C39-L67C51
+				ctx = setContextStatusCode(ctx, yarpcerrors.CodeInternal)
+			}
+		}
+	}
+	return ctx
+}
+
+func setContextStatusCode(ctx context.Context, code yarpcerrors.Code) context.Context {
+	if ctx != nil {
+		if statusCode := ctx.Value(_errorCodeAnnotationKey); statusCode == nil {
+			ctx = context.WithValue(ctx, _errorCodeAnnotationKey, code)
+		}
+	}
+	return ctx
+}
 `)
 
 func tchannel_clientTmplBytes() ([]byte, error) {
@@ -3391,7 +3452,7 @@ func tchannel_clientTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 15262, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_client.tmpl", size: 17374, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3555,7 +3616,7 @@ import (
 {{- $clientID := .ClientID }}
 
 {{with .Method -}}
-// New{{$handlerName}} creates a handler to be registered with a thrift server.
+// New{{$handlerName}} creates a simple handler to be registered with a thrift server.
 func New{{$handlerName}}(deps *module.Dependencies) *{{$handlerName}} {
 	handler := &{{$handlerName}}{
 		Deps: deps,
@@ -3800,7 +3861,7 @@ func tchannel_endpointTmpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8945, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
+	info := bindataFileInfo{name: "tchannel_endpoint.tmpl", size: 8952, mode: os.FileMode(420), modTime: time.Unix(1, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4384,11 +4445,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("notexist") would return an error

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -13,9 +13,9 @@ import (
 	"github.com/afex/hystrix-go/hystrix"
 	"github.com/uber/tchannel-go"
 	zanzibar "github.com/uber/zanzibar/runtime"
-	"github.com/uber/tchannel-go"
 	"github.com/uber/zanzibar/config"
 	"github.com/uber/zanzibar/runtime/ruleengine"
+	zerrors "github.com/uber/zanzibar/runtime/errors"
 
 
 	"go.uber.org/zap"
@@ -36,22 +36,6 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
-
-const _errorCodeAnnotationKey = "rpc.code"
-
-var (
-	// _tchannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
-	_tchannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
-		tchannel.ErrCodeTimeout:    yarpcerrors.CodeDeadlineExceeded,
-		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
-		tchannel.ErrCodeBusy:       yarpcerrors.CodeResourceExhausted,
-		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
-		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
-		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
-		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
-		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,
-	}
-)
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -364,8 +348,8 @@ type {{$clientName}} struct {
 			success, respHeaders, err = c.client.Call(
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
-			if isSystemError(err) {
-				ctx = setContextSystemErrorCode(ctx, err)
+			if zerrors.IsSystemError(err) {
+				ctx = zerrors.SetContextSystemErrorCode(ctx, err)
 			}
 		} else {
 			// We want hystrix ckt-breaker to count errors only for system issues
@@ -382,11 +366,11 @@ type {{$clientName}} struct {
 				success, respHeaders, clientErr = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
-				if !isSystemError(clientErr) {
+				if !zerrors.IsSystemError(clientErr) {
 					// Declare ok if it is not a system-error
 					return nil
 				}
-				ctx = setContextSystemErrorCode(ctx, clientErr)
+				ctx = zerrors.SetContextSystemErrorCode(ctx, clientErr)
 				return clientErr
 			}, nil)
 			if err == nil {
@@ -402,18 +386,18 @@ type {{$clientName}} struct {
 					err = result.{{title .Name}}
 					{{range $annotation, $statusCode := $exc.Annotations -}}
 					{{if eq $annotation "rpc.code" -}}
-						ctx = setContextStatusCode(ctx, {{$statusCode}})
+						ctx = zerrors.SetContextStatusCode(ctx, {{$statusCode}})
 					{{end -}}
 					{{end -}}
 				{{end -}}
 				{{if ne .ResponseType "" -}}
 				case result.Success != nil:
-					ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
+					ctx = zerrors.SetContextStatusCode(ctx, yarpcerrors.CodeOK)
 					ctx = logger.ErrorZ(ctx, "Internal error. Success flag is not set for {{title .Name}}. Overriding", zap.Error(err))
 					success = true
 				{{end -}}
 				default:
-					ctx = setContextStatusCode(ctx, yarpcerrors.CodeUnknown)
+					ctx = zerrors.SetContextStatusCode(ctx, yarpcerrors.CodeUnknown)
 					err = errors.New("{{$clientName}} received no result or unknown exception for {{title .Name}}")
 			}
 		}
@@ -426,7 +410,7 @@ type {{$clientName}} struct {
 		{{end -}}
 		}
 
-		ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
+		ctx = zerrors.SetContextStatusCode(ctx, yarpcerrors.CodeOK)
 
 		{{if eq .ResponseType "" -}}
 			return ctx, respHeaders, err
@@ -441,34 +425,3 @@ type {{$clientName}} struct {
 {{end -}}
 {{end -}}
 {{end}}
-
-func isSystemError(err error) bool {
-	if err == nil {
-		return false
-	}
-	_, isSysErr := err.(tchannel.SystemError)
-	return isSysErr
-}
-
-func setContextSystemErrorCode(ctx context.Context, err error) context.Context {
-	if ctx != nil && err != nil {
-		if systemErr, ok := err.(tchannel.SystemError); ok {
-			if code, ok := _tchannelCodeToCode[systemErr.Code()]; ok {
-				ctx = setContextStatusCode(ctx, code)
-			} else {
-				// same as yarpc-go https://github.com/yarpc/yarpc-go/blob/d33ff85d687eb11de3324507ffdc817a39001b3f/transport/tchannel/error.go#L67C39-L67C51
-				ctx = setContextStatusCode(ctx, yarpcerrors.CodeInternal)
-			}
-		}
-	}
-	return ctx
-}
-
-func setContextStatusCode(ctx context.Context, code yarpcerrors.Code) context.Context {
-	if ctx != nil {
-		if statusCode := ctx.Value(_errorCodeAnnotationKey); statusCode == nil {
-			ctx = context.WithValue(ctx, _errorCodeAnnotationKey, code)
-		}
-	}
-	return ctx
-}

--- a/codegen/templates/tchannel_client.tmpl
+++ b/codegen/templates/tchannel_client.tmpl
@@ -19,6 +19,7 @@ import (
 
 
 	"go.uber.org/zap"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	module "{{$instance.PackageInfo.ModulePackagePath}}"
 	{{range $idx, $pkg := .IncludedPackages -}}
@@ -35,6 +36,22 @@ import (
 
 // CircuitBreakerConfigKey is key value for qps level to circuit breaker parameters mapping
 const CircuitBreakerConfigKey = "circuitbreaking-configurations"
+
+const _errorCodeAnnotationKey = "rpc.code"
+
+var (
+	// _tchannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
+	_tchannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
+		tchannel.ErrCodeTimeout:    yarpcerrors.CodeDeadlineExceeded,
+		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
+		tchannel.ErrCodeBusy:       yarpcerrors.CodeResourceExhausted,
+		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
+		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
+		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,
+	}
+)
 
 // Client defines {{$clientID}} client interface.
 type Client interface {
@@ -347,6 +364,9 @@ type {{$clientName}} struct {
 			success, respHeaders, err = c.client.Call(
 				ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 			)
+			if isSystemError(err) {
+				ctx = setContextSystemErrorCode(ctx, err)
+			}
 		} else {
 			// We want hystrix ckt-breaker to count errors only for system issues
 			var clientErr error
@@ -362,10 +382,11 @@ type {{$clientName}} struct {
 				success, respHeaders, clientErr = c.client.Call(
 					ctx, "{{$svc.Name}}", "{{.Name}}", reqHeaders, args, &result,
 				)
-				if _, isSysErr := clientErr.(tchannel.SystemError); !isSysErr {
+				if !isSystemError(clientErr) {
 					// Declare ok if it is not a system-error
 					return nil
 				}
+				ctx = setContextSystemErrorCode(ctx, clientErr)
 				return clientErr
 			}, nil)
 			if err == nil {
@@ -376,16 +397,23 @@ type {{$clientName}} struct {
 
 		if err == nil && !success {
 			switch {
-				{{range .Exceptions -}}
+				{{range $exc := .Exceptions -}}
 				case result.{{title .Name}} != nil:
 					err = result.{{title .Name}}
+					{{range $annotation, $statusCode := $exc.Annotations -}}
+					{{if eq $annotation "rpc.code" -}}
+						ctx = setContextStatusCode(ctx, {{$statusCode}})
+					{{end -}}
+					{{end -}}
 				{{end -}}
 				{{if ne .ResponseType "" -}}
 				case result.Success != nil:
+					ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
 					ctx = logger.ErrorZ(ctx, "Internal error. Success flag is not set for {{title .Name}}. Overriding", zap.Error(err))
 					success = true
 				{{end -}}
 				default:
+					ctx = setContextStatusCode(ctx, yarpcerrors.CodeUnknown)
 					err = errors.New("{{$clientName}} received no result or unknown exception for {{title .Name}}")
 			}
 		}
@@ -397,6 +425,8 @@ type {{$clientName}} struct {
 			return ctx, resp, respHeaders, err
 		{{end -}}
 		}
+
+		ctx = setContextStatusCode(ctx, yarpcerrors.CodeOK)
 
 		{{if eq .ResponseType "" -}}
 			return ctx, respHeaders, err
@@ -411,3 +441,34 @@ type {{$clientName}} struct {
 {{end -}}
 {{end -}}
 {{end}}
+
+func isSystemError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, isSysErr := err.(tchannel.SystemError)
+	return isSysErr
+}
+
+func setContextSystemErrorCode(ctx context.Context, err error) context.Context {
+	if ctx != nil && err != nil {
+		if systemErr, ok := err.(tchannel.SystemError); ok {
+			if code, ok := _tchannelCodeToCode[systemErr.Code()]; ok {
+				ctx = setContextStatusCode(ctx, code)
+			} else {
+				// same as yarpc-go https://github.com/yarpc/yarpc-go/blob/d33ff85d687eb11de3324507ffdc817a39001b3f/transport/tchannel/error.go#L67C39-L67C51
+				ctx = setContextStatusCode(ctx, yarpcerrors.CodeInternal)
+			}
+		}
+	}
+	return ctx
+}
+
+func setContextStatusCode(ctx context.Context, code yarpcerrors.Code) context.Context {
+	if ctx != nil {
+		if statusCode := ctx.Value(_errorCodeAnnotationKey); statusCode == nil {
+			ctx = context.WithValue(ctx, _errorCodeAnnotationKey, code)
+		}
+	}
+	return ctx
+}

--- a/examples/example-gateway/idl/clients-idl/clients/baz/baz.thrift
+++ b/examples/example-gateway/idl/clients-idl/clients/baz/baz.thrift
@@ -27,11 +27,15 @@ struct HeaderSchema {}
 
 exception AuthErr {
     1: required string message
-}
+} (
+    rpc.code = "INVALID_ARGUMENT"
+)
 
 exception OtherAuthErr {
   1: required string message
-}
+} (
+    rpc.code = "internal"
+)
 
 struct Recur3 {
     1: required UUID field31
@@ -77,7 +81,7 @@ service SimpleService {
         1: required base.TransStruct arg1
         2: optional base.TransStruct arg2
     ) throws (
-        1: AuthErr authErr
+        1: AuthErr authErr (rpc.code = "internal")
         2: OtherAuthErr otherAuthErr
     )
 

--- a/runtime/errors/errors.go
+++ b/runtime/errors/errors.go
@@ -1,0 +1,55 @@
+package errors
+
+import (
+	"context"
+
+	"github.com/uber/tchannel-go"
+	"go.uber.org/yarpc/yarpcerrors"
+)
+
+const _statusCodeAnnotationKey = "rpc.code"
+
+var (
+	// _tchannelCodeToCode maps TChannel SystemErrCodes to their corresponding Code.
+	_tchannelCodeToCode = map[tchannel.SystemErrCode]yarpcerrors.Code{
+		tchannel.ErrCodeTimeout:    yarpcerrors.CodeDeadlineExceeded,
+		tchannel.ErrCodeCancelled:  yarpcerrors.CodeCancelled,
+		tchannel.ErrCodeBusy:       yarpcerrors.CodeResourceExhausted,
+		tchannel.ErrCodeDeclined:   yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeUnexpected: yarpcerrors.CodeInternal,
+		tchannel.ErrCodeBadRequest: yarpcerrors.CodeInvalidArgument,
+		tchannel.ErrCodeNetwork:    yarpcerrors.CodeUnavailable,
+		tchannel.ErrCodeProtocol:   yarpcerrors.CodeInternal,
+	}
+)
+
+func IsSystemError(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, isSysErr := err.(tchannel.SystemError)
+	return isSysErr
+}
+
+func SetContextSystemErrorCode(ctx context.Context, err error) context.Context {
+	if ctx != nil && err != nil {
+		if systemErr, ok := err.(tchannel.SystemError); ok {
+			if code, ok := _tchannelCodeToCode[systemErr.Code()]; ok {
+				ctx = SetContextStatusCode(ctx, code)
+			} else {
+				// same as yarpc-go https://github.com/yarpc/yarpc-go/blob/d33ff85d687eb11de3324507ffdc817a39001b3f/transport/tchannel/error.go#L67C39-L67C51
+				ctx = SetContextStatusCode(ctx, yarpcerrors.CodeInternal)
+			}
+		}
+	}
+	return ctx
+}
+
+func SetContextStatusCode(ctx context.Context, code yarpcerrors.Code) context.Context {
+	if ctx != nil {
+		if statusCode := ctx.Value(_statusCodeAnnotationKey); statusCode == nil {
+			ctx = context.WithValue(ctx, _statusCodeAnnotationKey, code)
+		}
+	}
+	return ctx
+}


### PR DESCRIPTION
This change adds the response status to the returned context from tchannel clients by inspecting system errors, as well as annotated applications errors (thrift exceptions)