### PR TITLE
Add hook for redirect function in ServeHTTP

### DIFF
--- a/runtime/events.go
+++ b/runtime/events.go
@@ -20,6 +20,8 @@
 
 package zanzibar
 
+import "net/http"
+
 // Context Variables
 const (
 	// ToCapture set to true if events have to be captured
@@ -35,6 +37,7 @@ const (
 
 type EventHandlerFn func([]Event) error
 type EnableEventGenFn func(string, string) bool
+type RedirectFn func(w http.ResponseWriter, r *http.Request) bool
 
 type Event interface {
 	Name() string
@@ -125,5 +128,9 @@ func NoOpEventHandler(events []Event) error {
 
 // NoOpEventGen will not sample
 func NoOpEventGen(_, _ string) bool {
+	return false
+}
+
+func NoOpRedirectFn(_ http.ResponseWriter, _ *http.Request) bool {
 	return false
 }

--- a/runtime/router.go
+++ b/runtime/router.go
@@ -91,6 +91,7 @@ type RouterEndpoint struct {
 	config           *StaticConfig
 	eventHandler     EventHandlerFn
 	enableEventGen   EnableEventGenFn
+	redirectFn       RedirectFn
 }
 
 // NewRouterEndpoint creates an endpoint that can be registered to HTTPRouter
@@ -106,9 +107,11 @@ func NewRouterEndpoint(
 	// continue working as is.
 	eh := NoOpEventHandler
 	eg := NoOpEventGen
+	rh := NoOpRedirectFn
 	if deps.Gateway != nil {
 		eh = deps.Gateway.EventHandler
 		eg = deps.Gateway.EnableEventGen
+		rh = deps.Gateway.RedirectFn
 	}
 
 	return &RouterEndpoint{
@@ -123,6 +126,7 @@ func NewRouterEndpoint(
 		config:           deps.Config,
 		eventHandler:     eh,
 		enableEventGen:   eg,
+		redirectFn:       rh,
 	}
 }
 
@@ -138,6 +142,10 @@ func (endpoint *RouterEndpoint) HandleRequest(
 	//	ctx, cancel = context.WithTimeout(ctx, time.Duration(100)*time.Millisecond)
 	//	defer cancel()
 	//}
+
+	if isRedirected := endpoint.redirectFn(w, r); isRedirected {
+		return
+	}
 
 	urlValues := ParamsFromContext(r.Context())
 	req := NewServerHTTPRequest(w, r, urlValues, endpoint)


### PR DESCRIPTION
To migrate direct callers, a flipr controlled gate is needed. This PR adds a hook in Zanzibar Router's ServeHTTP function so that a redirect function can be plugged in, to redirect the requests (received for a particular endpoint) a different gateway.

This cannot be done at middleware level as ServeHTTP function also emits endpoint metrics which should not be emitted if the requests are being served by another gateway.