### PR TITLE
Add hook for redirect function in ServeHTTP

### DIFF
--- a/runtime/events.go
+++ b/runtime/events.go
@@ -20,6 +20,8 @@
 
 package zanzibar
 
+import "net/http"
+
 // Context Variables
 const (
 	// ToCapture set to true if events have to be captured
@@ -35,6 +37,7 @@ const (
 
 type EventHandlerFn func([]Event) error
 type EnableEventGenFn func(string, string) bool
+type RedirectFn func(w http.ResponseWriter, r *http.Request) bool
 
 type Event interface {
 	Name() string
@@ -125,5 +128,9 @@ func NoOpEventHandler(events []Event) error {
 
 // NoOpEventGen will not sample
 func NoOpEventGen(_, _ string) bool {
+	return false
+}
+
+func NoOpRedirectFn(_ http.ResponseWriter, _ *http.Request) bool {
 	return false
 }


### PR DESCRIPTION
To migrate direct callers of edge-gateway to api-gateway-http, a flipr controlled gate is needed. This PR adds a hook in Zanzibar Router's ServeHTTP function so that a redirect function can be plugged in, to redirect the requests (received for a particular endpoint) to api-gateway-http instead of passing through edge-gateway. 

This cannot be done at middleware level as ServeHTTP function also emits endpoint metrics which should not be emitted if the requests are being served by api-gateway-http. 